### PR TITLE
SSO support voor de RuG IdP metdata.

### DIFF
--- a/src/ProgressOnderwijsUtils/SingleSignOn/IdentityProviderConfig.cs
+++ b/src/ProgressOnderwijsUtils/SingleSignOn/IdentityProviderConfig.cs
@@ -5,6 +5,7 @@ namespace ProgressOnderwijsUtils.SingleSignOn
     public struct IdentityProviderConfig
     {
         public string metadata;
+        public string MetaDataQueryParameter;
         public string identity;
         public X509Certificate2 certificate;
     }

--- a/test/ProgressOnderwijsUtilsTests/SsoProcessorValidationTest.cs
+++ b/test/ProgressOnderwijsUtilsTests/SsoProcessorValidationTest.cs
@@ -112,15 +112,15 @@ namespace ProgressOnderwijsUtilsTests
         [Fact]
         public void ValidateXDocument()
         {
-            SsoProcessor.Validate(VALID); //assert does not throw
-            Assert.ThrowsAny<XmlSchemaValidationException>(() => SsoProcessor.Validate(INVALID));
+            SsoProcessor.ValidateSchema(VALID); //assert does not throw
+            Assert.ThrowsAny<XmlSchemaValidationException>(() => SsoProcessor.ValidateSchema(INVALID));
         }
 
         [Fact]
         public void ValidateNested()
         {
-            SsoProcessor.Validate(XElement.Parse(VALID_NESTED)); //assert does not throw
-            Assert.ThrowsAny<XmlSchemaValidationException>(() => SsoProcessor.Validate(XElement.Parse(INVALID_NESTED)));
+            SsoProcessor.ValidateSchema(XElement.Parse(VALID_NESTED)); //assert does not throw
+            Assert.ThrowsAny<XmlSchemaValidationException>(() => SsoProcessor.ValidateSchema(XElement.Parse(INVALID_NESTED)));
         }
     }
 }


### PR DESCRIPTION
De RuG gebruikt een andere query parameter, die heb ik dus geparametiseerd.
Het bleek dat het inlezen van de metadata in een XElement toch nog extra whitespace toevoegde waardoor de signature niet gevalideerd kon worden.
Als we het daarentegen gelijk in een XmlDocument inlezen gaat het verder wel goed. Is ook wat handiger wat mij betreft.