### PR TITLE
Alleen members IMetaObject implicit use

### DIFF
--- a/src/ProgressOnderwijsUtils/MetaObject/MetaObject.cs
+++ b/src/ProgressOnderwijsUtils/MetaObject/MetaObject.cs
@@ -9,7 +9,7 @@ using static ProgressOnderwijsUtils.SafeSql;
 
 namespace ProgressOnderwijsUtils
 {
-    [UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.WithMembers)]
+    [UsedImplicitly(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.Members)]
     public interface IMetaObject { }
 
     public static class MetaObject

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Configuration">
-    <Version>5.1.0</Version>
+    <Version>5.1.1</Version>
     <Authors>Progress Onderwijs</Authors>
     <Owners>Progress Onderwijs</Owners>
     <Title>ProgressOnderwijsUtils</Title>


### PR DESCRIPTION
Ik hoop dat metaobjects die helemaal niet gebruikt worden nu als zodanig worden gemarkeerd.