### PR TITLE
RootedTree.ReplaceSubTree gemaakt om een (Rooted)Tree mee te kunnen manipuleren.

### DIFF
--- a/src/ProgressOnderwijsUtils/Collections/RootedTree.cs
+++ b/src/ProgressOnderwijsUtils/Collections/RootedTree.cs
@@ -1,7 +1,7 @@
-﻿using System.Linq;
+﻿using System;
 using System.Collections.Generic;
-using System;
-using ProgressOnderwijsUtils;
+using System.Linq;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils.Collections
 {
@@ -24,6 +24,7 @@ namespace ProgressOnderwijsUtils.Collections
         public bool IsRoot => PathSegments.Tail.IsEmpty;
         public bool HasValue => !PathSegments.IsEmpty;
         public RootedTree<T> Parent => new RootedTree<T>(PathSegments.Tail);
+        public RootedTree<T> Root => PathSegments.Last().ThisSubTree.RootHere();
 
         public bool Equals(RootedTree<T> other)
         {
@@ -57,6 +58,29 @@ namespace ProgressOnderwijsUtils.Collections
                 Index = index;
                 ThisSubTree = node;
             }
+        }
+
+        [Pure]
+        public RootedTree<T> ReplaceSubTree(Tree<T> newSubTree)
+        {
+            if (IsRoot) {
+                return newSubTree.RootHere();
+            } else {
+                var parentSubTree = PathSegments.Tail.Head.ThisSubTree;
+                var myIndex = PathSegments.Head.Index;
+                var newSiblings = CopyArrayWithNewValueOnIndex(parentSubTree.Children, myIndex, newSubTree);
+                var newParentSubTree = Tree.Node(parentSubTree.NodeValue, newSiblings);
+                var newParent = Parent.ReplaceSubTree(newParentSubTree);
+                return new RootedTree<T>(newParent.PathSegments.Prepend(new TreePathSegment(myIndex, newSubTree)));
+            }
+        }
+
+        [Pure]
+        static Tree<T>[] CopyArrayWithNewValueOnIndex(IReadOnlyList<Tree<T>> oldArray, int index, Tree<T> newValue)
+        {
+            var copy = oldArray.ToArray();
+            copy[index] = newValue;
+            return copy;
         }
     }
 }

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Configuration">
-    <Version>8.0.0</Version>
+    <Version>8.1.0</Version>
     <Authors>Progress Onderwijs</Authors>
     <Owners>Progress Onderwijs</Owners>
     <Title>ProgressOnderwijsUtils</Title>
@@ -8,7 +8,7 @@
       Various utility methods+classes used by Progress Onderwijs.
     </Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageReleaseNotes>BulkCopyToSqlServer no longer specifies UseInternalTransaction</PackageReleaseNotes>
+    <PackageReleaseNotes>RootedTree&lt;T&gt;::ReplaceSubTree(Tree&lt;T&gt;) method added to support editing of trees.</PackageReleaseNotes>
     <PackageTags>ProgressOnderwijs</PackageTags>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/progressonderwijs/ProgressOnderwijsUtils</PackageProjectUrl>

--- a/test/ProgressOnderwijsUtilsTests/RootedTreeTest.cs
+++ b/test/ProgressOnderwijsUtilsTests/RootedTreeTest.cs
@@ -1,0 +1,52 @@
+﻿using System.Linq;
+using ExpressionToCodeLib;
+using ProgressOnderwijsUtils;
+using ProgressOnderwijsUtils.Collections;
+using Xunit;
+
+namespace ProgressOnderwijsUtilsTests
+{
+    public sealed class RootedTreeTest
+    {
+        [Fact]
+        public void ReplaceSubTree_can_replace_single_root_node()
+        {
+            var tree = Tree.Node(42).RootHere();
+            var newTree = tree.ReplaceSubTree(Tree.Node(11));
+
+            PAssert.That(() => !newTree.Equals(tree));
+            PAssert.That(() => newTree.Equals(Tree.Node(11).RootHere()));
+        }
+
+        [Fact]
+        public void ReplaceSubTree_can_replace_nested_node()
+        {
+            var tree =
+                Tree.Node(1,
+                    Tree.Node(2),
+                    Tree.Node(3,
+                        Tree.Node(4),
+                        Tree.Node(5)
+                        )
+                    ).RootHere();
+
+            var toReplace = tree
+                .PreorderTraversal()
+                .Single(node => node.NodeValue == 3);
+
+            var newTree = toReplace
+                .ReplaceSubTree(Tree.Node(42, toReplace.UnrootedSubTree().Children))
+                .Root;
+
+            PAssert.That(() => !newTree.Equals(tree));
+            PAssert.That(() => newTree.Equals(
+                Tree.Node(1,
+                    Tree.Node(2),
+                    Tree.Node(42,
+                        Tree.Node(4),
+                        Tree.Node(5)
+                        )
+                    ).RootHere()));
+        }
+    }
+}


### PR DESCRIPTION
Hiermee kunnen we straks redelijk eenvoudig een node veranderen, toevoegen of verwijderen.
Zie ook de test case als voorbeeld hiervoor.