### PR TITLE
Allow multiple write-meta-objects.

### DIFF
--- a/src/ProgressOnderwijsUtils/Data/FieldMapping.cs
+++ b/src/ProgressOnderwijsUtils/Data/FieldMapping.cs
@@ -72,6 +72,7 @@ namespace ProgressOnderwijsUtils
 
         public static void ApplyFieldMappingsToBulkCopy(FieldMapping[] mapping, SqlBulkCopy bulkCopy)
         {
+            bulkCopy.ColumnMappings.Clear();
             foreach (var mapEntry in mapping) {
                 bulkCopy.ColumnMappings.Add(mapEntry.SrcIndex, mapEntry.DstIndex);
             }


### PR DESCRIPTION
Currently, we do all bulk insert in one big call.  That's not entirely flexible, and not necessary.  The only thing that needs to change to allow multiple calls to WriteMetaObjects on a single SqlBulkCopy is to ensure the column mappings are reset between calls.