### PR TITLE
Haal de specifieke transactie uit het TableValuedTypeDefinitionScripts.

### DIFF
--- a/src/ProgressOnderwijsUtils/Data/SqlParameterComponent.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlParameterComponent.cs
@@ -66,7 +66,7 @@ namespace ProgressOnderwijsUtils
         public static ISqlComponent ToTableValuedParameterFromPlainValues(IEnumerable set)
         {
             var enumerableType = set.GetType();
-            if (!tableValuedParameterFactoryCache.TryGetValue(enumerableType, out ITableValuedParameterFactory factory)) {
+            if (!tableValuedParameterFactoryCache.TryGetValue(enumerableType, out var factory)) {
                 factory = CreateTableValuedParameterFactory(enumerableType);
                 tableValuedParameterFactoryCache.TryAdd(enumerableType, factory);
             }
@@ -127,15 +127,14 @@ namespace ProgressOnderwijsUtils
 
             public static readonly Dictionary<Type, string> SqlTableTypeNameByDotnetType = All.ToDictionary(o => o.Type, o => o.SqlTypeName);
 
-            public static ParameterizedSql DefinitionScripts =>
-                ParameterizedSql.CreateDynamic($@"
-                    set transaction isolation level serializable;
-                    begin tran
-                    {All.Select(o => $@"
-                        drop type if exists {o.SqlTypeName}
-                        create type {o.SqlTypeName} as table ({o.TableDeclaration})
-                    ").JoinStrings("\n")}
-                    commit");
+            public static ParameterizedSql DefinitionScripts
+                => All
+                    .Select(o => SafeSql.SQL($@"
+                        drop type if exists {ParameterizedSql.CreateDynamic(o.SqlTypeName)};
+                        create type {ParameterizedSql.CreateDynamic(o.SqlTypeName)}
+                        as table ({ParameterizedSql.CreateDynamic(o.TableDeclaration)});
+                    "))
+                    .ConcatenateSql();
         }
 
         interface ITableValuedParameterFactory

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -8,7 +8,7 @@
       Various utility methods+classes used by Progress Onderwijs.
     </Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageReleaseNotes>Transactie uit de TableValuedTypeDefinitionScripts gehaald zodat deze kan worden aangeroepen in code met zijn eigen transactie.</PackageReleaseNotes>
+    <PackageReleaseNotes>Removed transaction from the TableValuedTypeDefinitionScripts so callers can define their own transaction.</PackageReleaseNotes>
     <PackageTags>ProgressOnderwijs</PackageTags>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/progressonderwijs/ProgressOnderwijsUtils</PackageProjectUrl>

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Configuration">
-    <Version>8.1.0</Version>
+    <Version>8.1.1</Version>
     <Authors>Progress Onderwijs</Authors>
     <Owners>Progress Onderwijs</Owners>
     <Title>ProgressOnderwijsUtils</Title>
@@ -8,7 +8,7 @@
       Various utility methods+classes used by Progress Onderwijs.
     </Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageReleaseNotes>RootedTree&lt;T&gt;::ReplaceSubTree(Tree&lt;T&gt;) method added to support editing of trees.</PackageReleaseNotes>
+    <PackageReleaseNotes>Transactie uit de TableValuedTypeDefinitionScripts gehaald zodat deze kan worden aangeroepen in code met zijn eigen transactie.</PackageReleaseNotes>
     <PackageTags>ProgressOnderwijs</PackageTags>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/progressonderwijs/ProgressOnderwijsUtils</PackageProjectUrl>

--- a/test/ProgressOnderwijsUtilsTests/TableValuedParameterTest.cs
+++ b/test/ProgressOnderwijsUtilsTests/TableValuedParameterTest.cs
@@ -2,23 +2,20 @@
 using System.Data;
 using System.Data.Common;
 using System.Linq;
-using System.Net.Mime;
-using System.Security.Cryptography;
 using System.Text;
 using ExpressionToCodeLib;
-using Xunit;
 using ProgressOnderwijsUtils;
 using ProgressOnderwijsUtils.Internal;
+using Xunit;
 using static ProgressOnderwijsUtils.SafeSql;
 
 namespace ProgressOnderwijsUtilsTests
 {
-    
     public class TableValuedParameterTest : TransactedLocalConnection
     {
         public enum SomeEnum
         { }
-        
+
         [Fact]
         public void DatabaseCanProcessTableValuedParameters()
         {
@@ -38,7 +35,7 @@ namespace ProgressOnderwijsUtilsTests
         [Fact]
         public void ParameterizedSqlCanIncludeEnumTvps()
         {
-            var q = SQL($@"select sum(x.querytablevalue) from {Enumerable.Range(1, 100).Select(i =>(SomeEnum) i)} x");
+            var q = SQL($@"select sum(x.querytablevalue) from {Enumerable.Range(1, 100).Select(i => (SomeEnum)i)} x");
             var sum = (int)q.ReadScalar<SomeEnum>(Context);
             PAssert.That(() => sum == (100 * 100 + 100) / 2);
         }
@@ -46,7 +43,7 @@ namespace ProgressOnderwijsUtilsTests
         [Fact]
         public void ParameterizedSqlTvpsCanCountDaysOfWeek()
         {
-            var q = SQL($@"select count(x.querytablevalue) from {new[]{DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Friday }} x");
+            var q = SQL($@"select count(x.querytablevalue) from {new[] { DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Friday }} x");
             var dayCount = q.ReadScalar<int>(Context);
             PAssert.That(() => dayCount == 5);
         }
@@ -79,7 +76,7 @@ namespace ProgressOnderwijsUtilsTests
         {
             PAssert.That(() => SQL($@"
                 select sum(datalength(hashes.QueryTableValue))
-                from {new[] {Encoding.ASCII.GetBytes( "0123456789"), Encoding.ASCII.GetBytes("abcdef") }} hashes
+                from {new[] { Encoding.ASCII.GetBytes("0123456789"), Encoding.ASCII.GetBytes("abcdef") }} hashes
             ").ReadPlain<long>(Context).Single() == 16);
         }
 

--- a/test/ProgressOnderwijsUtilsTests/TransactedLocalConnection.cs
+++ b/test/ProgressOnderwijsUtilsTests/TransactedLocalConnection.cs
@@ -14,15 +14,10 @@ namespace ProgressOnderwijsUtilsTests
         public TransactedLocalConnection()
         {
             Transaction = new CommittableTransaction();
-            Context = new SqlCommandCreationContext(new SqlConnection(Environment.GetEnvironmentVariable("CONNECTION_STRING") ?? @"Server = (localdb)\MSSQLLocalDB; Integrated Security = true"), 60, SqlCommandTracer.CreateAlwaysOffTracer());
+            Context = new SqlCommandCreationContext(new SqlConnection(Environment.GetEnvironmentVariable("CONNECTION_STRING") ?? @"Server = localhost; Integrated Security = true"), 60, SqlCommandTracer.CreateAlwaysOffTracer());
             try {
                 Context.Connection.Open();
-                SQL($@"
-                    set transaction isolation level serializable;
-                    begin tran
-                    {ParameterizedSql.TableValuedTypeDefinitionScripts}
-                    commit
-                ").ExecuteNonQuery(Context);
+                ParameterizedSql.TableValuedTypeDefinitionScripts.ExecuteNonQuery(Context);
                 Context.Connection.EnlistTransaction(Transaction);
             } catch {
                 Dispose();

--- a/test/ProgressOnderwijsUtilsTests/TransactedLocalConnection.cs
+++ b/test/ProgressOnderwijsUtilsTests/TransactedLocalConnection.cs
@@ -2,7 +2,6 @@
 using System.Data.SqlClient;
 using System.Transactions;
 using ProgressOnderwijsUtils;
-using static ProgressOnderwijsUtils.SafeSql;
 
 namespace ProgressOnderwijsUtilsTests
 {
@@ -14,7 +13,7 @@ namespace ProgressOnderwijsUtilsTests
         public TransactedLocalConnection()
         {
             Transaction = new CommittableTransaction();
-            Context = new SqlCommandCreationContext(new SqlConnection(Environment.GetEnvironmentVariable("CONNECTION_STRING") ?? @"Server = localhost; Integrated Security = true"), 60, SqlCommandTracer.CreateAlwaysOffTracer());
+            Context = new SqlCommandCreationContext(new SqlConnection(Environment.GetEnvironmentVariable("CONNECTION_STRING") ?? @"Server = (localdb)\MSSQLLocalDB; Integrated Security = true"), 60, SqlCommandTracer.CreateAlwaysOffTracer());
             try {
                 Context.Connection.Open();
                 ParameterizedSql.TableValuedTypeDefinitionScripts.ExecuteNonQuery(Context);


### PR DESCRIPTION
Zodat we de scripts ook kunnen draaien straks in de SqlMigrator die zijn eigen transactie heeft.