### PR TITLE
Allow safe copy-&-mutate operation for HtmlFragments

### DIFF
--- a/src/ProgressOnderwijsUtils/Html/HtmlElement.cs
+++ b/src/ProgressOnderwijsUtils/Html/HtmlElement.cs
@@ -2,13 +2,18 @@
 
 namespace ProgressOnderwijsUtils.Html
 {
-    public struct HtmlElement : IHtmlTagAllowingContent
+    public struct HtmlElement : IHtmlTagAllowingContent<HtmlElement>
     {
         public HtmlElement(string tagName, HtmlAttribute[] attributes, HtmlFragment[] childNodes)
+            : this(tagName, 
+                  attributes == null || attributes.Length == 0 ? HtmlAttributes.Empty : HtmlAttributes.FromArray(attributes), 
+                  childNodes == null || childNodes.Length == 0 ? null : childNodes) { }
+
+        internal HtmlElement(string tagName, HtmlAttributes attributes, HtmlFragment[] childNodes)
         {
             TagName = tagName;
-            Attributes = attributes == null || attributes.Length == 0 ? HtmlAttributes.Empty : HtmlAttributes.FromArray(attributes);
-            Contents = childNodes == null || childNodes.Length == 0 ? null : childNodes;
+            Attributes = attributes;
+            Contents = childNodes;
         }
 
         public HtmlElement(string tagName)
@@ -18,13 +23,19 @@ namespace ProgressOnderwijsUtils.Html
             Contents = null;
         }
 
-        [Pure]
-        public HtmlFragment AsFragment() => this;
 
         public string TagName { get; }
+        public HtmlAttributes Attributes { get; }
+        public HtmlFragment[] Contents { get; }
+
+        [Pure] public HtmlFragment AsFragment() => this;
+
         string IHtmlTag.TagStart => "<" + TagName;
         string IHtmlTag.EndTag => Contents != null || !TagDescription.LookupTag(TagName).IsSelfClosing ? "</" + TagName + ">" : "";
-        public HtmlAttributes Attributes { get; set; }
-        public HtmlFragment[] Contents { get; set; }
+
+
+        IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+        HtmlElement IHtmlTag<HtmlElement>.WithAttributes(HtmlAttributes replacementAttributes) => new HtmlElement(TagName, replacementAttributes, Contents);
+        HtmlElement IHtmlTagAllowingContent<HtmlElement>.WithContents(HtmlFragment[] replacementContents) => new HtmlElement(TagName, Attributes, replacementContents);
     }
 }

