### PR TITLE
Serialize objects as xml name

### DIFF
--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="ExpressionToCodeLib" version="2.0.0-beta2" />
     <PackageReference Include="log4net" version="2.0.7" />
     <PackageReference Include="morelinq" version="2.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="ValueUtils" version="1.3.0.0" />
     <PackageReference Include="ZlibWithDictionary" version="2.1.1" />
   </ItemGroup>

--- a/src/ProgressOnderwijsUtils/XmlLocalNameSafeSerializer.cs
+++ b/src/ProgressOnderwijsUtils/XmlLocalNameSafeSerializer.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Text;
+using System.Xml;
+using Newtonsoft.Json;
+
+namespace ProgressOnderwijsUtils
+{
+    public static class XmlLocalNameSafeSerializer
+    {
+        // using base64 generally results in shorter strings, because less character have to be escaped and XmlConvert escaping is inefficient
+        public static string Encode(object obj)
+            => XmlConvert.EncodeLocalName(Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(obj))));
+
+        public static T Decode<T>(string str)
+            => JsonConvert.DeserializeObject<T>(Encoding.UTF8.GetString(Convert.FromBase64String(XmlConvert.DecodeName(str))));
+    }
+}

--- a/test/ProgressOnderwijsUtilsTests/XmlLocalNameSafeSerializerTest.cs
+++ b/test/ProgressOnderwijsUtilsTests/XmlLocalNameSafeSerializerTest.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Xml;
+using ExpressionToCodeLib;
+using ProgressOnderwijsUtils;
+using Xunit;
+
+namespace ProgressOnderwijsUtilsTests
+{
+    public sealed class XmlLocalNameSafeSerializerTest
+    {
+        struct Data
+        {
+            public string Url;
+            public DateTime Time;
+            public string Token;
+        }
+
+        readonly Data data = new Data {
+            Url = "https://en.wikipedia.org/wiki/Main_Page",
+            Time = new DateTime(2017, 3, 9, 12, 33, 32, DateTimeKind.Utc),
+            Token = "BQac8Qd2aQaJWrOnL-8LEh~VDRpnM1yWDOLyAmwUTeeLOWxGb3",
+        };
+
+        [Fact]
+        public void Encode_is_reversible_using_Decode()
+        {
+            var encoded = XmlLocalNameSafeSerializer.Encode(data);
+            var decoded = XmlLocalNameSafeSerializer.Decode<Data>(encoded);
+            PAssert.That(() => Equals(decoded, data));
+        }
+
+        [Fact]
+        public void Encode_produces_a_valid_NCName()
+        {
+            var encoded = XmlLocalNameSafeSerializer.Encode(data);
+            XmlConvert.VerifyNCName(encoded);
+        }
+    }
+}


### PR DESCRIPTION
Om willekeurig spul in de sessionindex van saml te kunnen stoppen.