### PR TITLE
ValueBase.ToString(): add newlines between properties.

### DIFF
--- a/src/ProgressOnderwijsUtils/ValueBase.cs
+++ b/src/ProgressOnderwijsUtils/ValueBase.cs
@@ -71,41 +71,47 @@ namespace ProgressOnderwijsUtils
 
         static Func<T, string> byPublicMembers()
         {
+            var concatMethod = ((Func<string[], string>)string.Concat).Method;
+
+            Expression concatStringExpressions(params Expression[] stringExpressions)
+                => Expression.Call(concatMethod, Expression.NewArrayInit(typeof(string), stringExpressions));
+
             var type = typeof(T);
             var refEqMethod = ((Func<object, object, bool>)ReferenceEquals).Method;
             var toStringMethod = typeof(ToStringByMembers<T>).GetMethod("ToString", BindingFlags.Static | BindingFlags.NonPublic);
-            var concatMethod = ((Func<string, string, string>)string.Concat).Method;
+
             var parA = Expression.Parameter(type, "a");
+            var fields = type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            var readableProperties = type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).Where(pi => pi.CanRead && pi.GetGetMethod() != null);
+            var fieldsAndProperties = fields.Cast<MemberInfo>().Concat(readableProperties);
+            var nonCompilerGeneratedMembers = fieldsAndProperties.Where(fi => !fi.Name.StartsWith("<"));
+
+            var replaceMethod = ((Func<string, string, string>)"".Replace).Method;
+
+            Expression MemberToStringExpression(MemberInfo fi) =>
+                concatStringExpressions(
+                    Expression.Constant("    " + FriendlyMemberName(fi) + " = "),
+                    Expression.Condition(
+                        Expression.Call(refEqMethod, Expression.Convert(MemberAccessExpression(parA, fi), typeof(object)), Expression.Default(typeof(object))),
+                        Expression.Constant("null"),
+                        Expression.Call(
+                            Expression.Coalesce(
+                                Expression.Call(toStringMethod, Expression.Convert(MemberAccessExpression(parA, fi), typeof(object))),
+                                Expression.Constant("")
+                                ),
+                            replaceMethod,
+                            Expression.Constant("\n"),
+                            Expression.Constant("\n    ")
+                            )),
+                    Expression.Constant(",\n")
+                    );
 
             var toStringExpr =
-                Expression.Call(
-                    concatMethod,
-                    type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).Concat(
-                        type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).Where(pi => pi.CanRead && pi.GetGetMethod() != null)
-                            .Cast<MemberInfo>()
-                        )
-                        .Where(fi => !fi.Name.StartsWith("<"))
-                        .Select(
-                            fi =>
-                                Expression.Call(
-                                    concatMethod,
-                                    Expression.Call(
-                                        concatMethod,
-                                        Expression.Constant(FriendlyMemberName(fi) + " = "),
-                                        Expression.Condition(
-                                            Expression.Call(
-                                                null,
-                                                refEqMethod,
-                                                Expression.Convert(MemberAccessExpression(parA, fi), typeof(object)),
-                                                Expression.Default(typeof(object))),
-                                            Expression.Constant("null"),
-                                            Expression.Call(toStringMethod, Expression.Convert(MemberAccessExpression(parA, fi), typeof(object)))
-                                            )
-                                        ),
-                                    Expression.Constant(", ")
-                                    )
-                        ).Aggregate((Expression)Expression.Constant("new " + type.Name + " { "), (a, b) => Expression.Call(concatMethod, a, b)),
-                    Expression.Constant("}")
+                concatStringExpressions(
+                    new[] { Expression.Constant("new " + type.Name + " {\n"), }
+                        .Concat(nonCompilerGeneratedMembers.Select(MemberToStringExpression))
+                        .Concat(new[] { Expression.Constant("}") })
+                        .ToArray()
                     );
 
             return Expression.Lambda<Func<T, string>>(toStringExpr, parA).Compile();

--- a/test/ProgressOnderwijsUtilsTests/ValueBaseTest.ToString_ReturnsCleanLookingOutput.approved.txt
+++ b/test/ProgressOnderwijsUtilsTests/ValueBaseTest.ToString_ReturnsCleanLookingOutput.approved.txt
@@ -1,0 +1,15 @@
+﻿new ExampleValue {
+    MyInt = 42,
+    Nested = new ExampleValue {
+        MyInt = 0,
+        Nested = null,
+        NullableField = null,
+        AnEnum = ConsoleKey.BrowserRefresh,
+        MyString = null,
+        SomeValueType = default(DateTime),
+    },
+    NullableField = null,
+    AnEnum = ConsoleKey.BrowserBack,
+    MyString = "Hello World!",
+    SomeValueType = default(DateTime),
+}

--- a/test/ProgressOnderwijsUtilsTests/ValueBaseTest.cs
+++ b/test/ProgressOnderwijsUtilsTests/ValueBaseTest.cs
@@ -1,8 +1,7 @@
 ﻿using System;
-using ExpressionToCodeLib;
 using JetBrains.Annotations;
-using Xunit;
 using ProgressOnderwijsUtils;
+using Xunit;
 
 namespace ProgressOnderwijsUtilsTests
 {
@@ -20,19 +19,17 @@ namespace ProgressOnderwijsUtilsTests
     public class ValueBaseTest
     {
         [Fact]
-        public void ToString_IsCompilableWherePossible()
+        public void ToString_ReturnsCleanLookingOutput()
         {
-            PAssert.That(
-                () =>
-                    new ExampleValue {
-                        NullableField = null,
-                        AnEnum = ConsoleKey.BrowserBack,
-                        MyString = "Hello World!",
-                        Nested = new ExampleValue { AnEnum = ConsoleKey.BrowserRefresh },
-                        SomeValueType = default(DateTime),
-                        MyInt = 42,
-                    }.ToString()
-                        == @"new ExampleValue { MyInt = 42, Nested = new ExampleValue { MyInt = 0, Nested = null, NullableField = null, AnEnum = ConsoleKey.BrowserRefresh, MyString = null, SomeValueType = default(DateTime), }, NullableField = null, AnEnum = ConsoleKey.BrowserBack, MyString = ""Hello World!"", SomeValueType = default(DateTime), }");
+            ApprovalTest.Verify(
+                new ExampleValue {
+                    NullableField = null,
+                    AnEnum = ConsoleKey.BrowserBack,
+                    MyString = "Hello World!",
+                    Nested = new ExampleValue { AnEnum = ConsoleKey.BrowserRefresh },
+                    SomeValueType = default(DateTime),
+                    MyInt = 42,
+                }.ToString());
         }
     }
 }


### PR DESCRIPTION
Also, indent sub-property ToStrings.

Aim: to make some complicated assertion failures a little more readable.