--- a/src/ProgressOnderwijsUtils/Html/HtmlSpec.Generated.cs
+++ b/src/ProgressOnderwijsUtils/Html/HtmlSpec.Generated.cs
@@ -1,1122 +1,1657 @@
-﻿using System.Runtime.CompilerServices;
+﻿using JetBrains.Annotations;
+
 namespace ProgressOnderwijsUtils.Html
 {
     using AttributeNameInterfaces;
 
     public static class HtmlTagKinds
     {
-        public struct A : IHtmlTagAllowingContent, IHasAttr_href, IHasAttr_target, IHasAttr_download, IHasAttr_ping, IHasAttr_rel, IHasAttr_hreflang, IHasAttr_type, IHasAttr_referrerpolicy
+        public struct A : IHtmlTagAllowingContent<A>, IHasAttr_href, IHasAttr_target, IHasAttr_download, IHasAttr_ping, IHasAttr_rel, IHasAttr_hreflang, IHasAttr_type, IHasAttr_referrerpolicy
         {
             public string TagName => "a";
             string IHtmlTag.TagStart => "<a";
             string IHtmlTag.EndTag => "</a>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            A IHtmlTag<A>.WithAttributes(HtmlAttributes replacementAttributes) => new A { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            A IHtmlTagAllowingContent<A>.WithContents(HtmlFragment[] replacementContents) => new A { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(A tag) => tag.AsFragment();
         }
-        public struct ABBR : IHtmlTagAllowingContent
+        public struct ABBR : IHtmlTagAllowingContent<ABBR>
         {
             public string TagName => "abbr";
             string IHtmlTag.TagStart => "<abbr";
             string IHtmlTag.EndTag => "</abbr>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            ABBR IHtmlTag<ABBR>.WithAttributes(HtmlAttributes replacementAttributes) => new ABBR { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            ABBR IHtmlTagAllowingContent<ABBR>.WithContents(HtmlFragment[] replacementContents) => new ABBR { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(ABBR tag) => tag.AsFragment();
         }
-        public struct ADDRESS : IHtmlTagAllowingContent
+        public struct ADDRESS : IHtmlTagAllowingContent<ADDRESS>
         {
             public string TagName => "address";
             string IHtmlTag.TagStart => "<address";
             string IHtmlTag.EndTag => "</address>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            ADDRESS IHtmlTag<ADDRESS>.WithAttributes(HtmlAttributes replacementAttributes) => new ADDRESS { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            ADDRESS IHtmlTagAllowingContent<ADDRESS>.WithContents(HtmlFragment[] replacementContents) => new ADDRESS { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(ADDRESS tag) => tag.AsFragment();
         }
-        public struct AREA : IHtmlTag, IHasAttr_alt, IHasAttr_coords, IHasAttr_shape, IHasAttr_href, IHasAttr_target, IHasAttr_download, IHasAttr_ping, IHasAttr_rel, IHasAttr_referrerpolicy
+        public struct AREA : IHtmlTag<AREA>, IHasAttr_alt, IHasAttr_coords, IHasAttr_shape, IHasAttr_href, IHasAttr_target, IHasAttr_download, IHasAttr_ping, IHasAttr_rel, IHasAttr_referrerpolicy
         {
             public string TagName => "area";
             string IHtmlTag.TagStart => "<area";
             string IHtmlTag.EndTag => "";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            AREA IHtmlTag<AREA>.WithAttributes(HtmlAttributes replacementAttributes) => new AREA { attrs = replacementAttributes };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeEmpty(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(AREA tag) => tag.AsFragment();
         }
-        public struct ARTICLE : IHtmlTagAllowingContent
+        public struct ARTICLE : IHtmlTagAllowingContent<ARTICLE>
         {
             public string TagName => "article";
             string IHtmlTag.TagStart => "<article";
             string IHtmlTag.EndTag => "</article>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            ARTICLE IHtmlTag<ARTICLE>.WithAttributes(HtmlAttributes replacementAttributes) => new ARTICLE { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            ARTICLE IHtmlTagAllowingContent<ARTICLE>.WithContents(HtmlFragment[] replacementContents) => new ARTICLE { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(ARTICLE tag) => tag.AsFragment();
         }
-        public struct ASIDE : IHtmlTagAllowingContent
+        public struct ASIDE : IHtmlTagAllowingContent<ASIDE>
         {
             public string TagName => "aside";
             string IHtmlTag.TagStart => "<aside";
             string IHtmlTag.EndTag => "</aside>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            ASIDE IHtmlTag<ASIDE>.WithAttributes(HtmlAttributes replacementAttributes) => new ASIDE { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            ASIDE IHtmlTagAllowingContent<ASIDE>.WithContents(HtmlFragment[] replacementContents) => new ASIDE { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(ASIDE tag) => tag.AsFragment();
         }
-        public struct AUDIO : IHtmlTagAllowingContent, IHasAttr_src, IHasAttr_crossorigin, IHasAttr_preload, IHasAttr_autoplay, IHasAttr_loop, IHasAttr_muted, IHasAttr_controls
+        public struct AUDIO : IHtmlTagAllowingContent<AUDIO>, IHasAttr_src, IHasAttr_crossorigin, IHasAttr_preload, IHasAttr_autoplay, IHasAttr_loop, IHasAttr_muted, IHasAttr_controls
         {
             public string TagName => "audio";
             string IHtmlTag.TagStart => "<audio";
             string IHtmlTag.EndTag => "</audio>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            AUDIO IHtmlTag<AUDIO>.WithAttributes(HtmlAttributes replacementAttributes) => new AUDIO { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            AUDIO IHtmlTagAllowingContent<AUDIO>.WithContents(HtmlFragment[] replacementContents) => new AUDIO { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(AUDIO tag) => tag.AsFragment();
         }
-        public struct B : IHtmlTagAllowingContent
+        public struct B : IHtmlTagAllowingContent<B>
         {
             public string TagName => "b";
             string IHtmlTag.TagStart => "<b";
             string IHtmlTag.EndTag => "</b>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            B IHtmlTag<B>.WithAttributes(HtmlAttributes replacementAttributes) => new B { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            B IHtmlTagAllowingContent<B>.WithContents(HtmlFragment[] replacementContents) => new B { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(B tag) => tag.AsFragment();
         }
-        public struct BASE : IHtmlTag, IHasAttr_href, IHasAttr_target
+        public struct BASE : IHtmlTag<BASE>, IHasAttr_href, IHasAttr_target
         {
             public string TagName => "base";
             string IHtmlTag.TagStart => "<base";
             string IHtmlTag.EndTag => "";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            BASE IHtmlTag<BASE>.WithAttributes(HtmlAttributes replacementAttributes) => new BASE { attrs = replacementAttributes };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeEmpty(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(BASE tag) => tag.AsFragment();
         }
-        public struct BDI : IHtmlTagAllowingContent
+        public struct BDI : IHtmlTagAllowingContent<BDI>
         {
             public string TagName => "bdi";
             string IHtmlTag.TagStart => "<bdi";
             string IHtmlTag.EndTag => "</bdi>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            BDI IHtmlTag<BDI>.WithAttributes(HtmlAttributes replacementAttributes) => new BDI { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            BDI IHtmlTagAllowingContent<BDI>.WithContents(HtmlFragment[] replacementContents) => new BDI { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(BDI tag) => tag.AsFragment();
         }
-        public struct BDO : IHtmlTagAllowingContent
+        public struct BDO : IHtmlTagAllowingContent<BDO>
         {
             public string TagName => "bdo";
             string IHtmlTag.TagStart => "<bdo";
             string IHtmlTag.EndTag => "</bdo>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            BDO IHtmlTag<BDO>.WithAttributes(HtmlAttributes replacementAttributes) => new BDO { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            BDO IHtmlTagAllowingContent<BDO>.WithContents(HtmlFragment[] replacementContents) => new BDO { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(BDO tag) => tag.AsFragment();
         }
-        public struct BLOCKQUOTE : IHtmlTagAllowingContent, IHasAttr_cite
+        public struct BLOCKQUOTE : IHtmlTagAllowingContent<BLOCKQUOTE>, IHasAttr_cite
         {
             public string TagName => "blockquote";
             string IHtmlTag.TagStart => "<blockquote";
             string IHtmlTag.EndTag => "</blockquote>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            BLOCKQUOTE IHtmlTag<BLOCKQUOTE>.WithAttributes(HtmlAttributes replacementAttributes) => new BLOCKQUOTE { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            BLOCKQUOTE IHtmlTagAllowingContent<BLOCKQUOTE>.WithContents(HtmlFragment[] replacementContents) => new BLOCKQUOTE { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(BLOCKQUOTE tag) => tag.AsFragment();
         }
-        public struct BODY : IHtmlTagAllowingContent, IHasAttr_onafterprint, IHasAttr_onbeforeprint, IHasAttr_onbeforeunload, IHasAttr_onhashchange, IHasAttr_onlanguagechange, IHasAttr_onmessage, IHasAttr_onoffline, IHasAttr_ononline, IHasAttr_onpagehide, IHasAttr_onpageshow, IHasAttr_onpopstate, IHasAttr_onrejectionhandled, IHasAttr_onstorage, IHasAttr_onunhandledrejection, IHasAttr_onunload
+        public struct BODY : IHtmlTagAllowingContent<BODY>, IHasAttr_onafterprint, IHasAttr_onbeforeprint, IHasAttr_onbeforeunload, IHasAttr_onhashchange, IHasAttr_onlanguagechange, IHasAttr_onmessage, IHasAttr_onmessageerror, IHasAttr_onoffline, IHasAttr_ononline, IHasAttr_onpagehide, IHasAttr_onpageshow, IHasAttr_onpopstate, IHasAttr_onrejectionhandled, IHasAttr_onstorage, IHasAttr_onunhandledrejection, IHasAttr_onunload
         {
             public string TagName => "body";
             string IHtmlTag.TagStart => "<body";
             string IHtmlTag.EndTag => "</body>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            BODY IHtmlTag<BODY>.WithAttributes(HtmlAttributes replacementAttributes) => new BODY { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            BODY IHtmlTagAllowingContent<BODY>.WithContents(HtmlFragment[] replacementContents) => new BODY { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(BODY tag) => tag.AsFragment();
         }
-        public struct BR : IHtmlTag
+        public struct BR : IHtmlTag<BR>
         {
             public string TagName => "br";
             string IHtmlTag.TagStart => "<br";
             string IHtmlTag.EndTag => "";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            BR IHtmlTag<BR>.WithAttributes(HtmlAttributes replacementAttributes) => new BR { attrs = replacementAttributes };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeEmpty(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(BR tag) => tag.AsFragment();
         }
-        public struct BUTTON : IHtmlTagAllowingContent, IHasAttr_autofocus, IHasAttr_disabled, IHasAttr_form, IHasAttr_formaction, IHasAttr_formenctype, IHasAttr_formmethod, IHasAttr_formnovalidate, IHasAttr_formtarget, IHasAttr_name, IHasAttr_type, IHasAttr_value
+        public struct BUTTON : IHtmlTagAllowingContent<BUTTON>, IHasAttr_autofocus, IHasAttr_disabled, IHasAttr_form, IHasAttr_formaction, IHasAttr_formenctype, IHasAttr_formmethod, IHasAttr_formnovalidate, IHasAttr_formtarget, IHasAttr_name, IHasAttr_type, IHasAttr_value
         {
             public string TagName => "button";
             string IHtmlTag.TagStart => "<button";
             string IHtmlTag.EndTag => "</button>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            BUTTON IHtmlTag<BUTTON>.WithAttributes(HtmlAttributes replacementAttributes) => new BUTTON { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            BUTTON IHtmlTagAllowingContent<BUTTON>.WithContents(HtmlFragment[] replacementContents) => new BUTTON { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(BUTTON tag) => tag.AsFragment();
         }
-        public struct CANVAS : IHtmlTagAllowingContent, IHasAttr_width, IHasAttr_height
+        public struct CANVAS : IHtmlTagAllowingContent<CANVAS>, IHasAttr_width, IHasAttr_height
         {
             public string TagName => "canvas";
             string IHtmlTag.TagStart => "<canvas";
             string IHtmlTag.EndTag => "</canvas>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            CANVAS IHtmlTag<CANVAS>.WithAttributes(HtmlAttributes replacementAttributes) => new CANVAS { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            CANVAS IHtmlTagAllowingContent<CANVAS>.WithContents(HtmlFragment[] replacementContents) => new CANVAS { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(CANVAS tag) => tag.AsFragment();
         }
-        public struct CAPTION : IHtmlTagAllowingContent
+        public struct CAPTION : IHtmlTagAllowingContent<CAPTION>
         {
             public string TagName => "caption";
             string IHtmlTag.TagStart => "<caption";
             string IHtmlTag.EndTag => "</caption>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            CAPTION IHtmlTag<CAPTION>.WithAttributes(HtmlAttributes replacementAttributes) => new CAPTION { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            CAPTION IHtmlTagAllowingContent<CAPTION>.WithContents(HtmlFragment[] replacementContents) => new CAPTION { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(CAPTION tag) => tag.AsFragment();
         }
-        public struct CITE : IHtmlTagAllowingContent
+        public struct CITE : IHtmlTagAllowingContent<CITE>
         {
             public string TagName => "cite";
             string IHtmlTag.TagStart => "<cite";
             string IHtmlTag.EndTag => "</cite>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            CITE IHtmlTag<CITE>.WithAttributes(HtmlAttributes replacementAttributes) => new CITE { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            CITE IHtmlTagAllowingContent<CITE>.WithContents(HtmlFragment[] replacementContents) => new CITE { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(CITE tag) => tag.AsFragment();
         }
-        public struct CODE : IHtmlTagAllowingContent
+        public struct CODE : IHtmlTagAllowingContent<CODE>
         {
             public string TagName => "code";
             string IHtmlTag.TagStart => "<code";
             string IHtmlTag.EndTag => "</code>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            CODE IHtmlTag<CODE>.WithAttributes(HtmlAttributes replacementAttributes) => new CODE { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            CODE IHtmlTagAllowingContent<CODE>.WithContents(HtmlFragment[] replacementContents) => new CODE { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(CODE tag) => tag.AsFragment();
         }
-        public struct COL : IHtmlTag, IHasAttr_span
+        public struct COL : IHtmlTag<COL>, IHasAttr_span
         {
             public string TagName => "col";
             string IHtmlTag.TagStart => "<col";
             string IHtmlTag.EndTag => "";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            COL IHtmlTag<COL>.WithAttributes(HtmlAttributes replacementAttributes) => new COL { attrs = replacementAttributes };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeEmpty(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(COL tag) => tag.AsFragment();
         }
-        public struct COLGROUP : IHtmlTagAllowingContent, IHasAttr_span
+        public struct COLGROUP : IHtmlTagAllowingContent<COLGROUP>, IHasAttr_span
         {
             public string TagName => "colgroup";
             string IHtmlTag.TagStart => "<colgroup";
             string IHtmlTag.EndTag => "</colgroup>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            COLGROUP IHtmlTag<COLGROUP>.WithAttributes(HtmlAttributes replacementAttributes) => new COLGROUP { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            COLGROUP IHtmlTagAllowingContent<COLGROUP>.WithContents(HtmlFragment[] replacementContents) => new COLGROUP { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(COLGROUP tag) => tag.AsFragment();
         }
-        public struct DATA : IHtmlTagAllowingContent, IHasAttr_value
+        public struct DATA : IHtmlTagAllowingContent<DATA>, IHasAttr_value
         {
             public string TagName => "data";
             string IHtmlTag.TagStart => "<data";
             string IHtmlTag.EndTag => "</data>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            DATA IHtmlTag<DATA>.WithAttributes(HtmlAttributes replacementAttributes) => new DATA { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            DATA IHtmlTagAllowingContent<DATA>.WithContents(HtmlFragment[] replacementContents) => new DATA { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(DATA tag) => tag.AsFragment();
         }
-        public struct DATALIST : IHtmlTagAllowingContent
+        public struct DATALIST : IHtmlTagAllowingContent<DATALIST>
         {
             public string TagName => "datalist";
             string IHtmlTag.TagStart => "<datalist";
             string IHtmlTag.EndTag => "</datalist>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            DATALIST IHtmlTag<DATALIST>.WithAttributes(HtmlAttributes replacementAttributes) => new DATALIST { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            DATALIST IHtmlTagAllowingContent<DATALIST>.WithContents(HtmlFragment[] replacementContents) => new DATALIST { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(DATALIST tag) => tag.AsFragment();
         }
-        public struct DD : IHtmlTagAllowingContent
+        public struct DD : IHtmlTagAllowingContent<DD>
         {
             public string TagName => "dd";
             string IHtmlTag.TagStart => "<dd";
             string IHtmlTag.EndTag => "</dd>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            DD IHtmlTag<DD>.WithAttributes(HtmlAttributes replacementAttributes) => new DD { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            DD IHtmlTagAllowingContent<DD>.WithContents(HtmlFragment[] replacementContents) => new DD { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(DD tag) => tag.AsFragment();
         }
-        public struct DEL : IHtmlTagAllowingContent, IHasAttr_cite, IHasAttr_datetime
+        public struct DEL : IHtmlTagAllowingContent<DEL>, IHasAttr_cite, IHasAttr_datetime
         {
             public string TagName => "del";
             string IHtmlTag.TagStart => "<del";
             string IHtmlTag.EndTag => "</del>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            DEL IHtmlTag<DEL>.WithAttributes(HtmlAttributes replacementAttributes) => new DEL { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            DEL IHtmlTagAllowingContent<DEL>.WithContents(HtmlFragment[] replacementContents) => new DEL { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(DEL tag) => tag.AsFragment();
         }
-        public struct DETAILS : IHtmlTagAllowingContent, IHasAttr_open
+        public struct DETAILS : IHtmlTagAllowingContent<DETAILS>, IHasAttr_open
         {
             public string TagName => "details";
             string IHtmlTag.TagStart => "<details";
             string IHtmlTag.EndTag => "</details>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            DETAILS IHtmlTag<DETAILS>.WithAttributes(HtmlAttributes replacementAttributes) => new DETAILS { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            DETAILS IHtmlTagAllowingContent<DETAILS>.WithContents(HtmlFragment[] replacementContents) => new DETAILS { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(DETAILS tag) => tag.AsFragment();
         }
-        public struct DFN : IHtmlTagAllowingContent
+        public struct DFN : IHtmlTagAllowingContent<DFN>
         {
             public string TagName => "dfn";
             string IHtmlTag.TagStart => "<dfn";
             string IHtmlTag.EndTag => "</dfn>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            DFN IHtmlTag<DFN>.WithAttributes(HtmlAttributes replacementAttributes) => new DFN { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            DFN IHtmlTagAllowingContent<DFN>.WithContents(HtmlFragment[] replacementContents) => new DFN { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(DFN tag) => tag.AsFragment();
         }
-        public struct DIALOG : IHtmlTagAllowingContent, IHasAttr_open
+        public struct DIALOG : IHtmlTagAllowingContent<DIALOG>, IHasAttr_open
         {
             public string TagName => "dialog";
             string IHtmlTag.TagStart => "<dialog";
             string IHtmlTag.EndTag => "</dialog>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            DIALOG IHtmlTag<DIALOG>.WithAttributes(HtmlAttributes replacementAttributes) => new DIALOG { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            DIALOG IHtmlTagAllowingContent<DIALOG>.WithContents(HtmlFragment[] replacementContents) => new DIALOG { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(DIALOG tag) => tag.AsFragment();
         }
-        public struct DIV : IHtmlTagAllowingContent
+        public struct DIV : IHtmlTagAllowingContent<DIV>
         {
             public string TagName => "div";
             string IHtmlTag.TagStart => "<div";
             string IHtmlTag.EndTag => "</div>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            DIV IHtmlTag<DIV>.WithAttributes(HtmlAttributes replacementAttributes) => new DIV { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            DIV IHtmlTagAllowingContent<DIV>.WithContents(HtmlFragment[] replacementContents) => new DIV { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(DIV tag) => tag.AsFragment();
         }
-        public struct DL : IHtmlTagAllowingContent
+        public struct DL : IHtmlTagAllowingContent<DL>
         {
             public string TagName => "dl";
             string IHtmlTag.TagStart => "<dl";
             string IHtmlTag.EndTag => "</dl>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            DL IHtmlTag<DL>.WithAttributes(HtmlAttributes replacementAttributes) => new DL { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            DL IHtmlTagAllowingContent<DL>.WithContents(HtmlFragment[] replacementContents) => new DL { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(DL tag) => tag.AsFragment();
         }
-        public struct DT : IHtmlTagAllowingContent
+        public struct DT : IHtmlTagAllowingContent<DT>
         {
             public string TagName => "dt";
             string IHtmlTag.TagStart => "<dt";
             string IHtmlTag.EndTag => "</dt>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            DT IHtmlTag<DT>.WithAttributes(HtmlAttributes replacementAttributes) => new DT { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            DT IHtmlTagAllowingContent<DT>.WithContents(HtmlFragment[] replacementContents) => new DT { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(DT tag) => tag.AsFragment();
         }
-        public struct EM : IHtmlTagAllowingContent
+        public struct EM : IHtmlTagAllowingContent<EM>
         {
             public string TagName => "em";
             string IHtmlTag.TagStart => "<em";
             string IHtmlTag.EndTag => "</em>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            EM IHtmlTag<EM>.WithAttributes(HtmlAttributes replacementAttributes) => new EM { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            EM IHtmlTagAllowingContent<EM>.WithContents(HtmlFragment[] replacementContents) => new EM { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(EM tag) => tag.AsFragment();
         }
-        public struct EMBED : IHtmlTag, IHasAttr_src, IHasAttr_type, IHasAttr_width, IHasAttr_height
+        public struct EMBED : IHtmlTag<EMBED>, IHasAttr_src, IHasAttr_type, IHasAttr_width, IHasAttr_height
         {
             public string TagName => "embed";
             string IHtmlTag.TagStart => "<embed";
             string IHtmlTag.EndTag => "";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            EMBED IHtmlTag<EMBED>.WithAttributes(HtmlAttributes replacementAttributes) => new EMBED { attrs = replacementAttributes };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeEmpty(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(EMBED tag) => tag.AsFragment();
         }
-        public struct FIELDSET : IHtmlTagAllowingContent, IHasAttr_disabled, IHasAttr_form, IHasAttr_name
+        public struct FIELDSET : IHtmlTagAllowingContent<FIELDSET>, IHasAttr_disabled, IHasAttr_form, IHasAttr_name
         {
             public string TagName => "fieldset";
             string IHtmlTag.TagStart => "<fieldset";
             string IHtmlTag.EndTag => "</fieldset>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            FIELDSET IHtmlTag<FIELDSET>.WithAttributes(HtmlAttributes replacementAttributes) => new FIELDSET { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            FIELDSET IHtmlTagAllowingContent<FIELDSET>.WithContents(HtmlFragment[] replacementContents) => new FIELDSET { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(FIELDSET tag) => tag.AsFragment();
         }
-        public struct FIGCAPTION : IHtmlTagAllowingContent
+        public struct FIGCAPTION : IHtmlTagAllowingContent<FIGCAPTION>
         {
             public string TagName => "figcaption";
             string IHtmlTag.TagStart => "<figcaption";
             string IHtmlTag.EndTag => "</figcaption>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            FIGCAPTION IHtmlTag<FIGCAPTION>.WithAttributes(HtmlAttributes replacementAttributes) => new FIGCAPTION { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            FIGCAPTION IHtmlTagAllowingContent<FIGCAPTION>.WithContents(HtmlFragment[] replacementContents) => new FIGCAPTION { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(FIGCAPTION tag) => tag.AsFragment();
         }
-        public struct FIGURE : IHtmlTagAllowingContent
+        public struct FIGURE : IHtmlTagAllowingContent<FIGURE>
         {
             public string TagName => "figure";
             string IHtmlTag.TagStart => "<figure";
             string IHtmlTag.EndTag => "</figure>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            FIGURE IHtmlTag<FIGURE>.WithAttributes(HtmlAttributes replacementAttributes) => new FIGURE { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            FIGURE IHtmlTagAllowingContent<FIGURE>.WithContents(HtmlFragment[] replacementContents) => new FIGURE { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(FIGURE tag) => tag.AsFragment();
         }
-        public struct FOOTER : IHtmlTagAllowingContent
+        public struct FOOTER : IHtmlTagAllowingContent<FOOTER>
         {
             public string TagName => "footer";
             string IHtmlTag.TagStart => "<footer";
             string IHtmlTag.EndTag => "</footer>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            FOOTER IHtmlTag<FOOTER>.WithAttributes(HtmlAttributes replacementAttributes) => new FOOTER { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            FOOTER IHtmlTagAllowingContent<FOOTER>.WithContents(HtmlFragment[] replacementContents) => new FOOTER { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(FOOTER tag) => tag.AsFragment();
         }
-        public struct FORM : IHtmlTagAllowingContent, IHasAttr_accept_charset, IHasAttr_action, IHasAttr_autocomplete, IHasAttr_enctype, IHasAttr_method, IHasAttr_name, IHasAttr_novalidate, IHasAttr_target
+        public struct FORM : IHtmlTagAllowingContent<FORM>, IHasAttr_accept_charset, IHasAttr_action, IHasAttr_autocomplete, IHasAttr_enctype, IHasAttr_method, IHasAttr_name, IHasAttr_novalidate, IHasAttr_target
         {
             public string TagName => "form";
             string IHtmlTag.TagStart => "<form";
             string IHtmlTag.EndTag => "</form>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            FORM IHtmlTag<FORM>.WithAttributes(HtmlAttributes replacementAttributes) => new FORM { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            FORM IHtmlTagAllowingContent<FORM>.WithContents(HtmlFragment[] replacementContents) => new FORM { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(FORM tag) => tag.AsFragment();
         }
-        public struct H1 : IHtmlTagAllowingContent
+        public struct H1 : IHtmlTagAllowingContent<H1>
         {
             public string TagName => "h1";
             string IHtmlTag.TagStart => "<h1";
             string IHtmlTag.EndTag => "</h1>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            H1 IHtmlTag<H1>.WithAttributes(HtmlAttributes replacementAttributes) => new H1 { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            H1 IHtmlTagAllowingContent<H1>.WithContents(HtmlFragment[] replacementContents) => new H1 { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(H1 tag) => tag.AsFragment();
         }
-        public struct H2 : IHtmlTagAllowingContent
+        public struct H2 : IHtmlTagAllowingContent<H2>
         {
             public string TagName => "h2";
             string IHtmlTag.TagStart => "<h2";
             string IHtmlTag.EndTag => "</h2>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            H2 IHtmlTag<H2>.WithAttributes(HtmlAttributes replacementAttributes) => new H2 { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            H2 IHtmlTagAllowingContent<H2>.WithContents(HtmlFragment[] replacementContents) => new H2 { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(H2 tag) => tag.AsFragment();
         }
-        public struct H3 : IHtmlTagAllowingContent
+        public struct H3 : IHtmlTagAllowingContent<H3>
         {
             public string TagName => "h3";
             string IHtmlTag.TagStart => "<h3";
             string IHtmlTag.EndTag => "</h3>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            H3 IHtmlTag<H3>.WithAttributes(HtmlAttributes replacementAttributes) => new H3 { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            H3 IHtmlTagAllowingContent<H3>.WithContents(HtmlFragment[] replacementContents) => new H3 { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(H3 tag) => tag.AsFragment();
         }
-        public struct H4 : IHtmlTagAllowingContent
+        public struct H4 : IHtmlTagAllowingContent<H4>
         {
             public string TagName => "h4";
             string IHtmlTag.TagStart => "<h4";
             string IHtmlTag.EndTag => "</h4>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            H4 IHtmlTag<H4>.WithAttributes(HtmlAttributes replacementAttributes) => new H4 { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            H4 IHtmlTagAllowingContent<H4>.WithContents(HtmlFragment[] replacementContents) => new H4 { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(H4 tag) => tag.AsFragment();
         }
-        public struct H5 : IHtmlTagAllowingContent
+        public struct H5 : IHtmlTagAllowingContent<H5>
         {
             public string TagName => "h5";
             string IHtmlTag.TagStart => "<h5";
             string IHtmlTag.EndTag => "</h5>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            H5 IHtmlTag<H5>.WithAttributes(HtmlAttributes replacementAttributes) => new H5 { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            H5 IHtmlTagAllowingContent<H5>.WithContents(HtmlFragment[] replacementContents) => new H5 { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(H5 tag) => tag.AsFragment();
         }
-        public struct H6 : IHtmlTagAllowingContent
+        public struct H6 : IHtmlTagAllowingContent<H6>
         {
             public string TagName => "h6";
             string IHtmlTag.TagStart => "<h6";
             string IHtmlTag.EndTag => "</h6>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            H6 IHtmlTag<H6>.WithAttributes(HtmlAttributes replacementAttributes) => new H6 { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            H6 IHtmlTagAllowingContent<H6>.WithContents(HtmlFragment[] replacementContents) => new H6 { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(H6 tag) => tag.AsFragment();
         }
-        public struct HEAD : IHtmlTagAllowingContent
+        public struct HEAD : IHtmlTagAllowingContent<HEAD>
         {
             public string TagName => "head";
             string IHtmlTag.TagStart => "<head";
             string IHtmlTag.EndTag => "</head>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            HEAD IHtmlTag<HEAD>.WithAttributes(HtmlAttributes replacementAttributes) => new HEAD { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            HEAD IHtmlTagAllowingContent<HEAD>.WithContents(HtmlFragment[] replacementContents) => new HEAD { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(HEAD tag) => tag.AsFragment();
         }
-        public struct HEADER : IHtmlTagAllowingContent
+        public struct HEADER : IHtmlTagAllowingContent<HEADER>
         {
             public string TagName => "header";
             string IHtmlTag.TagStart => "<header";
             string IHtmlTag.EndTag => "</header>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            HEADER IHtmlTag<HEADER>.WithAttributes(HtmlAttributes replacementAttributes) => new HEADER { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            HEADER IHtmlTagAllowingContent<HEADER>.WithContents(HtmlFragment[] replacementContents) => new HEADER { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(HEADER tag) => tag.AsFragment();
         }
-        public struct HGROUP : IHtmlTagAllowingContent
+        public struct HGROUP : IHtmlTagAllowingContent<HGROUP>
         {
             public string TagName => "hgroup";
             string IHtmlTag.TagStart => "<hgroup";
             string IHtmlTag.EndTag => "</hgroup>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            HGROUP IHtmlTag<HGROUP>.WithAttributes(HtmlAttributes replacementAttributes) => new HGROUP { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            HGROUP IHtmlTagAllowingContent<HGROUP>.WithContents(HtmlFragment[] replacementContents) => new HGROUP { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(HGROUP tag) => tag.AsFragment();
         }
-        public struct HR : IHtmlTag
+        public struct HR : IHtmlTag<HR>
         {
             public string TagName => "hr";
             string IHtmlTag.TagStart => "<hr";
             string IHtmlTag.EndTag => "";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            HR IHtmlTag<HR>.WithAttributes(HtmlAttributes replacementAttributes) => new HR { attrs = replacementAttributes };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeEmpty(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(HR tag) => tag.AsFragment();
         }
-        public struct HTML : IHtmlTagAllowingContent, IHasAttr_manifest
+        public struct HTML : IHtmlTagAllowingContent<HTML>, IHasAttr_manifest
         {
             public string TagName => "html";
             string IHtmlTag.TagStart => "<html";
             string IHtmlTag.EndTag => "</html>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            HTML IHtmlTag<HTML>.WithAttributes(HtmlAttributes replacementAttributes) => new HTML { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            HTML IHtmlTagAllowingContent<HTML>.WithContents(HtmlFragment[] replacementContents) => new HTML { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(HTML tag) => tag.AsFragment();
         }
-        public struct I : IHtmlTagAllowingContent
+        public struct I : IHtmlTagAllowingContent<I>
         {
             public string TagName => "i";
             string IHtmlTag.TagStart => "<i";
             string IHtmlTag.EndTag => "</i>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            I IHtmlTag<I>.WithAttributes(HtmlAttributes replacementAttributes) => new I { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            I IHtmlTagAllowingContent<I>.WithContents(HtmlFragment[] replacementContents) => new I { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(I tag) => tag.AsFragment();
         }
-        public struct IFRAME : IHtmlTag, IHasAttr_src, IHasAttr_srcdoc, IHasAttr_name, IHasAttr_sandbox, IHasAttr_allowfullscreen, IHasAttr_allowpaymentrequest, IHasAttr_allowusermedia, IHasAttr_width, IHasAttr_height, IHasAttr_referrerpolicy
+        public struct IFRAME : IHtmlTag<IFRAME>, IHasAttr_src, IHasAttr_srcdoc, IHasAttr_name, IHasAttr_sandbox, IHasAttr_allowfullscreen, IHasAttr_allowpaymentrequest, IHasAttr_allowusermedia, IHasAttr_width, IHasAttr_height, IHasAttr_referrerpolicy
         {
             public string TagName => "iframe";
             string IHtmlTag.TagStart => "<iframe";
             string IHtmlTag.EndTag => "";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            IFRAME IHtmlTag<IFRAME>.WithAttributes(HtmlAttributes replacementAttributes) => new IFRAME { attrs = replacementAttributes };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeEmpty(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(IFRAME tag) => tag.AsFragment();
         }
-        public struct IMG : IHtmlTag, IHasAttr_alt, IHasAttr_src, IHasAttr_srcset, IHasAttr_crossorigin, IHasAttr_usemap, IHasAttr_ismap, IHasAttr_width, IHasAttr_height, IHasAttr_referrerpolicy
+        public struct IMG : IHtmlTag<IMG>, IHasAttr_alt, IHasAttr_src, IHasAttr_srcset, IHasAttr_crossorigin, IHasAttr_usemap, IHasAttr_ismap, IHasAttr_width, IHasAttr_height, IHasAttr_referrerpolicy
         {
             public string TagName => "img";
             string IHtmlTag.TagStart => "<img";
             string IHtmlTag.EndTag => "";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            IMG IHtmlTag<IMG>.WithAttributes(HtmlAttributes replacementAttributes) => new IMG { attrs = replacementAttributes };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeEmpty(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(IMG tag) => tag.AsFragment();
         }
-        public struct INPUT : IHtmlTag, IHasAttr_accept, IHasAttr_alt, IHasAttr_autocomplete, IHasAttr_autofocus, IHasAttr_checked, IHasAttr_dirname, IHasAttr_disabled, IHasAttr_form, IHasAttr_formaction, IHasAttr_formenctype, IHasAttr_formmethod, IHasAttr_formnovalidate, IHasAttr_formtarget, IHasAttr_height, IHasAttr_inputmode, IHasAttr_list, IHasAttr_max, IHasAttr_maxlength, IHasAttr_min, IHasAttr_minlength, IHasAttr_multiple, IHasAttr_name, IHasAttr_pattern, IHasAttr_placeholder, IHasAttr_readonly, IHasAttr_required, IHasAttr_size, IHasAttr_src, IHasAttr_step, IHasAttr_type, IHasAttr_value, IHasAttr_width
+        public struct INPUT : IHtmlTag<INPUT>, IHasAttr_accept, IHasAttr_alt, IHasAttr_autocomplete, IHasAttr_autofocus, IHasAttr_checked, IHasAttr_dirname, IHasAttr_disabled, IHasAttr_form, IHasAttr_formaction, IHasAttr_formenctype, IHasAttr_formmethod, IHasAttr_formnovalidate, IHasAttr_formtarget, IHasAttr_height, IHasAttr_inputmode, IHasAttr_list, IHasAttr_max, IHasAttr_maxlength, IHasAttr_min, IHasAttr_minlength, IHasAttr_multiple, IHasAttr_name, IHasAttr_pattern, IHasAttr_placeholder, IHasAttr_readonly, IHasAttr_required, IHasAttr_size, IHasAttr_src, IHasAttr_step, IHasAttr_type, IHasAttr_value, IHasAttr_width
         {
             public string TagName => "input";
             string IHtmlTag.TagStart => "<input";
             string IHtmlTag.EndTag => "";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            INPUT IHtmlTag<INPUT>.WithAttributes(HtmlAttributes replacementAttributes) => new INPUT { attrs = replacementAttributes };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeEmpty(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(INPUT tag) => tag.AsFragment();
         }
-        public struct INS : IHtmlTagAllowingContent, IHasAttr_cite, IHasAttr_datetime
+        public struct INS : IHtmlTagAllowingContent<INS>, IHasAttr_cite, IHasAttr_datetime
         {
             public string TagName => "ins";
             string IHtmlTag.TagStart => "<ins";
             string IHtmlTag.EndTag => "</ins>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            INS IHtmlTag<INS>.WithAttributes(HtmlAttributes replacementAttributes) => new INS { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            INS IHtmlTagAllowingContent<INS>.WithContents(HtmlFragment[] replacementContents) => new INS { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(INS tag) => tag.AsFragment();
         }
-        public struct KBD : IHtmlTagAllowingContent
+        public struct KBD : IHtmlTagAllowingContent<KBD>
         {
             public string TagName => "kbd";
             string IHtmlTag.TagStart => "<kbd";
             string IHtmlTag.EndTag => "</kbd>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            KBD IHtmlTag<KBD>.WithAttributes(HtmlAttributes replacementAttributes) => new KBD { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            KBD IHtmlTagAllowingContent<KBD>.WithContents(HtmlFragment[] replacementContents) => new KBD { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(KBD tag) => tag.AsFragment();
         }
-        public struct LABEL : IHtmlTagAllowingContent, IHasAttr_for
+        public struct LABEL : IHtmlTagAllowingContent<LABEL>, IHasAttr_for
         {
             public string TagName => "label";
             string IHtmlTag.TagStart => "<label";
             string IHtmlTag.EndTag => "</label>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            LABEL IHtmlTag<LABEL>.WithAttributes(HtmlAttributes replacementAttributes) => new LABEL { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            LABEL IHtmlTagAllowingContent<LABEL>.WithContents(HtmlFragment[] replacementContents) => new LABEL { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(LABEL tag) => tag.AsFragment();
         }
-        public struct LEGEND : IHtmlTagAllowingContent
+        public struct LEGEND : IHtmlTagAllowingContent<LEGEND>
         {
             public string TagName => "legend";
             string IHtmlTag.TagStart => "<legend";
             string IHtmlTag.EndTag => "</legend>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            LEGEND IHtmlTag<LEGEND>.WithAttributes(HtmlAttributes replacementAttributes) => new LEGEND { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            LEGEND IHtmlTagAllowingContent<LEGEND>.WithContents(HtmlFragment[] replacementContents) => new LEGEND { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(LEGEND tag) => tag.AsFragment();
         }
-        public struct LI : IHtmlTagAllowingContent, IHasAttr_value
+        public struct LI : IHtmlTagAllowingContent<LI>, IHasAttr_value
         {
             public string TagName => "li";
             string IHtmlTag.TagStart => "<li";
             string IHtmlTag.EndTag => "</li>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            LI IHtmlTag<LI>.WithAttributes(HtmlAttributes replacementAttributes) => new LI { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            LI IHtmlTagAllowingContent<LI>.WithContents(HtmlFragment[] replacementContents) => new LI { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(LI tag) => tag.AsFragment();
         }
-        public struct LINK : IHtmlTag, IHasAttr_href, IHasAttr_crossorigin, IHasAttr_rel, IHasAttr_as, IHasAttr_media, IHasAttr_hreflang, IHasAttr_type, IHasAttr_sizes, IHasAttr_referrerpolicy, IHasAttr_nonce, IHasAttr_integrity
+        public struct LINK : IHtmlTag<LINK>, IHasAttr_href, IHasAttr_crossorigin, IHasAttr_rel, IHasAttr_as, IHasAttr_media, IHasAttr_hreflang, IHasAttr_type, IHasAttr_sizes, IHasAttr_referrerpolicy, IHasAttr_nonce, IHasAttr_integrity
         {
             public string TagName => "link";
             string IHtmlTag.TagStart => "<link";
             string IHtmlTag.EndTag => "";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            LINK IHtmlTag<LINK>.WithAttributes(HtmlAttributes replacementAttributes) => new LINK { attrs = replacementAttributes };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeEmpty(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(LINK tag) => tag.AsFragment();
         }
-        public struct MAIN : IHtmlTagAllowingContent
+        public struct MAIN : IHtmlTagAllowingContent<MAIN>
         {
             public string TagName => "main";
             string IHtmlTag.TagStart => "<main";
             string IHtmlTag.EndTag => "</main>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            MAIN IHtmlTag<MAIN>.WithAttributes(HtmlAttributes replacementAttributes) => new MAIN { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            MAIN IHtmlTagAllowingContent<MAIN>.WithContents(HtmlFragment[] replacementContents) => new MAIN { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(MAIN tag) => tag.AsFragment();
         }
-        public struct MAP : IHtmlTagAllowingContent, IHasAttr_name
+        public struct MAP : IHtmlTagAllowingContent<MAP>, IHasAttr_name
         {
             public string TagName => "map";
             string IHtmlTag.TagStart => "<map";
             string IHtmlTag.EndTag => "</map>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            MAP IHtmlTag<MAP>.WithAttributes(HtmlAttributes replacementAttributes) => new MAP { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            MAP IHtmlTagAllowingContent<MAP>.WithContents(HtmlFragment[] replacementContents) => new MAP { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(MAP tag) => tag.AsFragment();
         }
-        public struct MARK : IHtmlTagAllowingContent
+        public struct MARK : IHtmlTagAllowingContent<MARK>
         {
             public string TagName => "mark";
             string IHtmlTag.TagStart => "<mark";
             string IHtmlTag.EndTag => "</mark>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            MARK IHtmlTag<MARK>.WithAttributes(HtmlAttributes replacementAttributes) => new MARK { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            MARK IHtmlTagAllowingContent<MARK>.WithContents(HtmlFragment[] replacementContents) => new MARK { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(MARK tag) => tag.AsFragment();
         }
-        public struct MENU : IHtmlTagAllowingContent, IHasAttr_type, IHasAttr_label
+        public struct MENU : IHtmlTagAllowingContent<MENU>, IHasAttr_type, IHasAttr_label
         {
             public string TagName => "menu";
             string IHtmlTag.TagStart => "<menu";
             string IHtmlTag.EndTag => "</menu>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            MENU IHtmlTag<MENU>.WithAttributes(HtmlAttributes replacementAttributes) => new MENU { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            MENU IHtmlTagAllowingContent<MENU>.WithContents(HtmlFragment[] replacementContents) => new MENU { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(MENU tag) => tag.AsFragment();
         }
-        public struct MENUITEM : IHtmlTagAllowingContent, IHasAttr_type, IHasAttr_label, IHasAttr_icon, IHasAttr_disabled, IHasAttr_checked, IHasAttr_radiogroup, IHasAttr_default
+        public struct MENUITEM : IHtmlTagAllowingContent<MENUITEM>, IHasAttr_type, IHasAttr_label, IHasAttr_icon, IHasAttr_disabled, IHasAttr_checked, IHasAttr_radiogroup, IHasAttr_default
         {
             public string TagName => "menuitem";
             string IHtmlTag.TagStart => "<menuitem";
             string IHtmlTag.EndTag => "</menuitem>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            MENUITEM IHtmlTag<MENUITEM>.WithAttributes(HtmlAttributes replacementAttributes) => new MENUITEM { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            MENUITEM IHtmlTagAllowingContent<MENUITEM>.WithContents(HtmlFragment[] replacementContents) => new MENUITEM { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(MENUITEM tag) => tag.AsFragment();
         }
-        public struct META : IHtmlTag, IHasAttr_name, IHasAttr_http_equiv, IHasAttr_content, IHasAttr_charset
+        public struct META : IHtmlTag<META>, IHasAttr_name, IHasAttr_http_equiv, IHasAttr_content, IHasAttr_charset
         {
             public string TagName => "meta";
             string IHtmlTag.TagStart => "<meta";
             string IHtmlTag.EndTag => "";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            META IHtmlTag<META>.WithAttributes(HtmlAttributes replacementAttributes) => new META { attrs = replacementAttributes };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeEmpty(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(META tag) => tag.AsFragment();
         }
-        public struct METER : IHtmlTagAllowingContent, IHasAttr_value, IHasAttr_min, IHasAttr_max, IHasAttr_low, IHasAttr_high, IHasAttr_optimum
+        public struct METER : IHtmlTagAllowingContent<METER>, IHasAttr_value, IHasAttr_min, IHasAttr_max, IHasAttr_low, IHasAttr_high, IHasAttr_optimum
         {
             public string TagName => "meter";
             string IHtmlTag.TagStart => "<meter";
             string IHtmlTag.EndTag => "</meter>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            METER IHtmlTag<METER>.WithAttributes(HtmlAttributes replacementAttributes) => new METER { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            METER IHtmlTagAllowingContent<METER>.WithContents(HtmlFragment[] replacementContents) => new METER { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(METER tag) => tag.AsFragment();
         }
-        public struct NAV : IHtmlTagAllowingContent
+        public struct NAV : IHtmlTagAllowingContent<NAV>
         {
             public string TagName => "nav";
             string IHtmlTag.TagStart => "<nav";
             string IHtmlTag.EndTag => "</nav>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            NAV IHtmlTag<NAV>.WithAttributes(HtmlAttributes replacementAttributes) => new NAV { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            NAV IHtmlTagAllowingContent<NAV>.WithContents(HtmlFragment[] replacementContents) => new NAV { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(NAV tag) => tag.AsFragment();
         }
-        public struct NOSCRIPT : IHtmlTagAllowingContent
+        public struct NOSCRIPT : IHtmlTagAllowingContent<NOSCRIPT>
         {
             public string TagName => "noscript";
             string IHtmlTag.TagStart => "<noscript";
             string IHtmlTag.EndTag => "</noscript>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            NOSCRIPT IHtmlTag<NOSCRIPT>.WithAttributes(HtmlAttributes replacementAttributes) => new NOSCRIPT { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            NOSCRIPT IHtmlTagAllowingContent<NOSCRIPT>.WithContents(HtmlFragment[] replacementContents) => new NOSCRIPT { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(NOSCRIPT tag) => tag.AsFragment();
         }
-        public struct OBJECT : IHtmlTagAllowingContent, IHasAttr_data, IHasAttr_type, IHasAttr_typemustmatch, IHasAttr_name, IHasAttr_usemap, IHasAttr_form, IHasAttr_width, IHasAttr_height
+        public struct OBJECT : IHtmlTagAllowingContent<OBJECT>, IHasAttr_data, IHasAttr_type, IHasAttr_typemustmatch, IHasAttr_name, IHasAttr_usemap, IHasAttr_form, IHasAttr_width, IHasAttr_height
         {
             public string TagName => "object";
             string IHtmlTag.TagStart => "<object";
             string IHtmlTag.EndTag => "</object>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            OBJECT IHtmlTag<OBJECT>.WithAttributes(HtmlAttributes replacementAttributes) => new OBJECT { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            OBJECT IHtmlTagAllowingContent<OBJECT>.WithContents(HtmlFragment[] replacementContents) => new OBJECT { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(OBJECT tag) => tag.AsFragment();
         }
-        public struct OL : IHtmlTagAllowingContent, IHasAttr_reversed, IHasAttr_start, IHasAttr_type
+        public struct OL : IHtmlTagAllowingContent<OL>, IHasAttr_reversed, IHasAttr_start, IHasAttr_type
         {
             public string TagName => "ol";
             string IHtmlTag.TagStart => "<ol";
             string IHtmlTag.EndTag => "</ol>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            OL IHtmlTag<OL>.WithAttributes(HtmlAttributes replacementAttributes) => new OL { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            OL IHtmlTagAllowingContent<OL>.WithContents(HtmlFragment[] replacementContents) => new OL { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(OL tag) => tag.AsFragment();
         }
-        public struct OPTGROUP : IHtmlTagAllowingContent, IHasAttr_disabled, IHasAttr_label
+        public struct OPTGROUP : IHtmlTagAllowingContent<OPTGROUP>, IHasAttr_disabled, IHasAttr_label
         {
             public string TagName => "optgroup";
             string IHtmlTag.TagStart => "<optgroup";
             string IHtmlTag.EndTag => "</optgroup>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            OPTGROUP IHtmlTag<OPTGROUP>.WithAttributes(HtmlAttributes replacementAttributes) => new OPTGROUP { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            OPTGROUP IHtmlTagAllowingContent<OPTGROUP>.WithContents(HtmlFragment[] replacementContents) => new OPTGROUP { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(OPTGROUP tag) => tag.AsFragment();
         }
-        public struct OPTION : IHtmlTagAllowingContent, IHasAttr_disabled, IHasAttr_label, IHasAttr_selected, IHasAttr_value
+        public struct OPTION : IHtmlTagAllowingContent<OPTION>, IHasAttr_disabled, IHasAttr_label, IHasAttr_selected, IHasAttr_value
         {
             public string TagName => "option";
             string IHtmlTag.TagStart => "<option";
             string IHtmlTag.EndTag => "</option>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            OPTION IHtmlTag<OPTION>.WithAttributes(HtmlAttributes replacementAttributes) => new OPTION { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            OPTION IHtmlTagAllowingContent<OPTION>.WithContents(HtmlFragment[] replacementContents) => new OPTION { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(OPTION tag) => tag.AsFragment();
         }
-        public struct OUTPUT : IHtmlTagAllowingContent, IHasAttr_for, IHasAttr_form, IHasAttr_name
+        public struct OUTPUT : IHtmlTagAllowingContent<OUTPUT>, IHasAttr_for, IHasAttr_form, IHasAttr_name
         {
             public string TagName => "output";
             string IHtmlTag.TagStart => "<output";
             string IHtmlTag.EndTag => "</output>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            OUTPUT IHtmlTag<OUTPUT>.WithAttributes(HtmlAttributes replacementAttributes) => new OUTPUT { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            OUTPUT IHtmlTagAllowingContent<OUTPUT>.WithContents(HtmlFragment[] replacementContents) => new OUTPUT { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(OUTPUT tag) => tag.AsFragment();
         }
-        public struct P : IHtmlTagAllowingContent
+        public struct P : IHtmlTagAllowingContent<P>
         {
             public string TagName => "p";
             string IHtmlTag.TagStart => "<p";
             string IHtmlTag.EndTag => "</p>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            P IHtmlTag<P>.WithAttributes(HtmlAttributes replacementAttributes) => new P { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            P IHtmlTagAllowingContent<P>.WithContents(HtmlFragment[] replacementContents) => new P { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(P tag) => tag.AsFragment();
         }
-        public struct PARAM : IHtmlTag, IHasAttr_name, IHasAttr_value
+        public struct PARAM : IHtmlTag<PARAM>, IHasAttr_name, IHasAttr_value
         {
             public string TagName => "param";
             string IHtmlTag.TagStart => "<param";
             string IHtmlTag.EndTag => "";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            PARAM IHtmlTag<PARAM>.WithAttributes(HtmlAttributes replacementAttributes) => new PARAM { attrs = replacementAttributes };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeEmpty(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(PARAM tag) => tag.AsFragment();
         }
-        public struct PICTURE : IHtmlTagAllowingContent
+        public struct PICTURE : IHtmlTagAllowingContent<PICTURE>
         {
             public string TagName => "picture";
             string IHtmlTag.TagStart => "<picture";
             string IHtmlTag.EndTag => "</picture>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            PICTURE IHtmlTag<PICTURE>.WithAttributes(HtmlAttributes replacementAttributes) => new PICTURE { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            PICTURE IHtmlTagAllowingContent<PICTURE>.WithContents(HtmlFragment[] replacementContents) => new PICTURE { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(PICTURE tag) => tag.AsFragment();
         }
-        public struct PRE : IHtmlTagAllowingContent
+        public struct PRE : IHtmlTagAllowingContent<PRE>
         {
             public string TagName => "pre";
             string IHtmlTag.TagStart => "<pre";
             string IHtmlTag.EndTag => "</pre>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            PRE IHtmlTag<PRE>.WithAttributes(HtmlAttributes replacementAttributes) => new PRE { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            PRE IHtmlTagAllowingContent<PRE>.WithContents(HtmlFragment[] replacementContents) => new PRE { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(PRE tag) => tag.AsFragment();
         }
-        public struct PROGRESS : IHtmlTagAllowingContent, IHasAttr_value, IHasAttr_max
+        public struct PROGRESS : IHtmlTagAllowingContent<PROGRESS>, IHasAttr_value, IHasAttr_max
         {
             public string TagName => "progress";
             string IHtmlTag.TagStart => "<progress";
             string IHtmlTag.EndTag => "</progress>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            PROGRESS IHtmlTag<PROGRESS>.WithAttributes(HtmlAttributes replacementAttributes) => new PROGRESS { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            PROGRESS IHtmlTagAllowingContent<PROGRESS>.WithContents(HtmlFragment[] replacementContents) => new PROGRESS { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(PROGRESS tag) => tag.AsFragment();
         }
-        public struct Q : IHtmlTagAllowingContent, IHasAttr_cite
+        public struct Q : IHtmlTagAllowingContent<Q>, IHasAttr_cite
         {
             public string TagName => "q";
             string IHtmlTag.TagStart => "<q";
             string IHtmlTag.EndTag => "</q>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            Q IHtmlTag<Q>.WithAttributes(HtmlAttributes replacementAttributes) => new Q { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            Q IHtmlTagAllowingContent<Q>.WithContents(HtmlFragment[] replacementContents) => new Q { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(Q tag) => tag.AsFragment();
         }
-        public struct RP : IHtmlTagAllowingContent
+        public struct RP : IHtmlTagAllowingContent<RP>
         {
             public string TagName => "rp";
             string IHtmlTag.TagStart => "<rp";
             string IHtmlTag.EndTag => "</rp>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            RP IHtmlTag<RP>.WithAttributes(HtmlAttributes replacementAttributes) => new RP { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            RP IHtmlTagAllowingContent<RP>.WithContents(HtmlFragment[] replacementContents) => new RP { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(RP tag) => tag.AsFragment();
         }
-        public struct RT : IHtmlTagAllowingContent
+        public struct RT : IHtmlTagAllowingContent<RT>
         {
             public string TagName => "rt";
             string IHtmlTag.TagStart => "<rt";
             string IHtmlTag.EndTag => "</rt>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            RT IHtmlTag<RT>.WithAttributes(HtmlAttributes replacementAttributes) => new RT { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            RT IHtmlTagAllowingContent<RT>.WithContents(HtmlFragment[] replacementContents) => new RT { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(RT tag) => tag.AsFragment();
         }
-        public struct RUBY : IHtmlTagAllowingContent
+        public struct RUBY : IHtmlTagAllowingContent<RUBY>
         {
             public string TagName => "ruby";
             string IHtmlTag.TagStart => "<ruby";
             string IHtmlTag.EndTag => "</ruby>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            RUBY IHtmlTag<RUBY>.WithAttributes(HtmlAttributes replacementAttributes) => new RUBY { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            RUBY IHtmlTagAllowingContent<RUBY>.WithContents(HtmlFragment[] replacementContents) => new RUBY { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(RUBY tag) => tag.AsFragment();
         }
-        public struct S : IHtmlTagAllowingContent
+        public struct S : IHtmlTagAllowingContent<S>
         {
             public string TagName => "s";
             string IHtmlTag.TagStart => "<s";
             string IHtmlTag.EndTag => "</s>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            S IHtmlTag<S>.WithAttributes(HtmlAttributes replacementAttributes) => new S { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            S IHtmlTagAllowingContent<S>.WithContents(HtmlFragment[] replacementContents) => new S { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(S tag) => tag.AsFragment();
         }
-        public struct SAMP : IHtmlTagAllowingContent
+        public struct SAMP : IHtmlTagAllowingContent<SAMP>
         {
             public string TagName => "samp";
             string IHtmlTag.TagStart => "<samp";
             string IHtmlTag.EndTag => "</samp>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            SAMP IHtmlTag<SAMP>.WithAttributes(HtmlAttributes replacementAttributes) => new SAMP { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            SAMP IHtmlTagAllowingContent<SAMP>.WithContents(HtmlFragment[] replacementContents) => new SAMP { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(SAMP tag) => tag.AsFragment();
         }
-        public struct SCRIPT : IHtmlTagAllowingContent, IHasAttr_src, IHasAttr_type, IHasAttr_charset, IHasAttr_async, IHasAttr_defer, IHasAttr_crossorigin, IHasAttr_nonce, IHasAttr_integrity
+        public struct SCRIPT : IHtmlTagAllowingContent<SCRIPT>, IHasAttr_src, IHasAttr_type, IHasAttr_charset, IHasAttr_async, IHasAttr_defer, IHasAttr_crossorigin, IHasAttr_nonce, IHasAttr_integrity
         {
             public string TagName => "script";
             string IHtmlTag.TagStart => "<script";
             string IHtmlTag.EndTag => "</script>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            SCRIPT IHtmlTag<SCRIPT>.WithAttributes(HtmlAttributes replacementAttributes) => new SCRIPT { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            SCRIPT IHtmlTagAllowingContent<SCRIPT>.WithContents(HtmlFragment[] replacementContents) => new SCRIPT { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(SCRIPT tag) => tag.AsFragment();
         }
-        public struct SECTION : IHtmlTagAllowingContent
+        public struct SECTION : IHtmlTagAllowingContent<SECTION>
         {
             public string TagName => "section";
             string IHtmlTag.TagStart => "<section";
             string IHtmlTag.EndTag => "</section>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            SECTION IHtmlTag<SECTION>.WithAttributes(HtmlAttributes replacementAttributes) => new SECTION { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            SECTION IHtmlTagAllowingContent<SECTION>.WithContents(HtmlFragment[] replacementContents) => new SECTION { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(SECTION tag) => tag.AsFragment();
         }
-        public struct SELECT : IHtmlTagAllowingContent, IHasAttr_autocomplete, IHasAttr_autofocus, IHasAttr_disabled, IHasAttr_form, IHasAttr_multiple, IHasAttr_name, IHasAttr_required, IHasAttr_size
+        public struct SELECT : IHtmlTagAllowingContent<SELECT>, IHasAttr_autocomplete, IHasAttr_autofocus, IHasAttr_disabled, IHasAttr_form, IHasAttr_multiple, IHasAttr_name, IHasAttr_required, IHasAttr_size
         {
             public string TagName => "select";
             string IHtmlTag.TagStart => "<select";
             string IHtmlTag.EndTag => "</select>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            SELECT IHtmlTag<SELECT>.WithAttributes(HtmlAttributes replacementAttributes) => new SELECT { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            SELECT IHtmlTagAllowingContent<SELECT>.WithContents(HtmlFragment[] replacementContents) => new SELECT { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(SELECT tag) => tag.AsFragment();
         }
-        public struct SLOT : IHtmlTagAllowingContent, IHasAttr_name
+        public struct SLOT : IHtmlTagAllowingContent<SLOT>, IHasAttr_name
         {
             public string TagName => "slot";
             string IHtmlTag.TagStart => "<slot";
             string IHtmlTag.EndTag => "</slot>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            SLOT IHtmlTag<SLOT>.WithAttributes(HtmlAttributes replacementAttributes) => new SLOT { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            SLOT IHtmlTagAllowingContent<SLOT>.WithContents(HtmlFragment[] replacementContents) => new SLOT { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(SLOT tag) => tag.AsFragment();
         }
-        public struct SMALL : IHtmlTagAllowingContent
+        public struct SMALL : IHtmlTagAllowingContent<SMALL>
         {
             public string TagName => "small";
             string IHtmlTag.TagStart => "<small";
             string IHtmlTag.EndTag => "</small>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            SMALL IHtmlTag<SMALL>.WithAttributes(HtmlAttributes replacementAttributes) => new SMALL { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            SMALL IHtmlTagAllowingContent<SMALL>.WithContents(HtmlFragment[] replacementContents) => new SMALL { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(SMALL tag) => tag.AsFragment();
         }
-        public struct SOURCE : IHtmlTag, IHasAttr_src, IHasAttr_sizes, IHasAttr_media
+        public struct SOURCE : IHtmlTag<SOURCE>, IHasAttr_src, IHasAttr_sizes, IHasAttr_media
         {
             public string TagName => "source";
             string IHtmlTag.TagStart => "<source";
             string IHtmlTag.EndTag => "";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            SOURCE IHtmlTag<SOURCE>.WithAttributes(HtmlAttributes replacementAttributes) => new SOURCE { attrs = replacementAttributes };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeEmpty(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(SOURCE tag) => tag.AsFragment();
         }
-        public struct SPAN : IHtmlTagAllowingContent
+        public struct SPAN : IHtmlTagAllowingContent<SPAN>
         {
             public string TagName => "span";
             string IHtmlTag.TagStart => "<span";
             string IHtmlTag.EndTag => "</span>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            SPAN IHtmlTag<SPAN>.WithAttributes(HtmlAttributes replacementAttributes) => new SPAN { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            SPAN IHtmlTagAllowingContent<SPAN>.WithContents(HtmlFragment[] replacementContents) => new SPAN { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(SPAN tag) => tag.AsFragment();
         }
-        public struct STRONG : IHtmlTagAllowingContent
+        public struct STRONG : IHtmlTagAllowingContent<STRONG>
         {
             public string TagName => "strong";
             string IHtmlTag.TagStart => "<strong";
             string IHtmlTag.EndTag => "</strong>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            STRONG IHtmlTag<STRONG>.WithAttributes(HtmlAttributes replacementAttributes) => new STRONG { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            STRONG IHtmlTagAllowingContent<STRONG>.WithContents(HtmlFragment[] replacementContents) => new STRONG { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(STRONG tag) => tag.AsFragment();
         }
-        public struct STYLE : IHtmlTagAllowingContent, IHasAttr_media, IHasAttr_nonce, IHasAttr_type
+        public struct STYLE : IHtmlTagAllowingContent<STYLE>, IHasAttr_media, IHasAttr_nonce, IHasAttr_type
         {
             public string TagName => "style";
             string IHtmlTag.TagStart => "<style";
             string IHtmlTag.EndTag => "</style>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            STYLE IHtmlTag<STYLE>.WithAttributes(HtmlAttributes replacementAttributes) => new STYLE { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            STYLE IHtmlTagAllowingContent<STYLE>.WithContents(HtmlFragment[] replacementContents) => new STYLE { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(STYLE tag) => tag.AsFragment();
         }
-        public struct SUB : IHtmlTagAllowingContent
+        public struct SUB : IHtmlTagAllowingContent<SUB>
         {
             public string TagName => "sub";
             string IHtmlTag.TagStart => "<sub";
             string IHtmlTag.EndTag => "</sub>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            SUB IHtmlTag<SUB>.WithAttributes(HtmlAttributes replacementAttributes) => new SUB { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            SUB IHtmlTagAllowingContent<SUB>.WithContents(HtmlFragment[] replacementContents) => new SUB { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(SUB tag) => tag.AsFragment();
         }
-        public struct SUMMARY : IHtmlTagAllowingContent
+        public struct SUMMARY : IHtmlTagAllowingContent<SUMMARY>
         {
             public string TagName => "summary";
             string IHtmlTag.TagStart => "<summary";
             string IHtmlTag.EndTag => "</summary>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            SUMMARY IHtmlTag<SUMMARY>.WithAttributes(HtmlAttributes replacementAttributes) => new SUMMARY { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            SUMMARY IHtmlTagAllowingContent<SUMMARY>.WithContents(HtmlFragment[] replacementContents) => new SUMMARY { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(SUMMARY tag) => tag.AsFragment();
         }
-        public struct SUP : IHtmlTagAllowingContent
+        public struct SUP : IHtmlTagAllowingContent<SUP>
         {
             public string TagName => "sup";
             string IHtmlTag.TagStart => "<sup";
             string IHtmlTag.EndTag => "</sup>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+
+            HtmlAttributes attrs;
+            SUP IHtmlTag<SUP>.WithAttributes(HtmlAttributes replacementAttributes) => new SUP { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            SUP IHtmlTagAllowingContent<SUP>.WithContents(HtmlFragment[] replacementContents) => new SUP { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(SUP tag) => tag.AsFragment();
         }
-        public struct TABLE : IHtmlTagAllowingContent
+        public struct TABLE : IHtmlTagAllowingContent<TABLE>
         {
             public string TagName => "table";
             string IHtmlTag.TagStart => "<table";
             string IHtmlTag.EndTag => "</table>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            TABLE IHtmlTag<TABLE>.WithAttributes(HtmlAttributes replacementAttributes) => new TABLE { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            TABLE IHtmlTagAllowingContent<TABLE>.WithContents(HtmlFragment[] replacementContents) => new TABLE { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(TABLE tag) => tag.AsFragment();
         }
-        public struct TBODY : IHtmlTagAllowingContent
+        public struct TBODY : IHtmlTagAllowingContent<TBODY>
         {
             public string TagName => "tbody";
             string IHtmlTag.TagStart => "<tbody";
             string IHtmlTag.EndTag => "</tbody>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            TBODY IHtmlTag<TBODY>.WithAttributes(HtmlAttributes replacementAttributes) => new TBODY { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            TBODY IHtmlTagAllowingContent<TBODY>.WithContents(HtmlFragment[] replacementContents) => new TBODY { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(TBODY tag) => tag.AsFragment();
         }
-        public struct TD : IHtmlTagAllowingContent, IHasAttr_colspan, IHasAttr_rowspan, IHasAttr_headers
+        public struct TD : IHtmlTagAllowingContent<TD>, IHasAttr_colspan, IHasAttr_rowspan, IHasAttr_headers
         {
             public string TagName => "td";
             string IHtmlTag.TagStart => "<td";
             string IHtmlTag.EndTag => "</td>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            TD IHtmlTag<TD>.WithAttributes(HtmlAttributes replacementAttributes) => new TD { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            TD IHtmlTagAllowingContent<TD>.WithContents(HtmlFragment[] replacementContents) => new TD { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(TD tag) => tag.AsFragment();
         }
-        public struct TEMPLATE : IHtmlTag
+        public struct TEMPLATE : IHtmlTag<TEMPLATE>
         {
             public string TagName => "template";
             string IHtmlTag.TagStart => "<template";
             string IHtmlTag.EndTag => "";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            TEMPLATE IHtmlTag<TEMPLATE>.WithAttributes(HtmlAttributes replacementAttributes) => new TEMPLATE { attrs = replacementAttributes };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeEmpty(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(TEMPLATE tag) => tag.AsFragment();
         }
-        public struct TEXTAREA : IHtmlTagAllowingContent, IHasAttr_autofocus, IHasAttr_cols, IHasAttr_dirname, IHasAttr_disabled, IHasAttr_form, IHasAttr_inputmode, IHasAttr_maxlength, IHasAttr_minlength, IHasAttr_name, IHasAttr_placeholder, IHasAttr_readonly, IHasAttr_required, IHasAttr_rows, IHasAttr_wrap
+        public struct TEXTAREA : IHtmlTagAllowingContent<TEXTAREA>, IHasAttr_autofocus, IHasAttr_cols, IHasAttr_dirname, IHasAttr_disabled, IHasAttr_form, IHasAttr_inputmode, IHasAttr_maxlength, IHasAttr_minlength, IHasAttr_name, IHasAttr_placeholder, IHasAttr_readonly, IHasAttr_required, IHasAttr_rows, IHasAttr_wrap
         {
             public string TagName => "textarea";
             string IHtmlTag.TagStart => "<textarea";
             string IHtmlTag.EndTag => "</textarea>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            TEXTAREA IHtmlTag<TEXTAREA>.WithAttributes(HtmlAttributes replacementAttributes) => new TEXTAREA { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            TEXTAREA IHtmlTagAllowingContent<TEXTAREA>.WithContents(HtmlFragment[] replacementContents) => new TEXTAREA { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(TEXTAREA tag) => tag.AsFragment();
         }
-        public struct TFOOT : IHtmlTagAllowingContent
+        public struct TFOOT : IHtmlTagAllowingContent<TFOOT>
         {
             public string TagName => "tfoot";
             string IHtmlTag.TagStart => "<tfoot";
             string IHtmlTag.EndTag => "</tfoot>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            TFOOT IHtmlTag<TFOOT>.WithAttributes(HtmlAttributes replacementAttributes) => new TFOOT { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            TFOOT IHtmlTagAllowingContent<TFOOT>.WithContents(HtmlFragment[] replacementContents) => new TFOOT { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(TFOOT tag) => tag.AsFragment();
         }
-        public struct TH : IHtmlTagAllowingContent, IHasAttr_colspan, IHasAttr_rowspan, IHasAttr_headers, IHasAttr_scope, IHasAttr_abbr
+        public struct TH : IHtmlTagAllowingContent<TH>, IHasAttr_colspan, IHasAttr_rowspan, IHasAttr_headers, IHasAttr_scope, IHasAttr_abbr
         {
             public string TagName => "th";
             string IHtmlTag.TagStart => "<th";
             string IHtmlTag.EndTag => "</th>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            TH IHtmlTag<TH>.WithAttributes(HtmlAttributes replacementAttributes) => new TH { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            TH IHtmlTagAllowingContent<TH>.WithContents(HtmlFragment[] replacementContents) => new TH { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(TH tag) => tag.AsFragment();
         }
-        public struct THEAD : IHtmlTagAllowingContent
+        public struct THEAD : IHtmlTagAllowingContent<THEAD>
         {
             public string TagName => "thead";
             string IHtmlTag.TagStart => "<thead";
             string IHtmlTag.EndTag => "</thead>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            THEAD IHtmlTag<THEAD>.WithAttributes(HtmlAttributes replacementAttributes) => new THEAD { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            THEAD IHtmlTagAllowingContent<THEAD>.WithContents(HtmlFragment[] replacementContents) => new THEAD { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(THEAD tag) => tag.AsFragment();
         }
-        public struct TIME : IHtmlTagAllowingContent, IHasAttr_datetime
+        public struct TIME : IHtmlTagAllowingContent<TIME>, IHasAttr_datetime
         {
             public string TagName => "time";
             string IHtmlTag.TagStart => "<time";
             string IHtmlTag.EndTag => "</time>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            TIME IHtmlTag<TIME>.WithAttributes(HtmlAttributes replacementAttributes) => new TIME { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            TIME IHtmlTagAllowingContent<TIME>.WithContents(HtmlFragment[] replacementContents) => new TIME { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(TIME tag) => tag.AsFragment();
         }
-        public struct TITLE : IHtmlTagAllowingContent
+        public struct TITLE : IHtmlTagAllowingContent<TITLE>
         {
             public string TagName => "title";
             string IHtmlTag.TagStart => "<title";
             string IHtmlTag.EndTag => "</title>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            TITLE IHtmlTag<TITLE>.WithAttributes(HtmlAttributes replacementAttributes) => new TITLE { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            TITLE IHtmlTagAllowingContent<TITLE>.WithContents(HtmlFragment[] replacementContents) => new TITLE { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(TITLE tag) => tag.AsFragment();
         }
-        public struct TR : IHtmlTagAllowingContent
+        public struct TR : IHtmlTagAllowingContent<TR>
         {
             public string TagName => "tr";
             string IHtmlTag.TagStart => "<tr";
             string IHtmlTag.EndTag => "</tr>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            TR IHtmlTag<TR>.WithAttributes(HtmlAttributes replacementAttributes) => new TR { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            TR IHtmlTagAllowingContent<TR>.WithContents(HtmlFragment[] replacementContents) => new TR { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(TR tag) => tag.AsFragment();
         }
-        public struct TRACK : IHtmlTag, IHasAttr_default, IHasAttr_kind, IHasAttr_label, IHasAttr_src, IHasAttr_srclang
+        public struct TRACK : IHtmlTag<TRACK>, IHasAttr_default, IHasAttr_kind, IHasAttr_label, IHasAttr_src, IHasAttr_srclang
         {
             public string TagName => "track";
             string IHtmlTag.TagStart => "<track";
             string IHtmlTag.EndTag => "";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            TRACK IHtmlTag<TRACK>.WithAttributes(HtmlAttributes replacementAttributes) => new TRACK { attrs = replacementAttributes };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeEmpty(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(TRACK tag) => tag.AsFragment();
         }
-        public struct U : IHtmlTagAllowingContent
+        public struct U : IHtmlTagAllowingContent<U>
         {
             public string TagName => "u";
             string IHtmlTag.TagStart => "<u";
             string IHtmlTag.EndTag => "</u>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            U IHtmlTag<U>.WithAttributes(HtmlAttributes replacementAttributes) => new U { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            U IHtmlTagAllowingContent<U>.WithContents(HtmlFragment[] replacementContents) => new U { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(U tag) => tag.AsFragment();
         }
-        public struct UL : IHtmlTagAllowingContent
+        public struct UL : IHtmlTagAllowingContent<UL>
         {
             public string TagName => "ul";
             string IHtmlTag.TagStart => "<ul";
             string IHtmlTag.EndTag => "</ul>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            UL IHtmlTag<UL>.WithAttributes(HtmlAttributes replacementAttributes) => new UL { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            UL IHtmlTagAllowingContent<UL>.WithContents(HtmlFragment[] replacementContents) => new UL { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(UL tag) => tag.AsFragment();
         }
-        public struct VAR : IHtmlTagAllowingContent
+        public struct VAR : IHtmlTagAllowingContent<VAR>
         {
             public string TagName => "var";
             string IHtmlTag.TagStart => "<var";
             string IHtmlTag.EndTag => "</var>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            VAR IHtmlTag<VAR>.WithAttributes(HtmlAttributes replacementAttributes) => new VAR { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            VAR IHtmlTagAllowingContent<VAR>.WithContents(HtmlFragment[] replacementContents) => new VAR { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(VAR tag) => tag.AsFragment();
         }
-        public struct VIDEO : IHtmlTagAllowingContent, IHasAttr_src, IHasAttr_crossorigin, IHasAttr_poster, IHasAttr_preload, IHasAttr_autoplay, IHasAttr_playsinline, IHasAttr_loop, IHasAttr_muted, IHasAttr_controls, IHasAttr_width, IHasAttr_height
+        public struct VIDEO : IHtmlTagAllowingContent<VIDEO>, IHasAttr_src, IHasAttr_crossorigin, IHasAttr_poster, IHasAttr_preload, IHasAttr_autoplay, IHasAttr_playsinline, IHasAttr_loop, IHasAttr_muted, IHasAttr_controls, IHasAttr_width, IHasAttr_height
         {
             public string TagName => "video";
             string IHtmlTag.TagStart => "<video";
             string IHtmlTag.EndTag => "</video>";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            HtmlFragment[] IHtmlTagAllowingContent.Contents { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            VIDEO IHtmlTag<VIDEO>.WithAttributes(HtmlAttributes replacementAttributes) => new VIDEO { attrs = replacementAttributes, children = children };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            HtmlFragment[] children;
+            VIDEO IHtmlTagAllowingContent<VIDEO>.WithContents(HtmlFragment[] replacementContents) => new VIDEO { attrs = attrs, children = replacementContents };
+            HtmlFragment[] IHtmlTagAllowingContent.Contents => children;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(VIDEO tag) => tag.AsFragment();
         }
-        public struct WBR : IHtmlTag
+        public struct WBR : IHtmlTag<WBR>
         {
             public string TagName => "wbr";
             string IHtmlTag.TagStart => "<wbr";
             string IHtmlTag.EndTag => "";
-            HtmlAttributes IHtmlTag.Attributes { get; set; }
-            public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
+            HtmlAttributes attrs;
+            WBR IHtmlTag<WBR>.WithAttributes(HtmlAttributes replacementAttributes) => new WBR { attrs = replacementAttributes };
+            HtmlAttributes IHtmlTag.Attributes => attrs;
+            IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeEmpty(this);
+            [Pure] public HtmlFragment AsFragment() => HtmlFragment.HtmlElement(this);
             public static implicit operator HtmlFragment(WBR tag) => tag.AsFragment();
         }
     }
@@ -1463,6 +1998,7 @@ namespace ProgressOnderwijsUtils.Html
         ///<summary>Line breaking opportunity. See: <a href="https://html.spec.whatwg.org/#the-wbr-element">https://html.spec.whatwg.org/#the-wbr-element</a><br /></summary>
         public static readonly HtmlTagKinds.WBR _wbr = new HtmlTagKinds.WBR();
     }
+
     namespace AttributeNameInterfaces
     {
         public interface IHasAttr_href { }
@@ -1490,6 +2026,7 @@ namespace ProgressOnderwijsUtils.Html
         public interface IHasAttr_onhashchange { }
         public interface IHasAttr_onlanguagechange { }
         public interface IHasAttr_onmessage { }
+        public interface IHasAttr_onmessageerror { }
         public interface IHasAttr_onoffline { }
         public interface IHasAttr_ononline { }
         public interface IHasAttr_onpagehide { }
@@ -1585,413 +2122,416 @@ namespace ProgressOnderwijsUtils.Html
     public static class AttributeConstructionMethods
     {
         public static THtmlTag _accesskey<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHtmlTag
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("accesskey", attrValue);
         public static THtmlTag _class<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHtmlTag
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("class", attrValue);
         public static THtmlTag _contenteditable<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHtmlTag
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("contenteditable", attrValue);
         public static THtmlTag _contextmenu<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHtmlTag
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("contextmenu", attrValue);
         public static THtmlTag _dir<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHtmlTag
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("dir", attrValue);
         public static THtmlTag _draggable<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHtmlTag
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("draggable", attrValue);
         public static THtmlTag _hidden<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHtmlTag
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("hidden", attrValue);
         public static THtmlTag _id<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHtmlTag
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("id", attrValue);
         public static THtmlTag _is<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHtmlTag
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("is", attrValue);
         public static THtmlTag _itemid<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHtmlTag
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("itemid", attrValue);
         public static THtmlTag _itemprop<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHtmlTag
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("itemprop", attrValue);
         public static THtmlTag _itemref<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHtmlTag
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("itemref", attrValue);
         public static THtmlTag _itemscope<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHtmlTag
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("itemscope", attrValue);
         public static THtmlTag _itemtype<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHtmlTag
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("itemtype", attrValue);
         public static THtmlTag _lang<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHtmlTag
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("lang", attrValue);
         public static THtmlTag _slot<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHtmlTag
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("slot", attrValue);
         public static THtmlTag _spellcheck<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHtmlTag
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("spellcheck", attrValue);
         public static THtmlTag _style<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHtmlTag
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("style", attrValue);
         public static THtmlTag _tabindex<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHtmlTag
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("tabindex", attrValue);
         public static THtmlTag _title<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHtmlTag
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("title", attrValue);
         public static THtmlTag _translate<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHtmlTag
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("translate", attrValue);
         public static THtmlTag _href<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_href, IHtmlTag
+            where THtmlTag : struct, IHasAttr_href, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("href", attrValue);
         public static THtmlTag _target<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_target, IHtmlTag
+            where THtmlTag : struct, IHasAttr_target, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("target", attrValue);
         public static THtmlTag _download<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_download, IHtmlTag
+            where THtmlTag : struct, IHasAttr_download, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("download", attrValue);
         public static THtmlTag _ping<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_ping, IHtmlTag
+            where THtmlTag : struct, IHasAttr_ping, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("ping", attrValue);
         public static THtmlTag _rel<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_rel, IHtmlTag
+            where THtmlTag : struct, IHasAttr_rel, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("rel", attrValue);
         public static THtmlTag _hreflang<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_hreflang, IHtmlTag
+            where THtmlTag : struct, IHasAttr_hreflang, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("hreflang", attrValue);
         public static THtmlTag _type<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_type, IHtmlTag
+            where THtmlTag : struct, IHasAttr_type, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("type", attrValue);
         public static THtmlTag _referrerpolicy<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_referrerpolicy, IHtmlTag
+            where THtmlTag : struct, IHasAttr_referrerpolicy, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("referrerpolicy", attrValue);
         public static THtmlTag _alt<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_alt, IHtmlTag
+            where THtmlTag : struct, IHasAttr_alt, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("alt", attrValue);
         public static THtmlTag _coords<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_coords, IHtmlTag
+            where THtmlTag : struct, IHasAttr_coords, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("coords", attrValue);
         public static THtmlTag _shape<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_shape, IHtmlTag
+            where THtmlTag : struct, IHasAttr_shape, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("shape", attrValue);
         public static THtmlTag _src<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_src, IHtmlTag
+            where THtmlTag : struct, IHasAttr_src, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("src", attrValue);
         public static THtmlTag _crossorigin<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_crossorigin, IHtmlTag
+            where THtmlTag : struct, IHasAttr_crossorigin, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("crossorigin", attrValue);
         public static THtmlTag _preload<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_preload, IHtmlTag
+            where THtmlTag : struct, IHasAttr_preload, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("preload", attrValue);
         public static THtmlTag _autoplay<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_autoplay, IHtmlTag
+            where THtmlTag : struct, IHasAttr_autoplay, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("autoplay", attrValue);
         public static THtmlTag _loop<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_loop, IHtmlTag
+            where THtmlTag : struct, IHasAttr_loop, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("loop", attrValue);
         public static THtmlTag _muted<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_muted, IHtmlTag
+            where THtmlTag : struct, IHasAttr_muted, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("muted", attrValue);
         public static THtmlTag _controls<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_controls, IHtmlTag
+            where THtmlTag : struct, IHasAttr_controls, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("controls", attrValue);
         public static THtmlTag _cite<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_cite, IHtmlTag
+            where THtmlTag : struct, IHasAttr_cite, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("cite", attrValue);
         public static THtmlTag _onafterprint<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_onafterprint, IHtmlTag
+            where THtmlTag : struct, IHasAttr_onafterprint, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("onafterprint", attrValue);
         public static THtmlTag _onbeforeprint<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_onbeforeprint, IHtmlTag
+            where THtmlTag : struct, IHasAttr_onbeforeprint, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("onbeforeprint", attrValue);
         public static THtmlTag _onbeforeunload<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_onbeforeunload, IHtmlTag
+            where THtmlTag : struct, IHasAttr_onbeforeunload, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("onbeforeunload", attrValue);
         public static THtmlTag _onhashchange<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_onhashchange, IHtmlTag
+            where THtmlTag : struct, IHasAttr_onhashchange, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("onhashchange", attrValue);
         public static THtmlTag _onlanguagechange<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_onlanguagechange, IHtmlTag
+            where THtmlTag : struct, IHasAttr_onlanguagechange, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("onlanguagechange", attrValue);
         public static THtmlTag _onmessage<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_onmessage, IHtmlTag
+            where THtmlTag : struct, IHasAttr_onmessage, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("onmessage", attrValue);
+        public static THtmlTag _onmessageerror<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
+            where THtmlTag : struct, IHasAttr_onmessageerror, IHtmlTag<THtmlTag>
+            => htmlTagExpr.Attribute("onmessageerror", attrValue);
         public static THtmlTag _onoffline<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_onoffline, IHtmlTag
+            where THtmlTag : struct, IHasAttr_onoffline, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("onoffline", attrValue);
         public static THtmlTag _ononline<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_ononline, IHtmlTag
+            where THtmlTag : struct, IHasAttr_ononline, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("ononline", attrValue);
         public static THtmlTag _onpagehide<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_onpagehide, IHtmlTag
+            where THtmlTag : struct, IHasAttr_onpagehide, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("onpagehide", attrValue);
         public static THtmlTag _onpageshow<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_onpageshow, IHtmlTag
+            where THtmlTag : struct, IHasAttr_onpageshow, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("onpageshow", attrValue);
         public static THtmlTag _onpopstate<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_onpopstate, IHtmlTag
+            where THtmlTag : struct, IHasAttr_onpopstate, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("onpopstate", attrValue);
         public static THtmlTag _onrejectionhandled<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_onrejectionhandled, IHtmlTag
+            where THtmlTag : struct, IHasAttr_onrejectionhandled, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("onrejectionhandled", attrValue);
         public static THtmlTag _onstorage<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_onstorage, IHtmlTag
+            where THtmlTag : struct, IHasAttr_onstorage, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("onstorage", attrValue);
         public static THtmlTag _onunhandledrejection<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_onunhandledrejection, IHtmlTag
+            where THtmlTag : struct, IHasAttr_onunhandledrejection, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("onunhandledrejection", attrValue);
         public static THtmlTag _onunload<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_onunload, IHtmlTag
+            where THtmlTag : struct, IHasAttr_onunload, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("onunload", attrValue);
         public static THtmlTag _autofocus<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_autofocus, IHtmlTag
+            where THtmlTag : struct, IHasAttr_autofocus, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("autofocus", attrValue);
         public static THtmlTag _disabled<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_disabled, IHtmlTag
+            where THtmlTag : struct, IHasAttr_disabled, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("disabled", attrValue);
         public static THtmlTag _form<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_form, IHtmlTag
+            where THtmlTag : struct, IHasAttr_form, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("form", attrValue);
         public static THtmlTag _formaction<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_formaction, IHtmlTag
+            where THtmlTag : struct, IHasAttr_formaction, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("formaction", attrValue);
         public static THtmlTag _formenctype<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_formenctype, IHtmlTag
+            where THtmlTag : struct, IHasAttr_formenctype, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("formenctype", attrValue);
         public static THtmlTag _formmethod<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_formmethod, IHtmlTag
+            where THtmlTag : struct, IHasAttr_formmethod, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("formmethod", attrValue);
         public static THtmlTag _formnovalidate<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_formnovalidate, IHtmlTag
+            where THtmlTag : struct, IHasAttr_formnovalidate, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("formnovalidate", attrValue);
         public static THtmlTag _formtarget<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_formtarget, IHtmlTag
+            where THtmlTag : struct, IHasAttr_formtarget, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("formtarget", attrValue);
         public static THtmlTag _name<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_name, IHtmlTag
+            where THtmlTag : struct, IHasAttr_name, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("name", attrValue);
         public static THtmlTag _value<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_value, IHtmlTag
+            where THtmlTag : struct, IHasAttr_value, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("value", attrValue);
         public static THtmlTag _width<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_width, IHtmlTag
+            where THtmlTag : struct, IHasAttr_width, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("width", attrValue);
         public static THtmlTag _height<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_height, IHtmlTag
+            where THtmlTag : struct, IHasAttr_height, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("height", attrValue);
         public static THtmlTag _span<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_span, IHtmlTag
+            where THtmlTag : struct, IHasAttr_span, IHtmlTag<THtmlTag>
+
             => htmlTagExpr.Attribute("span", attrValue);
         public static THtmlTag _datetime<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_datetime, IHtmlTag
+            where THtmlTag : struct, IHasAttr_datetime, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("datetime", attrValue);
         public static THtmlTag _open<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_open, IHtmlTag
+            where THtmlTag : struct, IHasAttr_open, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("open", attrValue);
         public static THtmlTag _accept_charset<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_accept_charset, IHtmlTag
+            where THtmlTag : struct, IHasAttr_accept_charset, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("accept-charset", attrValue);
         public static THtmlTag _action<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_action, IHtmlTag
+            where THtmlTag : struct, IHasAttr_action, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("action", attrValue);
         public static THtmlTag _autocomplete<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_autocomplete, IHtmlTag
+            where THtmlTag : struct, IHasAttr_autocomplete, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("autocomplete", attrValue);
         public static THtmlTag _enctype<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_enctype, IHtmlTag
+            where THtmlTag : struct, IHasAttr_enctype, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("enctype", attrValue);
         public static THtmlTag _method<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_method, IHtmlTag
+            where THtmlTag : struct, IHasAttr_method, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("method", attrValue);
         public static THtmlTag _novalidate<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_novalidate, IHtmlTag
+            where THtmlTag : struct, IHasAttr_novalidate, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("novalidate", attrValue);
         public static THtmlTag _manifest<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_manifest, IHtmlTag
+            where THtmlTag : struct, IHasAttr_manifest, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("manifest", attrValue);
         public static THtmlTag _srcdoc<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_srcdoc, IHtmlTag
+            where THtmlTag : struct, IHasAttr_srcdoc, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("srcdoc", attrValue);
         public static THtmlTag _sandbox<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_sandbox, IHtmlTag
+            where THtmlTag : struct, IHasAttr_sandbox, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("sandbox", attrValue);
         public static THtmlTag _allowfullscreen<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_allowfullscreen, IHtmlTag
+            where THtmlTag : struct, IHasAttr_allowfullscreen, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("allowfullscreen", attrValue);
         public static THtmlTag _allowpaymentrequest<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_allowpaymentrequest, IHtmlTag
+            where THtmlTag : struct, IHasAttr_allowpaymentrequest, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("allowpaymentrequest", attrValue);
         public static THtmlTag _allowusermedia<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_allowusermedia, IHtmlTag
+            where THtmlTag : struct, IHasAttr_allowusermedia, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("allowusermedia", attrValue);
         public static THtmlTag _srcset<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_srcset, IHtmlTag
+            where THtmlTag : struct, IHasAttr_srcset, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("srcset", attrValue);
         public static THtmlTag _usemap<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_usemap, IHtmlTag
+            where THtmlTag : struct, IHasAttr_usemap, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("usemap", attrValue);
         public static THtmlTag _ismap<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_ismap, IHtmlTag
+            where THtmlTag : struct, IHasAttr_ismap, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("ismap", attrValue);
         public static THtmlTag _accept<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_accept, IHtmlTag
+            where THtmlTag : struct, IHasAttr_accept, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("accept", attrValue);
         public static THtmlTag _checked<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_checked, IHtmlTag
+            where THtmlTag : struct, IHasAttr_checked, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("checked", attrValue);
         public static THtmlTag _dirname<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_dirname, IHtmlTag
+            where THtmlTag : struct, IHasAttr_dirname, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("dirname", attrValue);
         public static THtmlTag _inputmode<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_inputmode, IHtmlTag
+            where THtmlTag : struct, IHasAttr_inputmode, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("inputmode", attrValue);
         public static THtmlTag _list<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_list, IHtmlTag
+            where THtmlTag : struct, IHasAttr_list, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("list", attrValue);
         public static THtmlTag _max<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_max, IHtmlTag
+            where THtmlTag : struct, IHasAttr_max, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("max", attrValue);
         public static THtmlTag _maxlength<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_maxlength, IHtmlTag
+            where THtmlTag : struct, IHasAttr_maxlength, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("maxlength", attrValue);
         public static THtmlTag _min<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_min, IHtmlTag
+            where THtmlTag : struct, IHasAttr_min, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("min", attrValue);
         public static THtmlTag _minlength<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_minlength, IHtmlTag
+            where THtmlTag : struct, IHasAttr_minlength, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("minlength", attrValue);
         public static THtmlTag _multiple<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_multiple, IHtmlTag
+            where THtmlTag : struct, IHasAttr_multiple, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("multiple", attrValue);
         public static THtmlTag _pattern<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_pattern, IHtmlTag
+            where THtmlTag : struct, IHasAttr_pattern, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("pattern", attrValue);
         public static THtmlTag _placeholder<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_placeholder, IHtmlTag
+            where THtmlTag : struct, IHasAttr_placeholder, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("placeholder", attrValue);
         public static THtmlTag _readonly<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_readonly, IHtmlTag
+            where THtmlTag : struct, IHasAttr_readonly, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("readonly", attrValue);
         public static THtmlTag _required<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_required, IHtmlTag
+            where THtmlTag : struct, IHasAttr_required, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("required", attrValue);
         public static THtmlTag _size<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_size, IHtmlTag
+            where THtmlTag : struct, IHasAttr_size, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("size", attrValue);
         public static THtmlTag _step<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_step, IHtmlTag
+            where THtmlTag : struct, IHasAttr_step, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("step", attrValue);
         public static THtmlTag _for<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_for, IHtmlTag
+            where THtmlTag : struct, IHasAttr_for, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("for", attrValue);
         public static THtmlTag _as<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_as, IHtmlTag
+            where THtmlTag : struct, IHasAttr_as, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("as", attrValue);
         public static THtmlTag _media<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_media, IHtmlTag
+            where THtmlTag : struct, IHasAttr_media, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("media", attrValue);
         public static THtmlTag _sizes<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_sizes, IHtmlTag
+            where THtmlTag : struct, IHasAttr_sizes, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("sizes", attrValue);
         public static THtmlTag _nonce<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_nonce, IHtmlTag
+            where THtmlTag : struct, IHasAttr_nonce, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("nonce", attrValue);
         public static THtmlTag _integrity<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_integrity, IHtmlTag
+            where THtmlTag : struct, IHasAttr_integrity, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("integrity", attrValue);
         public static THtmlTag _label<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_label, IHtmlTag
+            where THtmlTag : struct, IHasAttr_label, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("label", attrValue);
         public static THtmlTag _icon<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_icon, IHtmlTag
+            where THtmlTag : struct, IHasAttr_icon, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("icon", attrValue);
         public static THtmlTag _radiogroup<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_radiogroup, IHtmlTag
+            where THtmlTag : struct, IHasAttr_radiogroup, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("radiogroup", attrValue);
         public static THtmlTag _default<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_default, IHtmlTag
+            where THtmlTag : struct, IHasAttr_default, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("default", attrValue);
         public static THtmlTag _http_equiv<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_http_equiv, IHtmlTag
+            where THtmlTag : struct, IHasAttr_http_equiv, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("http-equiv", attrValue);
         public static THtmlTag _content<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_content, IHtmlTag
+            where THtmlTag : struct, IHasAttr_content, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("content", attrValue);
         public static THtmlTag _charset<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_charset, IHtmlTag
+            where THtmlTag : struct, IHasAttr_charset, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("charset", attrValue);
         public static THtmlTag _low<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_low, IHtmlTag
+            where THtmlTag : struct, IHasAttr_low, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("low", attrValue);
         public static THtmlTag _high<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_high, IHtmlTag
+            where THtmlTag : struct, IHasAttr_high, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("high", attrValue);
         public static THtmlTag _optimum<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_optimum, IHtmlTag
+            where THtmlTag : struct, IHasAttr_optimum, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("optimum", attrValue);
         public static THtmlTag _data<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_data, IHtmlTag
+            where THtmlTag : struct, IHasAttr_data, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("data", attrValue);
         public static THtmlTag _typemustmatch<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_typemustmatch, IHtmlTag
+            where THtmlTag : struct, IHasAttr_typemustmatch, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("typemustmatch", attrValue);
         public static THtmlTag _reversed<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_reversed, IHtmlTag
+            where THtmlTag : struct, IHasAttr_reversed, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("reversed", attrValue);
         public static THtmlTag _start<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_start, IHtmlTag
+            where THtmlTag : struct, IHasAttr_start, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("start", attrValue);
         public static THtmlTag _selected<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_selected, IHtmlTag
+            where THtmlTag : struct, IHasAttr_selected, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("selected", attrValue);
         public static THtmlTag _async<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_async, IHtmlTag
+            where THtmlTag : struct, IHasAttr_async, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("async", attrValue);
         public static THtmlTag _defer<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_defer, IHtmlTag
+            where THtmlTag : struct, IHasAttr_defer, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("defer", attrValue);
         public static THtmlTag _colspan<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_colspan, IHtmlTag
+            where THtmlTag : struct, IHasAttr_colspan, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("colspan", attrValue);
         public static THtmlTag _rowspan<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_rowspan, IHtmlTag
+            where THtmlTag : struct, IHasAttr_rowspan, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("rowspan", attrValue);
         public static THtmlTag _headers<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_headers, IHtmlTag
+            where THtmlTag : struct, IHasAttr_headers, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("headers", attrValue);
         public static THtmlTag _cols<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_cols, IHtmlTag
+            where THtmlTag : struct, IHasAttr_cols, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("cols", attrValue);
         public static THtmlTag _rows<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_rows, IHtmlTag
+            where THtmlTag : struct, IHasAttr_rows, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("rows", attrValue);
         public static THtmlTag _wrap<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_wrap, IHtmlTag
+            where THtmlTag : struct, IHasAttr_wrap, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("wrap", attrValue);
         public static THtmlTag _scope<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_scope, IHtmlTag
+            where THtmlTag : struct, IHasAttr_scope, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("scope", attrValue);
         public static THtmlTag _abbr<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_abbr, IHtmlTag
+            where THtmlTag : struct, IHasAttr_abbr, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("abbr", attrValue);
         public static THtmlTag _kind<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_kind, IHtmlTag
+            where THtmlTag : struct, IHasAttr_kind, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("kind", attrValue);
         public static THtmlTag _srclang<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_srclang, IHtmlTag
+            where THtmlTag : struct, IHasAttr_srclang, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("srclang", attrValue);
         public static THtmlTag _poster<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_poster, IHtmlTag
+            where THtmlTag : struct, IHasAttr_poster, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("poster", attrValue);
         public static THtmlTag _playsinline<THtmlTag>(this THtmlTag htmlTagExpr, string attrValue)
-            where THtmlTag : struct, IHasAttr_playsinline, IHtmlTag
+            where THtmlTag : struct, IHasAttr_playsinline, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute("playsinline", attrValue);
     }
 }
-

--- a/src/ProgressOnderwijsUtils/Html/HtmlTagAlterations.cs
+++ b/src/ProgressOnderwijsUtils/Html/HtmlTagAlterations.cs
@@ -1,0 +1,40 @@
+﻿namespace ProgressOnderwijsUtils.Html
+{
+    public static class HtmlTagAlterations
+    {
+        public static IHtmlTag ReplaceAttributes(IHtmlTag tag, HtmlAttributes attributes) => tag.ApplyChange(new HtmlTagAtributeAlteration(attributes));
+        public static IHtmlTagAllowingContent ReplaceContents(IHtmlTag tag, HtmlFragment[] children) => (IHtmlTagAllowingContent)tag.ApplyChange(new HtmlTagContentAlteration(children));
+
+        struct HtmlTagContentAlteration : IHtmlTagAlteration
+        {
+            readonly HtmlFragment[] newContents;
+
+            public HtmlTagContentAlteration(HtmlFragment[] newContents)
+            {
+                this.newContents = newContents;
+            }
+
+            public TSelf ChangeEmpty<TSelf>(TSelf typed) where TSelf : struct, IHtmlTag<TSelf>
+                => typed;
+
+            public TSelf ChangeWithContent<TSelf>(TSelf typed) where TSelf : struct, IHtmlTagAllowingContent<TSelf>
+                => typed.WithContents(newContents);
+        }
+
+        struct HtmlTagAtributeAlteration : IHtmlTagAlteration
+        {
+            readonly HtmlAttributes newAttributes;
+
+            public HtmlTagAtributeAlteration(HtmlAttributes newAttributes)
+            {
+                this.newAttributes = newAttributes;
+            }
+
+            public TSelf ChangeEmpty<TSelf>(TSelf typed) where TSelf : struct, IHtmlTag<TSelf>
+                => typed.WithAttributes(newAttributes);
+
+            public TSelf ChangeWithContent<TSelf>(TSelf typed) where TSelf : struct, IHtmlTagAllowingContent<TSelf>
+                => typed.WithAttributes(newAttributes);
+        }
+    }
+}

--- a/src/ProgressOnderwijsUtils/Html/HtmlTagHelpers.cs
+++ b/src/ProgressOnderwijsUtils/Html/HtmlTagHelpers.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
@@ -10,8 +9,8 @@ namespace ProgressOnderwijsUtils.Html
     public static class HtmlTagHelpers
     {
         [Pure]
-        public static TExpression Attributes<TExpression>(this TExpression htmlTagExpr, IEnumerable<HtmlAttribute> attributes)
-            where TExpression : struct, IHtmlTag
+        public static THtmlTag Attributes<THtmlTag>(this THtmlTag htmlTagExpr, IEnumerable<HtmlAttribute> attributes)
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
         {
             foreach (var attribute in attributes) {
                 htmlTagExpr = htmlTagExpr.Attribute(attribute.Name, attribute.Value);
@@ -20,19 +19,16 @@ namespace ProgressOnderwijsUtils.Html
         }
 
         [Pure]
-        public static TExpression Contents<TExpression, TContent>(this TExpression htmlTagExpr, IEnumerable<TContent> contents)
-            where TExpression : struct, IHtmlTagAllowingContent
+        public static THtmlTag Contents<THtmlTag, TContent>(this THtmlTag htmlTagExpr, IEnumerable<TContent> contents)
+            where THtmlTag : struct, IHtmlTagAllowingContent<THtmlTag>
             where TContent : IConvertibleToFragment
             => htmlTagExpr.Content(contents.Select(el => el.AsFragment()).ToArray());
 
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TExpression Content<TExpression>(this TExpression htmlTagExpr, params HtmlFragment[] contents)
-            where TExpression : struct, IHtmlTagAllowingContent
-        {
-            htmlTagExpr.Contents = htmlTagExpr.Contents.AppendArrays(contents);
-            return htmlTagExpr;
-        }
+        public static THtmlTag Content<THtmlTag>(this THtmlTag htmlTagExpr, params HtmlFragment[] contents)
+            where THtmlTag : struct, IHtmlTagAllowingContent<THtmlTag>
+            => htmlTagExpr.WithContents(htmlTagExpr.Contents.AppendArrays(contents));
 
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -40,30 +36,20 @@ namespace ProgressOnderwijsUtils.Html
 
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TExpression Attribute<TExpression>(this TExpression htmlTagExpr, HtmlAttribute attribute)
-            where TExpression : struct, IHtmlTag
+        public static THtmlTag Attribute<THtmlTag>(this THtmlTag htmlTagExpr, HtmlAttribute attribute)
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => htmlTagExpr.Attribute(attribute.Name, attribute.Value);
 
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TExpression Attribute<TExpression>(this TExpression htmlTagExpr, HtmlAttribute? attributeOrNull)
-            where TExpression : struct, IHtmlTag
+        public static THtmlTag Attribute<THtmlTag>(this THtmlTag htmlTagExpr, HtmlAttribute? attributeOrNull)
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
             => attributeOrNull == null ? htmlTagExpr : htmlTagExpr.Attribute(attributeOrNull.Value);
 
         [Pure]
         public static THtmlTag Attribute<THtmlTag>(this THtmlTag htmlTagExpr, string attrName, string attrValue)
-            where THtmlTag : struct, IHtmlTag
-        {
-            if (attrValue == null)
-            {
-                return htmlTagExpr;
-            }
-            else
-            {
-                htmlTagExpr.Attributes = htmlTagExpr.Attributes.Add(attrName, attrValue);
-                return htmlTagExpr;
-            }
-        }
+            where THtmlTag : struct, IHtmlTag<THtmlTag>
+            => attrValue == null ? htmlTagExpr : htmlTagExpr.WithAttributes(htmlTagExpr.Attributes.Add(attrName, attrValue));
 
         [Pure]
         public static HtmlFragment WrapInHtmlFragment<T>(this IEnumerable<T> htmlEls)

--- a/src/ProgressOnderwijsUtils/Html/interfaces.cs
+++ b/src/ProgressOnderwijsUtils/Html/interfaces.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils.Html
@@ -16,11 +14,35 @@ namespace ProgressOnderwijsUtils.Html
         string TagName { get; }
         string TagStart { get; }
         string EndTag { get; }
-        HtmlAttributes Attributes { get; set; }
+        HtmlAttributes Attributes { get; }
+
+        /// <summary>
+        /// See HtmlTagAlterations for simple examples.  Upon using this method, the "change" parameter with receive a call to
+        /// either ChangeWithContent or ChangeEmpty.
+        /// </summary>
+        IHtmlTag ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) where THtmlTagAlteration : IHtmlTagAlteration;
+    }
+
+    public interface IHtmlTagAlteration
+    {
+        TSelf ChangeEmpty<TSelf>(TSelf typed) where TSelf : struct, IHtmlTag<TSelf>;
+        TSelf ChangeWithContent<TSelf>(TSelf typed) where TSelf : struct, IHtmlTagAllowingContent<TSelf>;
     }
 
     public interface IHtmlTagAllowingContent : IHtmlTag
     {
-        HtmlFragment[] Contents { get; set; }
+        HtmlFragment[] Contents { get; }
+    }
+
+    public interface IHtmlTag<out TSelf> : IHtmlTag
+        where TSelf : struct, IHtmlTag<TSelf>
+    {
+        TSelf WithAttributes(HtmlAttributes replacementAttributes);
+    }
+
+    public interface IHtmlTagAllowingContent<out TSelf> : IHtmlTag<TSelf>, IHtmlTagAllowingContent
+        where TSelf : struct, IHtmlTagAllowingContent<TSelf>
+    {
+        TSelf WithContents(HtmlFragment[] replacementContents);
     }
 }


### PR DESCRIPTION
unfortunately the struct+mutation solution is a little too simple.  The idea *was* that it was OK to have a mutable struct - and it is as long as it's used by value.  But because the mutation can occur through an interface, and because that means it can occur on *boxed* values aka references, you can get pretty confusing aliasing with mutation.