### PR TITLE
Add nullability annotations

### DIFF
--- a/ProgressOnderwijsUtils.sln.DotSettings
+++ b/ProgressOnderwijsUtils.sln.DotSettings
@@ -1,4 +1,14 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AnnotateCanBeNullParameter/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AnnotateCanBeNullTypeMember/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AnnotateNotNullParameter/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AnnotateNotNullTypeMember/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertNullableToShortForm/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=JoinNullCheckWithUsage/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=JoinNullCheckWithUsageWhenPossible/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ReplaceWithStringIsNullOrEmpty/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseNullPropagationWhenPossible/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UsePatternMatching/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/JsInspections/LanguageLevel/@EntryValue">ECMAScript 2016</s:String>
 	<s:String x:Key="/Default/CodeInspection/TypeScriptInspections/Level/@EntryValue">TypeScript20</s:String>
 	<s:String x:Key="/Default/CodeEditing/GenerateMemberBody/AccessorImplementationKind/@EntryValue">Default</s:String>
@@ -28,7 +38,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AssignNullToNotNullAttribute/@EntryIndexedValue">SUGGESTION</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=BuiltInTypeReferenceStyle/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CanBeReplacedWithTryCastAndCheckForNull/@EntryIndexedValue">HINT</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CompareNonConstrainedGenericWithNull/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CompareNonConstrainedGenericWithNull/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertIfStatementToSwitchStatement/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertToConstant_002ELocal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CoVariantArrayConversion/@EntryIndexedValue">HINT</s:String>
@@ -43,7 +53,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ParameterTypeCanBeEnumerable_002ELocal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PossibleInvalidOperationException/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PossibleMultipleEnumeration/@EntryIndexedValue">HINT</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PossibleNullReferenceException/@EntryIndexedValue">HINT</s:String>
+	
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantArgumentNameForLiteralExpression/@EntryIndexedValue">SUGGESTION</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantCommaInArrayInitializer/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantCommaInInitializer/@EntryIndexedValue">DO_NOT_SHOW</s:String>

--- a/ProgressOnderwijsUtils.sln.DotSettings
+++ b/ProgressOnderwijsUtils.sln.DotSettings
@@ -3,10 +3,13 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AnnotateCanBeNullTypeMember/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AnnotateNotNullParameter/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AnnotateNotNullTypeMember/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CollectionNeverQueried_002EGlobal/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CollectionNeverUpdated_002EGlobal/@EntryIndexedValue">SUGGESTION</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertNullableToShortForm/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=JoinNullCheckWithUsage/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=JoinNullCheckWithUsageWhenPossible/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ReplaceWithStringIsNullOrEmpty/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedAutoPropertyAccessor_002EGlobal/@EntryIndexedValue">SUGGESTION</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseNullPropagationWhenPossible/@EntryIndexedValue">SUGGESTION</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UsePatternMatching/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/JsInspections/LanguageLevel/@EntryValue">ECMAScript 2016</s:String>
@@ -73,7 +76,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuggestVarOrType_005FElsewhere/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuggestVarOrType_005FSimpleTypes/@EntryIndexedValue">SUGGESTION</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedAutoPropertyAccessor_002ELocal/@EntryIndexedValue">ERROR</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedMember_002EGlobal/@EntryIndexedValue">WARNING</s:String>
+	
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedMember_002ELocal/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=PNet_0020Cleanup/@EntryIndexedValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;Profile name="PNet Cleanup"&gt;&lt;CSCodeStyleAttributes ArrangeTypeAccessModifier="True" ArrangeTypeMemberAccessModifier="True" SortModifiers="True" RemoveRedundantParentheses="True" AddMissingParentheses="False" ArrangeBraces="True" ArrangeAttributes="True" ArrangeArgumentsStyle="True" /&gt;&lt;CSEnforceVarKeywordUsageSettings&gt;True&lt;/CSEnforceVarKeywordUsageSettings&gt;&lt;CSOptimizeUsings&gt;&lt;OptimizeUsings&gt;True&lt;/OptimizeUsings&gt;&lt;EmbraceInRegion&gt;False&lt;/EmbraceInRegion&gt;&lt;RegionName&gt;&lt;/RegionName&gt;&lt;/CSOptimizeUsings&gt;&lt;CSReformatCode&gt;True&lt;/CSReformatCode&gt;&lt;AspOptimizeRegisterDirectives&gt;True&lt;/AspOptimizeRegisterDirectives&gt;&lt;HtmlReformatCode&gt;True&lt;/HtmlReformatCode&gt;&lt;FormatAttributeQuoteDescriptor&gt;True&lt;/FormatAttributeQuoteDescriptor&gt;&lt;CSArrangeQualifiers&gt;True&lt;/CSArrangeQualifiers&gt;&lt;CSFixBuiltinTypeReferences&gt;True&lt;/CSFixBuiltinTypeReferences&gt;&lt;/Profile&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=Var_0020Cleanup/@EntryIndexedValue"></s:String>

--- a/src/ProgressOnderwijsUtils/ArrayView.cs
+++ b/src/ProgressOnderwijsUtils/ArrayView.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -76,16 +77,19 @@ namespace ProgressOnderwijsUtils
 
     public static class CollectionViewExtensions
     {
+        [NotNull]
         public static IReadOnlyList<TOut> SelectIndexable<T, TOut>(this IReadOnlyList<T> vals, Func<T, TOut> map)
         {
             return new ArrayView_MappedByElement<T, TOut>(vals, map);
         }
 
+        [NotNull]
         public static IReadOnlyList<TOut> SelectIndexable<T, TOut>(this IReadOnlyList<T> vals, Func<T, int, TOut> map)
         {
             return new ArrayView_MappedWithIndex<T, TOut>(vals, map);
         }
 
+        [NotNull]
         public static IReadOnlyCollection<TOut> SelectCountable<T, TOut>(this ICollection<T> vals, Func<T, TOut> map)
         {
             return new CollectionView_Mapped<T, TOut>(vals, map);

--- a/src/ProgressOnderwijsUtils/BenchTimer.cs
+++ b/src/ProgressOnderwijsUtils/BenchTimer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -21,7 +22,7 @@ namespace ProgressOnderwijsUtils
             return bestTime;
         }
 
-        public static TimeSpan Time(Action a)
+        public static TimeSpan Time([NotNull] Action a)
         {
             var timer = Stopwatch.StartNew();
             a();

--- a/src/ProgressOnderwijsUtils/Collections/ArrayComparer.cs
+++ b/src/ProgressOnderwijsUtils/Collections/ArrayComparer.cs
@@ -35,7 +35,7 @@ namespace ProgressOnderwijsUtils.Collections
         }
 
         [Pure]
-        public int GetHashCode(T[] arr)
+        public int GetHashCode([CanBeNull] T[] arr)
         {
             ulong buffer;
             if (arr != null) {

--- a/src/ProgressOnderwijsUtils/Collections/Maybe.cs
+++ b/src/ProgressOnderwijsUtils/Collections/Maybe.cs
@@ -76,24 +76,28 @@ namespace ProgressOnderwijsUtils.Collections
         /// <summary>
         /// Creates a succesful Maybe that stores the provided value.
         /// </summary>
+        [NotNull]
         [Pure]
         public static Maybe_Ok<T> Ok<T>(T val) => new Maybe_Ok<T>(val);
 
         /// <summary>
         /// Creates a succesful Maybe value without a value.
         /// </summary>
+        [NotNull]
         [Pure]
         public static Maybe_Ok<Unit> Ok() => new Maybe_Ok<Unit>(Unit.Value);
 
         /// <summary>
         /// Create a failed maybe with an error state describing a failed operation.
         /// </summary>
+        [NotNull]
         [Pure]
         public static Maybe_Error<TError> Error<TError>(TError error) => new Maybe_Error<TError>(error);
 
         /// <summary>
         /// Create a failed maybe without any additional information about the error.
         /// </summary>
+        [NotNull]
         [Pure]
         public static Maybe_Error<Unit> Error() => new Maybe_Error<Unit>(Unit.Value);
 
@@ -107,7 +111,7 @@ namespace ProgressOnderwijsUtils.Collections
         /// Converts a error to a Maybe&lt;Unit, TError&gt;.  A null translatable represents success, any other value the error message to display.
         /// </summary>
         [Pure]
-        public static Maybe<Unit, TError> ErrorWhenNotNull<TError>(TError val)
+        public static Maybe<Unit, TError> ErrorWhenNotNull<TError>([CanBeNull] TError val)
             where TError : class
             => Either(val == null, Unit.Value, val);
 

--- a/src/ProgressOnderwijsUtils/Collections/MaybeExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Collections/MaybeExtensions.cs
@@ -283,7 +283,7 @@ namespace ProgressOnderwijsUtils.Collections
         }
 
         [Pure]
-        public static Maybe<TOk[], TError[]> WhenAllOk<TOk, TError>(this IEnumerable<Maybe<TOk, TError>> maybes)
+        public static Maybe<TOk[], TError[]> WhenAllOk<TOk, TError>([NotNull] this IEnumerable<Maybe<TOk, TError>> maybes)
         {
             var okValues = new List<TOk>();
             var errValues = new List<TError>();

--- a/src/ProgressOnderwijsUtils/Collections/RootedTree.cs
+++ b/src/ProgressOnderwijsUtils/Collections/RootedTree.cs
@@ -8,6 +8,7 @@ namespace ProgressOnderwijsUtils.Collections
     public struct RootedTree<T> : IEquatable<RootedTree<T>>, IRecursiveStructure<RootedTree<T>>
     {
         public static RootedTree<T> RootTree(Tree<T> rootNode) => new RootedTree<T>(SList.SingleElement(new TreePathSegment(0, rootNode)));
+        [NotNull]
         public IEnumerable<RootedTree<T>> PathSelfToRoot() => PathSegments.NonEmptySuffixes.Select(path => new RootedTree<T>(path));
         public int IndexInParent() => PathSegments.Head.Index;
         public Tree<T> UnrootedSubTree() => PathSegments.Head.ThisSubTree;
@@ -75,8 +76,9 @@ namespace ProgressOnderwijsUtils.Collections
             }
         }
 
+        [NotNull]
         [Pure]
-        static Tree<T>[] CopyArrayWithNewValueOnIndex(IReadOnlyList<Tree<T>> oldArray, int index, Tree<T> newValue)
+        static Tree<T>[] CopyArrayWithNewValueOnIndex([NotNull] IReadOnlyList<Tree<T>> oldArray, int index, Tree<T> newValue)
         {
             var copy = oldArray.ToArray();
             copy[index] = newValue;

--- a/src/ProgressOnderwijsUtils/Collections/RootedTree.cs
+++ b/src/ProgressOnderwijsUtils/Collections/RootedTree.cs
@@ -11,9 +11,9 @@ namespace ProgressOnderwijsUtils.Collections
         [NotNull]
         public IEnumerable<RootedTree<T>> PathSelfToRoot() => PathSegments.NonEmptySuffixes.Select(path => new RootedTree<T>(path));
         public int IndexInParent() => PathSegments.Head.Index;
+        [NotNull]
         public Tree<T> UnrootedSubTree() => PathSegments.Head.ThisSubTree;
 
-        [NotNull]
         public IReadOnlyList<RootedTree<T>> Children
         {
             get {
@@ -56,7 +56,7 @@ namespace ProgressOnderwijsUtils.Collections
             [NotNull]
             public readonly Tree<T> ThisSubTree;
 
-            public TreePathSegment(int index, Tree<T> node)
+            public TreePathSegment(int index, [NotNull] Tree<T> node)
             {
                 Index = index;
                 ThisSubTree = node;
@@ -64,7 +64,7 @@ namespace ProgressOnderwijsUtils.Collections
         }
 
         [Pure]
-        public RootedTree<T> ReplaceSubTree(Tree<T> newSubTree)
+        public RootedTree<T> ReplaceSubTree([NotNull] Tree<T> newSubTree)
         {
             if (IsRoot) {
                 return newSubTree.RootHere();

--- a/src/ProgressOnderwijsUtils/Collections/RootedTree.cs
+++ b/src/ProgressOnderwijsUtils/Collections/RootedTree.cs
@@ -7,7 +7,7 @@ namespace ProgressOnderwijsUtils.Collections
 {
     public struct RootedTree<T> : IEquatable<RootedTree<T>>, IRecursiveStructure<RootedTree<T>>
     {
-        public static RootedTree<T> RootTree(Tree<T> rootNode) => new RootedTree<T>(SList.SingleElement(new TreePathSegment(0, rootNode)));
+        public static RootedTree<T> RootTree([NotNull] Tree<T> rootNode) => new RootedTree<T>(SList.SingleElement(new TreePathSegment(0, rootNode)));
         [NotNull]
         public IEnumerable<RootedTree<T>> PathSelfToRoot() => PathSegments.NonEmptySuffixes.Select(path => new RootedTree<T>(path));
         public int IndexInParent() => PathSegments.Head.Index;
@@ -53,6 +53,7 @@ namespace ProgressOnderwijsUtils.Collections
         struct TreePathSegment
         {
             public readonly int Index;
+            [NotNull]
             public readonly Tree<T> ThisSubTree;
 
             public TreePathSegment(int index, Tree<T> node)

--- a/src/ProgressOnderwijsUtils/Collections/RootedTree.cs
+++ b/src/ProgressOnderwijsUtils/Collections/RootedTree.cs
@@ -13,6 +13,7 @@ namespace ProgressOnderwijsUtils.Collections
         public int IndexInParent() => PathSegments.Head.Index;
         public Tree<T> UnrootedSubTree() => PathSegments.Head.ThisSubTree;
 
+        [NotNull]
         public IReadOnlyList<RootedTree<T>> Children
         {
             get {

--- a/src/ProgressOnderwijsUtils/Collections/SList.cs
+++ b/src/ProgressOnderwijsUtils/Collections/SList.cs
@@ -120,7 +120,7 @@ namespace ProgressOnderwijsUtils.Collections
         }
 
         [Pure]
-        public static SList<T> PrependReversed<T>(this SList<T> self, IEnumerable<T> items)
+        public static SList<T> PrependReversed<T>(this SList<T> self, [NotNull] IEnumerable<T> items)
         {
             var retval = self;
             foreach (var item in items) {
@@ -179,7 +179,7 @@ namespace ProgressOnderwijsUtils.Collections
         }
 
         [Pure]
-        public static SList<T> Create<T>(IEnumerable<T> list)
+        public static SList<T> Create<T>([NotNull] IEnumerable<T> list)
         {
             if (list is IList<T>) {
                 return Create((IList<T>)list); //use IList interface for reverse iterability
@@ -189,7 +189,7 @@ namespace ProgressOnderwijsUtils.Collections
         }
 
         [Pure]
-        public static SList<T> Create<T>(IList<T> list)
+        public static SList<T> Create<T>([NotNull] IList<T> list)
         {
             if (list is T[]) {
                 return Create((T[])list);
@@ -202,7 +202,7 @@ namespace ProgressOnderwijsUtils.Collections
         }
 
         [Pure]
-        public static SList<T> Create<T>(T[] list)
+        public static SList<T> Create<T>([NotNull] T[] list)
         {
             var retval = default(SList<T>);
             for (var i = list.Length - 1; i >= 0; i--) {

--- a/src/ProgressOnderwijsUtils/Collections/Tree.cs
+++ b/src/ProgressOnderwijsUtils/Collections/Tree.cs
@@ -13,24 +13,30 @@ namespace ProgressOnderwijsUtils.Collections
 
     public static class Tree
     {
+        [NotNull]
         [Pure]
         public static Tree<T> Node<T>(T value, IEnumerable<Tree<T>> children) => new Tree<T>(value, children);
 
+        [NotNull]
         [Pure]
         public static Tree<T> Node<T>(T value, Tree<T> a) => new Tree<T>(value, new[] { a, });
 
+        [NotNull]
         [Pure]
         public static Tree<T> Node<T>(T value, Tree<T> a, Tree<T> b) => new Tree<T>(value, new[] { a, b });
 
+        [NotNull]
         [Pure]
         [CodeThatsOnlyUsedForTests]
         public static Tree<T> Node<T>(T value, Tree<T> a, Tree<T> b, Tree<T> c) => new Tree<T>(value, new[] { a, b, c });
 
         // ReSharper disable MethodOverloadWithOptionalParameter
+        [NotNull]
         [Pure]
         public static Tree<T> Node<T>(T value, params Tree<T>[] kids) => new Tree<T>(value, kids);
 
         // ReSharper restore MethodOverloadWithOptionalParameter
+        [NotNull]
         [Pure]
         public static Tree<T> Node<T>(T value) => new Tree<T>(value, null);
 
@@ -40,6 +46,7 @@ namespace ProgressOnderwijsUtils.Collections
         [Pure]
         public static Tree<T> BuildRecursively<T>(T root, IReadOnlyDictionary<T, IReadOnlyList<T>> kidLookup) => BuildRecursively(root, id => kidLookup.GetOrDefaultR(id));
 
+        [NotNull]
         [Pure]
         [CodeThatsOnlyUsedForTests]
         public static IEqualityComparer<Tree<T>> EqualityComparer<T>(IEqualityComparer<T> valueComparer) => new Tree<T>.Comparer(valueComparer);
@@ -87,7 +94,7 @@ namespace ProgressOnderwijsUtils.Collections
         /// </summary>
         /// <param name="value">The value of this node.</param>
         /// <param name="children">The children of this node, (null is allowed and means none).</param>
-        public Tree(T value, IEnumerable<Tree<T>> children)
+        public Tree(T value, [CanBeNull] IEnumerable<Tree<T>> children)
             : this(value, children == null ? null : children.ToArray()) { }
 
         /// <summary>
@@ -96,7 +103,7 @@ namespace ProgressOnderwijsUtils.Collections
         /// </summary>
         /// <param name="value">The value of this node.</param>
         /// <param name="children">The children of this node, (null is allowed and means none).</param>
-        public Tree(T value, Tree<T>[] children)
+        public Tree(T value, [CanBeNull] Tree<T>[] children)
         {
             nodeValue = value;
             kidArray = children ?? Array.Empty<Tree<T>>();
@@ -177,8 +184,9 @@ namespace ProgressOnderwijsUtils.Collections
         [Pure]
         public override string ToString() => "TREE:\n" + ToString("");
 
+        [NotNull]
         [Pure]
-        string ToString(string indent)
+        string ToString([NotNull] string indent)
         {
             if (indent.Length > 80) {
                 return "<<TOO DEEP>>";

--- a/src/ProgressOnderwijsUtils/Collections/Tree.cs
+++ b/src/ProgressOnderwijsUtils/Collections/Tree.cs
@@ -163,7 +163,7 @@ namespace ProgressOnderwijsUtils.Collections
             }
 
             [Pure]
-            public int GetHashCode(Tree<T> obj)
+            public int GetHashCode([CanBeNull] Tree<T> obj)
             {
                 if (obj == null) {
                     return typeHash;

--- a/src/ProgressOnderwijsUtils/Collections/Tree.cs
+++ b/src/ProgressOnderwijsUtils/Collections/Tree.cs
@@ -8,6 +8,8 @@ namespace ProgressOnderwijsUtils.Collections
     public interface IRecursiveStructure<out TTree>
         where TTree : IRecursiveStructure<TTree>
     {
+        [ItemNotNull]
+        [NotNull]
         IReadOnlyList<TTree> Children { get; }
     }
 
@@ -85,7 +87,11 @@ namespace ProgressOnderwijsUtils.Collections
     public sealed class Tree<T> : IEquatable<Tree<T>>, IRecursiveStructure<Tree<T>>
     {
         readonly T nodeValue;
+
+        [ItemNotNull]
+        [NotNull]
         readonly Tree<T>[] kidArray;
+
         public T NodeValue => nodeValue;
         public IReadOnlyList<Tree<T>> Children => kidArray;
 

--- a/src/ProgressOnderwijsUtils/Collections/Unit.cs
+++ b/src/ProgressOnderwijsUtils/Collections/Unit.cs
@@ -1,4 +1,5 @@
 using System;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils.Collections
 {
@@ -9,7 +10,7 @@ namespace ProgressOnderwijsUtils.Collections
     {
         public static Unit Value => default(Unit);
 
-        public static Unit SideEffect(Action action)
+        public static Unit SideEffect([NotNull] Action action)
         {
             action();
             return Value;

--- a/src/ProgressOnderwijsUtils/Collections/UnitExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Collections/UnitExtensions.cs
@@ -1,15 +1,18 @@
 using System;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils.Collections
 {
     public static class UnitExtensions
     {
+        [NotNull]
         public static Func<Unit> ToUnitReturningFunc(this Action action)
             => () => {
                 action();
                 return Unit.Value;
             };
 
+        [NotNull]
         public static Func<T, Unit> ToUnitReturningFunc<T>(this Action<T> action)
             => x => {
                 action(x);

--- a/src/ProgressOnderwijsUtils/Data/CodeGenHelper.cs
+++ b/src/ProgressOnderwijsUtils/Data/CodeGenHelper.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Linq;
 using System.Text.RegularExpressions;
 using ExpressionToCodeLib;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -11,7 +12,8 @@ namespace ProgressOnderwijsUtils
     /// </summary>
     public static class CodeGenHelper
     {
-        public static string GetColumnProperty(ColumnDefinition col, Func<ColumnDefinition, string> colNameOverride = null)
+        [NotNull]
+        public static string GetColumnProperty([NotNull] ColumnDefinition col, [CanBeNull] Func<ColumnDefinition, string> colNameOverride = null)
         {
             Func<ColumnDefinition, string> friendlyTypeNameDefault = x => x.DataType.ToCSharpFriendlyTypeName();
             var friendlyTypeName = colNameOverride ?? friendlyTypeNameDefault;
@@ -20,13 +22,15 @@ namespace ProgressOnderwijsUtils
         }
 
         static readonly Regex newLine = new Regex("^(?!$)", RegexOptions.Multiline | RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture);
-        public static string Indent(string str, int indentCount = 1) => newLine.Replace(str, new string(' ', indentCount * 4));
+        [NotNull]
+        public static string Indent([NotNull] string str, int indentCount = 1) => newLine.Replace(str, new string(' ', indentCount * 4));
 
         /// <summary>
         ///     This method makes a "best effort" auto-generated metaobject class that can replace the current datatable.
         ///     It's not quite as accurate as GetMetaObjectClassDef on a QueryBuilder; use that in preference.
         /// </summary>
-        public static string DataTableToMetaObjectClassDef(this DataTable dt, string classNameOverride = null, Func<ColumnDefinition, string> colNameOverride = null)
+        [NotNull]
+        public static string DataTableToMetaObjectClassDef([NotNull] this DataTable dt, string classNameOverride = null, [CanBeNull] Func<ColumnDefinition, string> colNameOverride = null)
         {
             classNameOverride = classNameOverride ?? (string.IsNullOrEmpty(dt.TableName) ? "XYZ" : dt.TableName);
 

--- a/src/ProgressOnderwijsUtils/Data/ColumnSort.cs
+++ b/src/ProgressOnderwijsUtils/Data/ColumnSort.cs
@@ -16,6 +16,7 @@ namespace ProgressOnderwijsUtils
         readonly SortDirection direction;
         public string ColumnName => column;
         public SortDirection SortDirection => direction;
+        [NotNull]
         public string SqlSortString() => column + " " + direction;
         public override string ToString() => "[" + column + " " + direction + "]";
 

--- a/src/ProgressOnderwijsUtils/Data/CommandFactory.cs
+++ b/src/ProgressOnderwijsUtils/Data/CommandFactory.cs
@@ -95,6 +95,7 @@ namespace ProgressOnderwijsUtils
             return new ReusableCommand { Command = command, QueryTimer = timer };
         }
 
+        [NotNull]
         public string FinishBuilding_CommandTextOnly()
         {
             FreeParamsAndLookup();
@@ -146,7 +147,7 @@ namespace ProgressOnderwijsUtils
             }
         }
 
-        public void AppendSql(string sql, int startIndex, int length) => queryText.AppendText(sql, startIndex, length);
+        public void AppendSql([NotNull] string sql, int startIndex, int length) => queryText.AppendText(sql, startIndex, length);
     }
 
     /// <summary>
@@ -196,8 +197,9 @@ namespace ProgressOnderwijsUtils
     {
         FastShortStringBuilder debugText;
         public string RegisterParameterAndGetName<T>([NotNull] T o) where T : IQueryParameter => SqlCommandTracer.InsecureSqlDebugString(o.EquatableValue, true);
-        public void AppendSql(string sql, int startIndex, int length) => debugText.AppendText(sql, startIndex, length);
+        public void AppendSql([NotNull] string sql, int startIndex, int length) => debugText.AppendText(sql, startIndex, length);
 
+        [NotNull]
         public static string DebugTextFor([CanBeNull] ISqlComponent impl)
         {
             var factory = new DebugCommandFactory { debugText = FastShortStringBuilder.Create() };
@@ -212,13 +214,14 @@ namespace ProgressOnderwijsUtils
         int argOffset;
         FastArrayBuilder<object> paramValues;
 
+        [NotNull]
         public string RegisterParameterAndGetName<T>([NotNull] T o) where T : IQueryParameter
         {
             paramValues.Add(o.EquatableValue);
             return CommandFactory.IndexToParameterName(argOffset++);
         }
 
-        public void AppendSql(string sql, int startIndex, int length) => debugText.AppendText(sql, startIndex, length);
+        public void AppendSql([NotNull] string sql, int startIndex, int length) => debugText.AppendText(sql, startIndex, length);
 
         public static ParameterizedSqlEquatableKey EqualityKey([CanBeNull] ISqlComponent impl)
         {

--- a/src/ProgressOnderwijsUtils/Data/CommandFactory.cs
+++ b/src/ProgressOnderwijsUtils/Data/CommandFactory.cs
@@ -196,6 +196,7 @@ namespace ProgressOnderwijsUtils
     struct DebugCommandFactory : ICommandFactory
     {
         FastShortStringBuilder debugText;
+        [NotNull]
         public string RegisterParameterAndGetName<T>([NotNull] T o) where T : IQueryParameter => SqlCommandTracer.InsecureSqlDebugString(o.EquatableValue, true);
         public void AppendSql([NotNull] string sql, int startIndex, int length) => debugText.AppendText(sql, startIndex, length);
 

--- a/src/ProgressOnderwijsUtils/Data/CurrentTimeToken.cs
+++ b/src/ProgressOnderwijsUtils/Data/CurrentTimeToken.cs
@@ -1,4 +1,5 @@
 using System;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -7,7 +8,7 @@ namespace ProgressOnderwijsUtils
         CurrentTimeToken() { }
         public static readonly CurrentTimeToken Instance = new CurrentTimeToken();
 
-        public static CurrentTimeToken Parse(string s)
+        public static CurrentTimeToken Parse([NotNull] string s)
         {
             if (s != "") {
                 throw new ArgumentException("Can only parse empty string as current time token!");

--- a/src/ProgressOnderwijsUtils/Data/DBNullRemover.cs
+++ b/src/ProgressOnderwijsUtils/Data/DBNullRemover.cs
@@ -40,7 +40,8 @@ namespace ProgressOnderwijsUtils
         {
             public static readonly Func<object, T> Extractor = GetExtractor(typeof(T));
 
-            static Func<object, T> GetExtractor(Type type)
+            [NotNull]
+            static Func<object, T> GetExtractor([NotNull] Type type)
             {
                 if (!type.IsValueType) {
                     return obj => obj == DBNull.Value ? default(T) : (T)obj;
@@ -56,7 +57,7 @@ namespace ProgressOnderwijsUtils
 
         static readonly MethodInfo extractNullableValueTypeMethod = typeof(DBNullRemover).GetMethod(nameof(ExtractNullableValueType), BindingFlags.Static | BindingFlags.NonPublic);
 
-        static TStruct? ExtractNullableValueType<TStruct>(object obj)
+        static TStruct? ExtractNullableValueType<TStruct>([CanBeNull] object obj)
             where TStruct : struct
             => obj == DBNull.Value || obj == null ? default(TStruct?) : (TStruct)obj;
 
@@ -67,7 +68,7 @@ namespace ProgressOnderwijsUtils
             => genericCastMethod.MakeGenericMethod(type).Invoke(null, new[] { val });
 
         [Pure]
-        public static bool EqualsConvertingIntToEnum(object val1, object val2)
+        public static bool EqualsConvertingIntToEnum([CanBeNull] object val1, [CanBeNull] object val2)
         {
             if (val1 is Enum && val2 != null && !(val2 is Enum)) {
                 return Equals(val1, Enum.ToObject(val1.GetType(), val2));

--- a/src/ProgressOnderwijsUtils/Data/DbColumnDefinition.cs
+++ b/src/ProgressOnderwijsUtils/Data/DbColumnDefinition.cs
@@ -26,6 +26,7 @@ namespace ProgressOnderwijsUtils
         public static ColumnDefinition[] GetFromReader([NotNull] IDataRecord reader)
             => Enumerable.Range(0, reader.FieldCount).Select(fI => new ColumnDefinition(reader.GetFieldType(fI), reader.GetName(fI))).ToArray();
 
+        [NotNull]
         public static ColumnDefinition[] GetFromTable([NotNull] SqlConnection sqlconn, string tableName)
         {
             using (var cmd = sqlconn.CreateCommand()) {

--- a/src/ProgressOnderwijsUtils/Data/DbColumnDefinition.cs
+++ b/src/ProgressOnderwijsUtils/Data/DbColumnDefinition.cs
@@ -3,6 +3,7 @@ using System;
 using System.Data;
 using System.Data.SqlClient;
 using ExpressionToCodeLib;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -17,13 +18,15 @@ namespace ProgressOnderwijsUtils
         public Type DataType { get; }
         public string Name { get; }
 
-        public static ColumnDefinition Create(DataColumn col)
+        [NotNull]
+        public static ColumnDefinition Create([NotNull] DataColumn col)
             => new ColumnDefinition((col.AllowDBNull ? col.DataType.MakeNullableType() : null) ?? col.DataType, col.ColumnName);
 
-        public static ColumnDefinition[] GetFromReader(IDataRecord reader)
+        [NotNull]
+        public static ColumnDefinition[] GetFromReader([NotNull] IDataRecord reader)
             => Enumerable.Range(0, reader.FieldCount).Select(fI => new ColumnDefinition(reader.GetFieldType(fI), reader.GetName(fI))).ToArray();
 
-        public static ColumnDefinition[] GetFromTable(SqlConnection sqlconn, string tableName)
+        public static ColumnDefinition[] GetFromTable([NotNull] SqlConnection sqlconn, string tableName)
         {
             using (var cmd = sqlconn.CreateCommand()) {
                 cmd.CommandText = "SET FMTONLY ON; select * from " + tableName + "; SET FMTONLY OFF";

--- a/src/ProgressOnderwijsUtils/Data/DbDataReaderBase.cs
+++ b/src/ProgressOnderwijsUtils/Data/DbDataReaderBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Data;
 using System.Data.Common;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -36,6 +37,7 @@ namespace ProgressOnderwijsUtils
             throw new NotSupportedException();
         }
 
+        [NotNull]
         public override string GetDataTypeName(int ordinal) => GetFieldType(ordinal).ToString();
         bool hasRows, afterFirstRowPeek;
         protected abstract bool ReadImpl();

--- a/src/ProgressOnderwijsUtils/Data/DbDataReaderBase.cs
+++ b/src/ProgressOnderwijsUtils/Data/DbDataReaderBase.cs
@@ -38,7 +38,8 @@ namespace ProgressOnderwijsUtils
         }
 
         [NotNull]
-        public override string GetDataTypeName(int ordinal) => GetFieldType(ordinal).ToString();
+        public override string GetDataTypeName(int ordinal) => (GetFieldType(ordinal) ?? throw new Exception("column " + ordinal + " untyped")).ToString();
+
         bool hasRows, afterFirstRowPeek;
         protected abstract bool ReadImpl();
 

--- a/src/ProgressOnderwijsUtils/Data/FieldMapping.cs
+++ b/src/ProgressOnderwijsUtils/Data/FieldMapping.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System;
 using System.Data.SqlClient;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -22,6 +23,7 @@ namespace ProgressOnderwijsUtils
             DstIndex = dstIndex;
         }
 
+        [NotNull]
         public static FieldMapping[] VerifyAndCreate(
             IColumnDefinition[] srcFields,
             string srcSetDebugName,
@@ -70,7 +72,7 @@ namespace ProgressOnderwijsUtils
             return srcFieldsByName.Values.Select(srcCol => new FieldMapping(srcCol.Def, srcCol.Index, dstFieldsByName[srcCol.Def.Name].Index)).ToArray();
         }
 
-        public static void ApplyFieldMappingsToBulkCopy(FieldMapping[] mapping, SqlBulkCopy bulkCopy)
+        public static void ApplyFieldMappingsToBulkCopy([NotNull] FieldMapping[] mapping, [NotNull] SqlBulkCopy bulkCopy)
         {
             bulkCopy.ColumnMappings.Clear();
             foreach (var mapEntry in mapping) {

--- a/src/ProgressOnderwijsUtils/Data/MetaObjectDataReader.cs
+++ b/src/ProgressOnderwijsUtils/Data/MetaObjectDataReader.cs
@@ -4,6 +4,7 @@ using System;
 using System.Data;
 using System.Linq.Expressions;
 using ExpressionToCodeLib;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -24,7 +25,7 @@ namespace ProgressOnderwijsUtils
         readonly IReadOnlyList<T> objectsOrNull_ForDebugging;
         T current;
 
-        public MetaObjectDataReader(IEnumerable<T> objects)
+        public MetaObjectDataReader([NotNull] IEnumerable<T> objects)
         {
             metaObjects = objects.GetEnumerator();
             objectsOrNull_ForDebugging = objects as IReadOnlyList<T>;
@@ -52,6 +53,7 @@ namespace ProgressOnderwijsUtils
         public override string GetName(int ordinal) => columnInfos[ordinal].Name;
         public override int GetOrdinal(string name) => columnIndexByName[name];
         public override int GetInt32(int ordinal) => ((Func<T, int>)columnInfos[ordinal].TypedNonNullableGetter)(current);
+        [NotNull]
         public override object GetValue(int ordinal) => columnInfos[ordinal].GetUntypedColumnValue(current) ?? DBNull.Value;
 
         public override bool IsDBNull(int ordinal)
@@ -80,7 +82,7 @@ namespace ProgressOnderwijsUtils
             //TypedNonNullableGetter is of type Func<T, _> such that typeof(_) == ColumnType - therefore cannot return nulls!
             public readonly Delegate TypedNonNullableGetter;
 
-            public ColumnInfo(IReadonlyMetaProperty<T> mp)
+            public ColumnInfo([NotNull] IReadonlyMetaProperty<T> mp)
             {
                 var propertyType = mp.DataType;
                 var metaObjectParameter = Expression.Parameter(typeof(T));
@@ -131,6 +133,7 @@ namespace ProgressOnderwijsUtils
             columnInfos = columnInfosBuilder.ToArray();
         }
 
+        [NotNull]
         static DataTable CreateEmptySchemaTable()
         {
             var dt = new DataTable();
@@ -157,6 +160,7 @@ namespace ProgressOnderwijsUtils
             return dt;
         }
 
+        [CanBeNull]
         IReadOnlyList<object> IOptionalObjectListForDebugging.ContentsForDebuggingOrNull() => objectsOrNull_ForDebugging?.SelectIndexable(o => (o as IOptionalObjectProjectionForDebugging)?.ProjectionForDebuggingOrNull() ?? o);
     }
 }

--- a/src/ProgressOnderwijsUtils/Data/MetaObjectDataReader.cs
+++ b/src/ProgressOnderwijsUtils/Data/MetaObjectDataReader.cs
@@ -49,6 +49,7 @@ namespace ProgressOnderwijsUtils
 
         public override DataTable GetSchemaTable() => schemaTable;
         public override int FieldCount => columnInfos.Length;
+        [NotNull]
         public override Type GetFieldType(int ordinal) => columnInfos[ordinal].ColumnType;
         public override string GetName(int ordinal) => columnInfos[ordinal].Name;
         public override int GetOrdinal(string name) => columnIndexByName[name];
@@ -75,6 +76,7 @@ namespace ProgressOnderwijsUtils
         {
             public readonly string Name;
             //ColumnType is non nullable with enum types replaced by their underlying type
+            [NotNull]
             public readonly Type ColumnType;
             public readonly Func<T, object> GetUntypedColumnValue;
             //WhenNullable_IsColumnDBNull is itself null if column non-nullable

--- a/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
+++ b/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
@@ -36,7 +36,7 @@ namespace ProgressOnderwijsUtils
         ColumnSort[] DirectAcessColumns => sortColumns ?? EmptyOrder;
         public static OrderByColumns Empty => default(OrderByColumns);
 
-        public OrderByColumns(IEnumerable<ColumnSort> order)
+        public OrderByColumns([NotNull] IEnumerable<ColumnSort> order)
         {
             var columns = new ColumnSort[4];
             var idx = 0;
@@ -96,7 +96,8 @@ namespace ProgressOnderwijsUtils
                 : new OrderByColumns(DirectAcessColumns.Prepend(new ColumnSort(kolomnaam, SortDirection.Desc)).ToArray());
         }
 
-        static IEnumerable<ColumnSort> PrependFiltered(ColumnSort head, IEnumerable<ColumnSort> tail)
+        [NotNull]
+        static IEnumerable<ColumnSort> PrependFiltered(ColumnSort head, [NotNull] IEnumerable<ColumnSort> tail)
         {
             return new[] { head }.Concat(tail.Where(sc => sc.ColumnName != head.ColumnName));
         }

--- a/src/ProgressOnderwijsUtils/Data/ParameterValuesForDebuggingExtension.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterValuesForDebuggingExtension.cs
@@ -5,6 +5,7 @@ namespace ProgressOnderwijsUtils
 {
     public static class ParameterValuesForDebuggingExtension
     {
+        [NotNull]
         [Pure]
         public static object[] ParameterValuesForDebugging(this ParameterizedSql sql)
         {
@@ -17,7 +18,8 @@ namespace ProgressOnderwijsUtils
         {
             public List<object> arguments;
 
-            public string RegisterParameterAndGetName<T>(T o) where T : IQueryParameter
+            [NotNull]
+            public string RegisterParameterAndGetName<T>([NotNull] T o) where T : IQueryParameter
             {
                 arguments.Add(o.EquatableValue);
                 return "";

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSql.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSql.cs
@@ -63,8 +63,10 @@ namespace ProgressOnderwijsUtils
 
         //ToString is constructed to be invalid sql, so that accidental string-concat doesn't result in something that looks reasonable to execute.
         public override string ToString() => "*/Pseudo-sql (with parameter values inlined!):/*\r\n" + DebugText();
+        [NotNull]
         public string DebugText() => DebugCommandFactory.DebugTextFor(impl);
 
+        [NotNull]
         [Pure]
         public string CommandText()
         {

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSql.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSql.cs
@@ -19,7 +19,7 @@ namespace ProgressOnderwijsUtils
             where TCommandFactory : struct, ICommandFactory
             => impl?.AppendTo(ref factory);
 
-        public ReusableCommand CreateSqlCommand(SqlCommandCreationContext conn)
+        public ReusableCommand CreateSqlCommand([NotNull] SqlCommandCreationContext conn)
         {
             var factory = CommandFactory.Create();
             impl?.AppendTo(ref factory);
@@ -76,7 +76,7 @@ namespace ProgressOnderwijsUtils
         public static ParameterizedSql Param(object paramVal) => new SingleParameterSqlFragment(paramVal).BuildableToQuery();
 
         [Pure]
-        public static ParameterizedSql TableParamDynamic(Array o) => SqlParameterComponent.ToTableValuedParameterFromPlainValues(o).BuildableToQuery();
+        public static ParameterizedSql TableParamDynamic([NotNull] Array o) => SqlParameterComponent.ToTableValuedParameterFromPlainValues(o).BuildableToQuery();
 
         /// <summary>
         /// Adds a parameter to the query with a table-value.  Parameters must be an enumerable of meta-object type.
@@ -138,7 +138,7 @@ namespace ProgressOnderwijsUtils
     public static class SafeSql
     {
         [Pure]
-        public static ParameterizedSql SQL(FormattableString interpolatedQuery) => ParameterizedSqlFactory.InterpolationToQuery(interpolatedQuery);
+        public static ParameterizedSql SQL([NotNull] FormattableString interpolatedQuery) => ParameterizedSqlFactory.InterpolationToQuery(interpolatedQuery);
     }
 
     static class ParameterizedSqlFactory

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSql.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSql.cs
@@ -32,7 +32,7 @@ namespace ProgressOnderwijsUtils
         public static ParameterizedSql operator +(ParameterizedSql a, ParameterizedSql b)
             => (a.impl == null || b.impl == null ? (a.impl ?? b.impl) : new TwoSqlFragments(a.impl, b.impl)).BuildableToQuery();
 
-        public static ParameterizedSql CreateDynamic(string rawSqlString)
+        public static ParameterizedSql CreateDynamic([NotNull] string rawSqlString)
         {
             if (rawSqlString == null) {
                 throw new ArgumentNullException(nameof(rawSqlString));
@@ -145,11 +145,11 @@ namespace ProgressOnderwijsUtils
     {
         public static ParameterizedSql BuildableToQuery(this ISqlComponent q) => new ParameterizedSql(q);
 
-        public static ParameterizedSql InterpolationToQuery(FormattableString interpolatedQuery) =>
+        public static ParameterizedSql InterpolationToQuery([NotNull] FormattableString interpolatedQuery) =>
             interpolatedQuery.Format == "" ? ParameterizedSql.Empty :
                 new InterpolatedSqlFragment(interpolatedQuery).BuildableToQuery();
 
-        public static void AppendSql<TCommandFactory>(ref TCommandFactory factory, string sql)
+        public static void AppendSql<TCommandFactory>(ref TCommandFactory factory, [NotNull] string sql)
             where TCommandFactory : struct, ICommandFactory
             => factory.AppendSql(sql, 0, sql.Length);
     }
@@ -215,10 +215,10 @@ namespace ProgressOnderwijsUtils
         static readonly ConcurrentDictionary<string, ParamRefSubString[]> parsedFormatStrings
             = new ConcurrentDictionary<string, ParamRefSubString[]>(new ReferenceEqualityComparer<string>());
 
-        static ParamRefSubString[] GetFormatStringParamRefs(string formatstring) => parsedFormatStrings.GetOrAdd(formatstring, ParseFormatString_Delegate);
+        static ParamRefSubString[] GetFormatStringParamRefs([NotNull] string formatstring) => parsedFormatStrings.GetOrAdd(formatstring, ParseFormatString_Delegate);
         static readonly Func<string, ParamRefSubString[]> ParseFormatString_Delegate = ParseFormatString;
 
-        static ParamRefSubString[] ParseFormatString(string formatstring)
+        static ParamRefSubString[] ParseFormatString([NotNull] string formatstring)
         {
             var arrayBuilder = FastArrayBuilder<ParamRefSubString>.Create();
             var pos = 0;

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlExecutionException.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlExecutionException.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.Serialization;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -14,7 +15,7 @@ namespace ProgressOnderwijsUtils
         public ParameterizedSqlExecutionException(string msg, Exception inner)
             : base(msg, inner) { }
 
-        protected ParameterizedSqlExecutionException(SerializationInfo serializationinfo, StreamingContext streamingcontext)
+        protected ParameterizedSqlExecutionException([NotNull] SerializationInfo serializationinfo, StreamingContext streamingcontext)
             : base(serializationinfo, streamingcontext) { }
     }
 }

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlExtensions.cs
@@ -30,7 +30,7 @@ namespace ProgressOnderwijsUtils
         /// Concatenate a sequence of sql expressions with a space separator.
         /// e.g.  concatenating 'a' and 'b' results in 'a b'
         /// </summary>
-        public static ParameterizedSql ConcatenateSql(this IEnumerable<ParameterizedSql> sqlExpressions) => ConcatenateSql(sqlExpressions, ParameterizedSql.Empty);
+        public static ParameterizedSql ConcatenateSql([NotNull] this IEnumerable<ParameterizedSql> sqlExpressions) => ConcatenateSql(sqlExpressions, ParameterizedSql.Empty);
 
         /// <summary>
         /// Concatenate a sequence of sql expressions with a separator (surrounded by space).  A sequence of N items includes the separator N-1 times.

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlExtensions.cs
@@ -36,6 +36,6 @@ namespace ProgressOnderwijsUtils
         /// Concatenate a sequence of sql expressions with a separator (surrounded by space).  A sequence of N items includes the separator N-1 times.
         /// e.g.  concatenating 'a' and 'b' with separator 'X' results in 'a X b'
         /// </summary>
-        public static ParameterizedSql ConcatenateSql(this IEnumerable<ParameterizedSql> sqlExpressions, ParameterizedSql separator) => sqlExpressions.Aggregate((a, b) => a.Append(separator).Append(b));
+        public static ParameterizedSql ConcatenateSql([NotNull] this IEnumerable<ParameterizedSql> sqlExpressions, ParameterizedSql separator) => sqlExpressions.Aggregate((a, b) => a.Append(separator).Append(b));
     }
 }

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -20,7 +20,7 @@ namespace ProgressOnderwijsUtils
     public static class ParameterizedSqlObjectMapper
     {
         [MustUseReturnValue]
-        public static T ExecuteQuery<T>(ParameterizedSql sql, SqlCommandCreationContext commandCreationContext, Func<string> exceptionMessage, Func<SqlCommand, T> action)
+        public static T ExecuteQuery<T>(ParameterizedSql sql, SqlCommandCreationContext commandCreationContext, Func<string> exceptionMessage, [NotNull] Func<SqlCommand, T> action)
         {
             using (var cmd = sql.CreateSqlCommand(commandCreationContext))
                 try {
@@ -123,7 +123,7 @@ namespace ProgressOnderwijsUtils
 
         [MustUseReturnValue]
         [NotNull]
-        public static T[] ReadMetaObjectsUnpacker<T>(SqlCommand cmd, FieldMappingMode fieldMappingMode = FieldMappingMode.RequireExactColumnMatches)
+        public static T[] ReadMetaObjectsUnpacker<T>([NotNull] SqlCommand cmd, FieldMappingMode fieldMappingMode = FieldMappingMode.RequireExactColumnMatches)
             where T : IMetaObject, new()
         {
             using (var reader = cmd.ExecuteReader(CommandBehavior.SequentialAccess)) {
@@ -137,7 +137,8 @@ namespace ProgressOnderwijsUtils
             }
         }
 
-        static string ColumnUnpackingErrorMessage<T>(SqlDataReader reader, int lastColumnRead) where T : IMetaObject, new()
+        [NotNull]
+        static string ColumnUnpackingErrorMessage<T>([NotNull] SqlDataReader reader, int lastColumnRead) where T : IMetaObject, new()
         {
             var mps = MetaObject.GetMetaProperties<T>();
             var metaObjectTypeName = typeof(T).ToCSharpFriendlyTypeName();
@@ -153,7 +154,8 @@ namespace ProgressOnderwijsUtils
                 + " of type " + actualCsTypeName;
         }
 
-        static string QueryExecutionErrorMessage<T>(SqlCommand cmd, [CallerMemberName] string caller = null) where T : IMetaObject, new()
+        [NotNull]
+        static string QueryExecutionErrorMessage<T>(SqlCommand cmd, [CanBeNull] [CallerMemberName] string caller = null) where T : IMetaObject, new()
         {
             return caller + "<" + typeof(T).ToCSharpFriendlyTypeName() + ">() failed. \n\nQUERY:\n\n"
                 + SqlCommandTracer.DebugFriendlyCommandText(cmd, SqlCommandTracerOptions.IncludeArgumentValuesInLog);
@@ -180,7 +182,7 @@ namespace ProgressOnderwijsUtils
 
         [MustUseReturnValue]
         [NotNull]
-        public static T[] ReadPlainUnpacker<T>(SqlCommand cmd)
+        public static T[] ReadPlainUnpacker<T>([NotNull] SqlCommand cmd)
         {
             using (var reader = cmd.ExecuteReader(CommandBehavior.SequentialAccess)) {
                 DataReaderSpecialization<SqlDataReader>.PlainImpl<T>.VerifyDataReaderShape(reader);
@@ -214,7 +216,8 @@ namespace ProgressOnderwijsUtils
 
         //static readonly MethodInfo IsDBNullMethod = typeof(IDataRecord).GetMethod("IsDBNull", binding);
         //static readonly MethodInfo ReadMethod = typeof(IDataReader).GetMethod("Read", binding);
-        static Dictionary<MethodInfo, MethodInfo> MakeMap(params InterfaceMapping[] mappings)
+        [NotNull]
+        static Dictionary<MethodInfo, MethodInfo> MakeMap([NotNull] params InterfaceMapping[] mappings)
         {
             return mappings.SelectMany(
                 map => map.InterfaceMethods.Zip(map.TargetMethods, Tuple.Create))
@@ -235,7 +238,7 @@ namespace ProgressOnderwijsUtils
         static readonly MethodInfo getDateTimeOffset_SqlDataReader = typeof(SqlDataReader).GetMethod("GetDateTimeOffset", binding);
         const int AsciiUpperToLowerDiff = 'a' - 'A';
 
-        static ulong CaseInsensitiveHash(string s)
+        static ulong CaseInsensitiveHash([NotNull] string s)
         {
             //Much faster than StringComparer.OrdinalIgnoreCase.GetHashCode(...)
             //Based on java's String.hashCode(): http://docs.oracle.com/javase/6/docs/api/java/lang/String.html#hashCode%28%29
@@ -249,7 +252,7 @@ namespace ProgressOnderwijsUtils
             return hash;
         }
 
-        static bool CaseInsensitiveEquality(string a, string b)
+        static bool CaseInsensitiveEquality([NotNull] string a, [NotNull] string b)
         {
             //Much faster than StringComparer.OrdinalIgnoreCase.Equals(a,b)
             //optimized for strings that are equal, because that's the expected use case.
@@ -300,14 +303,14 @@ namespace ProgressOnderwijsUtils
             static readonly MethodInfo ReadMethod = InterfaceMap[typeof(IDataReader).GetMethod("Read", binding)];
             static readonly bool isSqlDataReader = typeof(TReader) == typeof(SqlDataReader);
 
-            static bool SupportsType(Type type)
+            static bool SupportsType([NotNull] Type type)
             {
                 var underlyingType = type.GetNonNullableUnderlyingType();
                 return getterMethodsByType.ContainsKey(underlyingType) ||
                     isSqlDataReader && (underlyingType == typeof(TimeSpan) || underlyingType == typeof(DateTimeOffset));
             }
 
-            static MethodInfo GetterForType(Type underlyingType)
+            static MethodInfo GetterForType([NotNull] Type underlyingType)
             {
                 if (isSqlDataReader && underlyingType == typeof(TimeSpan)) {
                     return getTimeSpan_SqlDataReader;
@@ -318,7 +321,7 @@ namespace ProgressOnderwijsUtils
                 }
             }
 
-            static Expression GetCastExpression(Expression callExpression, Type type)
+            static Expression GetCastExpression(Expression callExpression, [NotNull] Type type)
             {
                 var underlyingType = type.GetNonNullableUnderlyingType();
                 var needsCast = underlyingType != type.GetNonNullableType();
@@ -328,7 +331,7 @@ namespace ProgressOnderwijsUtils
                 return callExpression;
             }
 
-            public static Expression GetColValueExpr(ParameterExpression readerParamExpr, int i, Type type)
+            public static Expression GetColValueExpr(ParameterExpression readerParamExpr, int i, [NotNull] Type type)
             {
                 var canBeNull = type.CanBeNull();
                 var underlyingType = type.GetNonNullableUnderlyingType();
@@ -349,7 +352,7 @@ namespace ProgressOnderwijsUtils
                 return colValueExpr;
             }
 
-            static TRowArrayReader<T> CreateLoadRowsMethod<T>(Func<ParameterExpression, ParameterExpression, Expression> createRowObjectExpression)
+            static TRowArrayReader<T> CreateLoadRowsMethod<T>([NotNull] Func<ParameterExpression, ParameterExpression, Expression> createRowObjectExpression)
             {
                 //read this method bottom-to-top, because expression trees need to be constructed inside-out.
                 var dataReaderParamExpr = Expression.Parameter(typeof(TReader), "dataReader");
@@ -381,7 +384,7 @@ namespace ProgressOnderwijsUtils
                 return ConvertLambdaExpressionIntoDelegate<T, TRowArrayReader<T>>(loadRowsLambda);
             }
 
-            static TRowReader<T> CreateLoadRowMethod<T>(Func<ParameterExpression, ParameterExpression, Expression> createRowObjectExpression)
+            static TRowReader<T> CreateLoadRowMethod<T>([NotNull] Func<ParameterExpression, ParameterExpression, Expression> createRowObjectExpression)
             {
                 var dataReaderParamExpr = Expression.Parameter(typeof(TReader), "dataReader");
                 var lastColumnReadParamExpr = Expression.Parameter(typeof(int).MakeByRefType(), "lastColumnRead");
@@ -392,7 +395,8 @@ namespace ProgressOnderwijsUtils
                 return ConvertLambdaExpressionIntoDelegate<T, TRowReader<T>>(loadRowsLambda);
             }
 
-            static TDelegate ConvertLambdaExpressionIntoDelegate<T, TDelegate>(Expression<TDelegate> loadRowsLambda)
+            [NotNull]
+            static TDelegate ConvertLambdaExpressionIntoDelegate<T, TDelegate>([NotNull] Expression<TDelegate> loadRowsLambda)
             {
                 try {
                     if (!typeof(T).IsPublic) {
@@ -419,7 +423,7 @@ namespace ProgressOnderwijsUtils
                     readonly ulong cachedHash;
                     public readonly string[] Cols;
 
-                    public ColumnOrdering(TReader reader)
+                    public ColumnOrdering([NotNull] TReader reader)
                     {
                         var primeArr = ColHashPrimes;
                         Cols = PooledSmallBufferAllocator<string>.GetByLength(reader.FieldCount);
@@ -451,6 +455,7 @@ namespace ProgressOnderwijsUtils
 
                 static readonly ConcurrentDictionary<ColumnOrdering, TRowArrayReaderWithCols<T>> LoadRows;
                 static readonly ConcurrentDictionary<ColumnOrdering, TRowReaderWithCols<T>> LoadRow;
+                [NotNull]
                 static Type type => typeof(T);
                 static string FriendlyName => type.ToCSharpFriendlyTypeName();
                 static readonly uint[] ColHashPrimes;
@@ -510,7 +515,7 @@ namespace ProgressOnderwijsUtils
                     return cachedRowReaderWithCols.RowReader;
                 }
 
-                static void AssertColumnsCanBeMappedToObject(TReader reader, FieldMappingMode fieldMappingMode)
+                static void AssertColumnsCanBeMappedToObject([NotNull] TReader reader, FieldMappingMode fieldMappingMode)
                 {
                     if (reader.FieldCount > ColHashPrimes.Length
                         || (reader.FieldCount < ColHashPrimes.Length || hasUnsupportedColumns) && fieldMappingMode == FieldMappingMode.RequireExactColumnMatches) {
@@ -605,9 +610,11 @@ namespace ProgressOnderwijsUtils
                 }
 
                 public static readonly TRowArrayReader<T> LoadRows;
+                [NotNull]
                 static Type type => typeof(T);
                 static string FriendlyName => type.ToCSharpFriendlyTypeName();
                 static readonly ConstructorInfo constructor;
+                [NotNull]
                 static ParameterInfo[] ConstructorParameters => constructor.GetParameters();
 
                 static ReadByConstructorImpl()
@@ -621,6 +628,7 @@ namespace ProgressOnderwijsUtils
                                     Expression.Block(Expression.Assign(lastReadExpr, Expression.Constant(i)), GetColValueExpr(readerParamExpr, i, ci.ParameterType)))));
                 }
 
+                [NotNull]
                 static ConstructorInfo VerifyTypeValidityAndGetConstructor()
                 {
                     if (!type.IsSealed || !type.IsPublic) {
@@ -646,7 +654,7 @@ namespace ProgressOnderwijsUtils
                     return retval;
                 }
 
-                public static void VerifyDataReaderShape(TReader reader)
+                public static void VerifyDataReaderShape([NotNull] TReader reader)
                 {
                     if (reader.FieldCount != ConstructorParameters.Length) {
                         throw new InvalidOperationException(
@@ -672,6 +680,7 @@ namespace ProgressOnderwijsUtils
             {
                 static string FriendlyName => type.ToCSharpFriendlyTypeName();
                 public static readonly TRowArrayReader<T> LoadRows;
+                [NotNull]
                 static Type type => typeof(T);
 
                 static PlainImpl()
@@ -689,7 +698,7 @@ namespace ProgressOnderwijsUtils
                     }
                 }
 
-                public static void VerifyDataReaderShape(TReader reader)
+                public static void VerifyDataReaderShape([NotNull] TReader reader)
                 {
                     if (reader.FieldCount != 1) {
                         throw new InvalidOperationException("Cannot unpack DbDataReader into type " + FriendlyName + "; column count = " + reader.FieldCount + " != 1");
@@ -710,8 +719,9 @@ namespace ProgressOnderwijsUtils
 
     public static class DbLoadingHelperImpl
     {
+        [NotNull]
         [UsedImplicitly]
-        public static byte[] GetBytes(this IDataRecord row, int colIndex)
+        public static byte[] GetBytes([NotNull] this IDataRecord row, int colIndex)
         {
             var byteCount = row.GetBytes(colIndex, 0L, null, 0, 0);
             if (byteCount > int.MaxValue) {
@@ -725,8 +735,9 @@ namespace ProgressOnderwijsUtils
             return arr;
         }
 
+        [NotNull]
         [UsedImplicitly]
-        public static char[] GetChars(this IDataRecord row, int colIndex)
+        public static char[] GetChars([NotNull] this IDataRecord row, int colIndex)
         {
             var charCount = row.GetChars(colIndex, 0L, null, 0, 0);
             if (charCount > int.MaxValue) {

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -20,7 +20,7 @@ namespace ProgressOnderwijsUtils
     public static class ParameterizedSqlObjectMapper
     {
         [MustUseReturnValue]
-        public static T ExecuteQuery<T>(ParameterizedSql sql, SqlCommandCreationContext commandCreationContext, Func<string> exceptionMessage, [NotNull] Func<SqlCommand, T> action)
+        public static T ExecuteQuery<T>(ParameterizedSql sql, [NotNull] SqlCommandCreationContext commandCreationContext, Func<string> exceptionMessage, [NotNull] Func<SqlCommand, T> action)
         {
             using (var cmd = sql.CreateSqlCommand(commandCreationContext))
                 try {
@@ -83,7 +83,7 @@ namespace ProgressOnderwijsUtils
         /// <param name="qCommandCreationContext">The database connection</param>
         [MustUseReturnValue]
         [NotNull]
-        public static IEnumerable<T> EnumerateMetaObjects<T>(this ParameterizedSql q, SqlCommandCreationContext qCommandCreationContext, FieldMappingMode fieldMappingMode = FieldMappingMode.RequireExactColumnMatches) where T : IMetaObject, new()
+        public static IEnumerable<T> EnumerateMetaObjects<T>(this ParameterizedSql q, [NotNull] SqlCommandCreationContext qCommandCreationContext, FieldMappingMode fieldMappingMode = FieldMappingMode.RequireExactColumnMatches) where T : IMetaObject, new()
         {
             using (var reusableCmd = q.CreateSqlCommand(qCommandCreationContext)) {
                 var cmd = reusableCmd.Command;

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -155,7 +155,7 @@ namespace ProgressOnderwijsUtils
         }
 
         [NotNull]
-        static string QueryExecutionErrorMessage<T>(SqlCommand cmd, [CanBeNull] [CallerMemberName] string caller = null) where T : IMetaObject, new()
+        static string QueryExecutionErrorMessage<T>([NotNull] SqlCommand cmd, [CanBeNull] [CallerMemberName] string caller = null) where T : IMetaObject, new()
         {
             return caller + "<" + typeof(T).ToCSharpFriendlyTypeName() + ">() failed. \n\nQUERY:\n\n"
                 + SqlCommandTracer.DebugFriendlyCommandText(cmd, SqlCommandTracerOptions.IncludeArgumentValuesInLog);
@@ -352,6 +352,7 @@ namespace ProgressOnderwijsUtils
                 return colValueExpr;
             }
 
+            [NotNull]
             static TRowArrayReader<T> CreateLoadRowsMethod<T>([NotNull] Func<ParameterExpression, ParameterExpression, Expression> createRowObjectExpression)
             {
                 //read this method bottom-to-top, because expression trees need to be constructed inside-out.
@@ -384,6 +385,7 @@ namespace ProgressOnderwijsUtils
                 return ConvertLambdaExpressionIntoDelegate<T, TRowArrayReader<T>>(loadRowsLambda);
             }
 
+            [NotNull]
             static TRowReader<T> CreateLoadRowMethod<T>([NotNull] Func<ParameterExpression, ParameterExpression, Expression> createRowObjectExpression)
             {
                 var dataReaderParamExpr = Expression.Parameter(typeof(TReader), "dataReader");
@@ -489,7 +491,7 @@ namespace ProgressOnderwijsUtils
                     LoadRow = new ConcurrentDictionary<ColumnOrdering, TRowReaderWithCols<T>>();
                 }
 
-                public static TRowArrayReader<T> DataReaderToRowArrayUnpacker(TReader reader, FieldMappingMode fieldMappingMode)
+                public static TRowArrayReader<T> DataReaderToRowArrayUnpacker([NotNull] TReader reader, FieldMappingMode fieldMappingMode)
                 {
                     AssertColumnsCanBeMappedToObject(reader, fieldMappingMode);
                     var ordering = new ColumnOrdering(reader);
@@ -502,7 +504,7 @@ namespace ProgressOnderwijsUtils
                     return cachedRowReaderWithCols.RowArrayReader;
                 }
 
-                public static TRowReader<T> DataReaderToSingleRowUnpacker(TReader reader, FieldMappingMode fieldMappingMode)
+                public static TRowReader<T> DataReaderToSingleRowUnpacker([NotNull] TReader reader, FieldMappingMode fieldMappingMode)
                 {
                     AssertColumnsCanBeMappedToObject(reader, fieldMappingMode);
                     var ordering = new ColumnOrdering(reader);
@@ -601,7 +603,7 @@ namespace ProgressOnderwijsUtils
             public static class ReadByConstructorImpl<T>
             {
                 // ReSharper disable UnusedMember.Local
-                public static T[] VerifyShapeAndLoadRows(SqlDataReader reader)
+                public static T[] VerifyShapeAndLoadRows([NotNull] SqlDataReader reader)
                     // ReSharper restore UnusedMember.Local
                 {
                     DataReaderSpecialization<SqlDataReader>.ReadByConstructorImpl<T>.VerifyDataReaderShape(reader);

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -31,7 +31,7 @@ namespace ProgressOnderwijsUtils
         }
 
         [MustUseReturnValue]
-        public static T ReadScalar<T>(this ParameterizedSql sql, SqlCommandCreationContext commandCreationContext)
+        public static T ReadScalar<T>(this ParameterizedSql sql, [NotNull] SqlCommandCreationContext commandCreationContext)
         {
             return ExecuteQuery(
                 sql,
@@ -40,7 +40,7 @@ namespace ProgressOnderwijsUtils
                 command => DBNullRemover.Cast<T>(command.ExecuteScalar()));
         }
 
-        public static int ExecuteNonQuery(this ParameterizedSql sql, SqlCommandCreationContext commandCreationContext)
+        public static int ExecuteNonQuery(this ParameterizedSql sql, [NotNull] SqlCommandCreationContext commandCreationContext)
         {
             return ExecuteQuery(
                 sql,
@@ -61,7 +61,7 @@ namespace ProgressOnderwijsUtils
         /// <returns>An array of strongly-typed objects; never null</returns>
         [MustUseReturnValue]
         [NotNull]
-        public static T[] ReadMetaObjects<T>(this ParameterizedSql q, SqlCommandCreationContext qCommandCreationContext) where T : IMetaObject, new()
+        public static T[] ReadMetaObjects<T>(this ParameterizedSql q, [NotNull] SqlCommandCreationContext qCommandCreationContext) where T : IMetaObject, new()
         {
             return ExecuteQuery(
                 q,
@@ -171,7 +171,7 @@ namespace ProgressOnderwijsUtils
         /// <returns>An array of strongly-typed objects; never null</returns>
         [MustUseReturnValue]
         [NotNull]
-        public static T[] ReadPlain<T>(this ParameterizedSql q, SqlCommandCreationContext qCommandCreationContext)
+        public static T[] ReadPlain<T>(this ParameterizedSql q, [NotNull] SqlCommandCreationContext qCommandCreationContext)
         {
             return ExecuteQuery(
                 q,

--- a/src/ProgressOnderwijsUtils/Data/PooledExponentialBufferAllocator.cs
+++ b/src/ProgressOnderwijsUtils/Data/PooledExponentialBufferAllocator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -9,6 +10,7 @@ namespace ProgressOnderwijsUtils
         static readonly int MaxArrayLength = 1 << MaxIndex;
         static readonly ConcurrentQueue<T[]>[] bagsByIndex = InitBags();
 
+        [NotNull]
         static ConcurrentQueue<T[]>[] InitBags()
         {
             var allBags = new ConcurrentQueue<T[]>[IndexCount];
@@ -41,7 +43,7 @@ namespace ProgressOnderwijsUtils
         /// It is inefficient to return "old" arrays into the pool; the most efficient usage is when the consumer only need needs few arrays simultaneously.
         /// Note that arrays are *NOT* cleared when they are returned to the pool; for reference types it may be advisable to clear the array to avoid unnecessary gc load.
         /// </summary>
-        public static void ReturnToPool(T[] arr)
+        public static void ReturnToPool([NotNull] T[] arr)
         {
             if (arr.Length > MaxArrayLength) {
                 return;

--- a/src/ProgressOnderwijsUtils/Data/PooledSmallBufferAllocator.cs
+++ b/src/ProgressOnderwijsUtils/Data/PooledSmallBufferAllocator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -12,6 +13,7 @@ namespace ProgressOnderwijsUtils
         //conceptually, a ConcurrentBag that doesn't allocation on .Add(...) is what we're looking for here, and a queue is close enough.
         static readonly ConcurrentQueue<T[]>[] bagsByIndex = InitBags();
 
+        [NotNull]
         static ConcurrentQueue<T[]>[] InitBags()
         {
             var allBags = new ConcurrentQueue<T[]>[IndexCount];
@@ -41,7 +43,7 @@ namespace ProgressOnderwijsUtils
         /// Releases an array array back into the pool.  It is an error for a caller to use the array after this call.
         /// Large arrays (currently longer than 128 elements) are never pooled; this operation is a no-op for such arrays.
         /// </summary>
-        public static void ReturnToPool(T[] arr)
+        public static void ReturnToPool([NotNull] T[] arr)
         {
             if (arr.Length > MaxArrayLength) {
                 return;

--- a/src/ProgressOnderwijsUtils/Data/PooledSqlCommandAllocator.cs
+++ b/src/ProgressOnderwijsUtils/Data/PooledSqlCommandAllocator.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Data.SqlClient;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -12,6 +13,7 @@ namespace ProgressOnderwijsUtils
         //conceptually, a ConcurrentBag that doesn't allocation on .Add(...) is what we're looking for here, and a queue is close enough.
         static readonly ConcurrentQueue<SqlCommand>[] bagsByIndex = InitBags();
 
+        [NotNull]
         static ConcurrentQueue<SqlCommand>[] InitBags()
         {
             var allBags = new ConcurrentQueue<SqlCommand>[IndexCount];
@@ -39,7 +41,7 @@ namespace ProgressOnderwijsUtils
             return cmd;
         }
 
-        public static void ReturnToPool(SqlCommand cmd)
+        public static void ReturnToPool([NotNull] SqlCommand cmd)
         {
             var parameters = cmd.Parameters;
             var parameterCount = parameters.Count;

--- a/src/ProgressOnderwijsUtils/Data/QueryScalarParameterComponent.cs
+++ b/src/ProgressOnderwijsUtils/Data/QueryScalarParameterComponent.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -11,7 +12,7 @@ namespace ProgressOnderwijsUtils
             paramArgs.Value = EquatableValue == CurrentTimeToken.Instance ? DateTime.Now : EquatableValue;
         }
 
-        public static void AppendScalarParameter<TCommandFactory>(ref TCommandFactory factory, object o)
+        public static void AppendScalarParameter<TCommandFactory>(ref TCommandFactory factory, [CanBeNull] object o)
             where TCommandFactory : struct, ICommandFactory
         {
             var param = new QueryScalarParameterComponent { EquatableValue = o ?? DBNull.Value };

--- a/src/ProgressOnderwijsUtils/Data/QueryTableValuedParameterComponent.cs
+++ b/src/ProgressOnderwijsUtils/Data/QueryTableValuedParameterComponent.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Collections.Generic;
 using System;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -19,6 +20,7 @@ namespace ProgressOnderwijsUtils
         readonly IEnumerable<TIn> values;
         readonly Func<IEnumerable<TIn>, TOut[]> projection;
         int cachedProjectedLength;
+        [NotNull]
         public object EquatableValue => Tuple.Create(values, DbTypeName);
 
         internal QueryTableValuedParameterComponent(string dbTypeName, IEnumerable<TIn> values, Func<IEnumerable<TIn>, TOut[]> projection)

--- a/src/ProgressOnderwijsUtils/Data/SqlCommandCreationContext.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlCommandCreationContext.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data.SqlClient;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -10,6 +11,7 @@ namespace ProgressOnderwijsUtils
         public int CommandTimeoutInS { get; }
         // ReSharper disable UnusedMember.Global
         // Handige generieke functionaliteit, maar niet altijd gebruikt
+        [NotNull]
         public SqlCommandCreationContext OverrideTimeout(int timeoutSeconds) => new SqlCommandCreationContext(Connection, timeoutSeconds, Tracer);
         // ReSharper restore UnusedMember.Global
         public SqlCommandCreationContext(SqlConnection conn, int defaultTimeoutInS, ISqlCommandTracer tracer)
@@ -24,6 +26,7 @@ namespace ProgressOnderwijsUtils
             Connection.Dispose();
         }
 
+        [NotNull]
         public static implicit operator SqlCommandCreationContext(SqlConnection conn) => new SqlCommandCreationContext(conn, 0, null);
     }
 }

--- a/src/ProgressOnderwijsUtils/Data/SqlCommandTracer.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlCommandTracer.cs
@@ -108,6 +108,7 @@ namespace ProgressOnderwijsUtils
                 ? par.TypeName
                 : par.SqlDbType + (par.SqlDbType == SqlDbType.NVarChar ? "(max)" : "");
 
+        [NotNull]
         public static string InsecureSqlDebugString([CanBeNull] object p, bool includeReadableEnumValue)
         {
             if (p is DBNull || p == null) {
@@ -165,6 +166,7 @@ namespace ProgressOnderwijsUtils
                 return new SqlCommandTimer(this, commandText);
             }
 
+            [NotNull]
             public IDisposable StartCommandTimer([NotNull] string commandText)
             {
                 if (commandText == null) {
@@ -174,7 +176,7 @@ namespace ProgressOnderwijsUtils
                 return StartCommandTimer(() => commandText);
             }
 
-            public IDisposable StartCommandTimer(SqlCommand sqlCommand) => StartCommandTimer(DebugFriendlyCommandText(sqlCommand, IncludeSensitiveInfo));
+            public IDisposable StartCommandTimer([NotNull] SqlCommand sqlCommand) => StartCommandTimer(DebugFriendlyCommandText(sqlCommand, IncludeSensitiveInfo));
 
             public void FinishDisposableTimer(Func<string> commandText, TimeSpan duration)
             {

--- a/src/ProgressOnderwijsUtils/Data/SqlCommandTracer.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlCommandTracer.cs
@@ -63,6 +63,7 @@ namespace ProgressOnderwijsUtils
         public static string DebugFriendlyCommandText([NotNull] SqlCommand sqlCommand, SqlCommandTracerOptions includeSensitiveInfo) 
             => CommandParamStringOrEmpty(sqlCommand, includeSensitiveInfo) + sqlCommand.CommandText;
 
+        [NotNull]
         static string CommandParamStringOrEmpty(SqlCommand sqlCommand, SqlCommandTracerOptions includeSensitiveInfo)
         {
             if (includeSensitiveInfo == SqlCommandTracerOptions.IncludeArgumentValuesInLog) {

--- a/src/ProgressOnderwijsUtils/Data/SqlCommandTracer.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlCommandTracer.cs
@@ -72,6 +72,7 @@ namespace ProgressOnderwijsUtils
             }
         }
 
+        [NotNull]
         static string CommandParamString([NotNull] SqlCommand sqlCommand)
             => sqlCommand.Parameters.Cast<SqlParameter>().Select(DeclareParameter).JoinStrings();
 
@@ -176,6 +177,7 @@ namespace ProgressOnderwijsUtils
                 return StartCommandTimer(() => commandText);
             }
 
+            [NotNull]
             public IDisposable StartCommandTimer([NotNull] SqlCommand sqlCommand) => StartCommandTimer(DebugFriendlyCommandText(sqlCommand, IncludeSensitiveInfo));
 
             public void FinishDisposableTimer(Func<string> commandText, TimeSpan duration)

--- a/src/ProgressOnderwijsUtils/Data/SqlParameterComponent.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlParameterComponent.cs
@@ -88,7 +88,7 @@ namespace ProgressOnderwijsUtils
         static readonly ConcurrentDictionary<Type, ITableValuedParameterFactory> tableValuedParameterFactoryCache = new ConcurrentDictionary<Type, ITableValuedParameterFactory>();
 
         [CanBeNull]
-        static ITableValuedParameterFactory CreateTableValuedParameterFactory(Type enumerableType)
+        static ITableValuedParameterFactory CreateTableValuedParameterFactory([NotNull] Type enumerableType)
         {
             var elementType = TryGetNonAmbiguousEnumerableElementType(enumerableType);
             if (elementType == null) {
@@ -162,6 +162,7 @@ namespace ProgressOnderwijsUtils
                 this.sqlTableTypeName = sqlTableTypeName;
             }
 
+            [NotNull]
             public ISqlComponent CreateFromPlainValues(IEnumerable enumerable)
             {
                 return ToTableValuedParameter(sqlTableTypeName, (IEnumerable<T>)enumerable, TableValuedParameterWrapperHelper.WrapPlainValueInMetaObject);

--- a/src/ProgressOnderwijsUtils/DateTimeShortAgeTag.cs
+++ b/src/ProgressOnderwijsUtils/DateTimeShortAgeTag.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Linq;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -12,6 +13,7 @@ namespace ProgressOnderwijsUtils
         /// now, we take 0xffffff of those pseudo seconds, or 2^24 * 2^23 * 10^-7 seconds, i.e. 162.9 days, or about 0.5 years.
         /// after this time, the AgeTag will loop.  So our Tag is granular to the second, and unique within a half year.
         /// </summary>
+        [NotNull]
         public static string ToAgeTag(DateTime datetime)
         {
             var granularTicks = (uint)(datetime.Ticks >> 23) & 0xffffff; //3byte code

--- a/src/ProgressOnderwijsUtils/DeepEquals.cs
+++ b/src/ProgressOnderwijsUtils/DeepEquals.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -59,12 +60,12 @@ namespace ProgressOnderwijsUtils
             public bool Equals(ReferencePair other) => other != null && ReferenceEquals(a, other.a) && ReferenceEquals(b, other.b);
             public override int GetHashCode() => RuntimeHelpers.GetHashCode(a) + 137 * RuntimeHelpers.GetHashCode(b);
 
-            public static bool operator ==(ReferencePair a, ReferencePair b)
+            public static bool operator ==([CanBeNull] ReferencePair a, [CanBeNull] ReferencePair b)
             {
                 return ReferenceEquals(a, b) || !ReferenceEquals(a, null) && a.Equals(b);
             }
 
-            public static bool operator !=(ReferencePair a, ReferencePair b)
+            public static bool operator !=([CanBeNull] ReferencePair a, [CanBeNull] ReferencePair b)
             {
                 return !(a == b);
             }
@@ -76,7 +77,8 @@ namespace ProgressOnderwijsUtils
             public Func<object, object> Getter;
         }
 
-        static IEnumerable<AccessibleMember> GetGetters(Type type)
+        [NotNull]
+        static IEnumerable<AccessibleMember> GetGetters([NotNull] Type type)
         {
             var propertyMembers =
                 type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
@@ -86,7 +88,7 @@ namespace ProgressOnderwijsUtils
             return fieldMembers.Concat(propertyMembers).ToArray();
         }
 
-        static bool CompareAsEnumerableOrAccessibleMembers(HashSet<ReferencePair> assumeEqual, Type type, object o1_nonnull, object o2_nonnull)
+        static bool CompareAsEnumerableOrAccessibleMembers(HashSet<ReferencePair> assumeEqual, Type type, object o1_nonnull, [NotNull] object o2_nonnull)
         {
             if (o1_nonnull is IEnumerable && o2_nonnull is IEnumerable) {
                 return CompareEnumerables(assumeEqual, (IEnumerable)o1_nonnull, (IEnumerable)o2_nonnull);
@@ -106,22 +108,23 @@ namespace ProgressOnderwijsUtils
             return true;
         }
 
-        static MethodInfo TypeBuiltinEquals(Type type)
+        [CanBeNull]
+        static MethodInfo TypeBuiltinEquals([NotNull] Type type)
         {
             return type.IsValueType
                 ? type.GetMethod("Equals", BindingFlags.Instance | BindingFlags.Public | BindingFlags.ExactBinding, null, new[] { type }, null)
                 : type.GetMethod("Equals", BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public | BindingFlags.ExactBinding, null, new[] { type }, null);
         }
 
-        static bool CompareWithBuiltinEquals(MethodInfo builtinEquals, object o1_nonnull, object o2) => (bool)builtinEquals.Invoke(o1_nonnull, new[] { o2 });
+        static bool CompareWithBuiltinEquals([NotNull] MethodInfo builtinEquals, object o1_nonnull, object o2) => (bool)builtinEquals.Invoke(o1_nonnull, new[] { o2 });
 
-        static bool CompareDictionaries(HashSet<ReferencePair> assumeEqual, IDictionary iDict1, IDictionary iDict2)
+        static bool CompareDictionaries(HashSet<ReferencePair> assumeEqual, [NotNull] IDictionary iDict1, [NotNull] IDictionary iDict2)
         {
             return iDict1.Count == iDict2.Count
                 && iDict1.Keys.Cast<object>().All(dict1key => iDict2.Contains(dict1key) && Compare(assumeEqual, iDict1[dict1key], iDict2[dict1key]));
         }
 
-        static bool CompareEnumerables(HashSet<ReferencePair> assumeEqual, IEnumerable ilist1, IEnumerable ilist2)
+        static bool CompareEnumerables(HashSet<ReferencePair> assumeEqual, [NotNull] IEnumerable ilist1, [NotNull] IEnumerable ilist2)
         {
             return ilist1.Cast<object>().Zip(ilist2.Cast<object>(), (el1, el2) => Compare(assumeEqual, el1, el2)).All(b => b);
         }

--- a/src/ProgressOnderwijsUtils/DistinctArray.cs
+++ b/src/ProgressOnderwijsUtils/DistinctArray.cs
@@ -18,7 +18,7 @@ namespace ProgressOnderwijsUtils
         public static DistinctArray<T> Empty
             => FromDistinct(Array.Empty<T>());
 
-        public static DistinctArray<T> FromDistinct(IEnumerable<T> items)
+        public static DistinctArray<T> FromDistinct([NotNull] IEnumerable<T> items)
             => FromDistinct(items, EqualityComparer<T>.Default);
 
         public static DistinctArray<T> FromDistinct([NotNull] IEnumerable<T> items, IEqualityComparer<T> comparer)
@@ -32,7 +32,7 @@ namespace ProgressOnderwijsUtils
             };
         }
 
-        public static DistinctArray<T> FromPossiblyNotDistinct(IEnumerable<T> items)
+        public static DistinctArray<T> FromPossiblyNotDistinct([NotNull] IEnumerable<T> items)
             => FromPossiblyNotDistinct(items, EqualityComparer<T>.Default);
 
         public static DistinctArray<T> FromPossiblyNotDistinct([NotNull] IEnumerable<T> items, IEqualityComparer<T> comparer)

--- a/src/ProgressOnderwijsUtils/DistinctArray.cs
+++ b/src/ProgressOnderwijsUtils/DistinctArray.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -20,7 +21,7 @@ namespace ProgressOnderwijsUtils
         public static DistinctArray<T> FromDistinct(IEnumerable<T> items)
             => FromDistinct(items, EqualityComparer<T>.Default);
 
-        public static DistinctArray<T> FromDistinct(IEnumerable<T> items, IEqualityComparer<T> comparer)
+        public static DistinctArray<T> FromDistinct([NotNull] IEnumerable<T> items, IEqualityComparer<T> comparer)
         {
             if (items.ContainsDuplicates(comparer)) {
                 throw new ArgumentException("items are not distinct");
@@ -34,7 +35,7 @@ namespace ProgressOnderwijsUtils
         public static DistinctArray<T> FromPossiblyNotDistinct(IEnumerable<T> items)
             => FromPossiblyNotDistinct(items, EqualityComparer<T>.Default);
 
-        public static DistinctArray<T> FromPossiblyNotDistinct(IEnumerable<T> items, IEqualityComparer<T> comparer)
+        public static DistinctArray<T> FromPossiblyNotDistinct([NotNull] IEnumerable<T> items, IEqualityComparer<T> comparer)
         {
             return new DistinctArray<T> {
                 items = items.Distinct(comparer).ToArray()

--- a/src/ProgressOnderwijsUtils/DistinctArray.cs
+++ b/src/ProgressOnderwijsUtils/DistinctArray.cs
@@ -8,7 +8,7 @@ namespace ProgressOnderwijsUtils
 {
     public static class DistinctArray
     {
-        public static DistinctArray<T> FromDistinct<T>(IEnumerable<T> items)
+        public static DistinctArray<T> FromDistinct<T>([NotNull] IEnumerable<T> items)
             => DistinctArray<T>.FromDistinct(items);
     }
 

--- a/src/ProgressOnderwijsUtils/Extensions/ArrayExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/ArrayExtensions.cs
@@ -14,7 +14,7 @@ namespace ProgressOnderwijsUtils
         /// <param name="defaultValue">The value to get if the index is out of range.</param>
         /// <returns>The value at the index, or the default if the array does encompass that index.</returns>
         [Pure]
-        public static TValue GetOrDefault<TValue>(this TValue[] array, int index, TValue defaultValue)
+        public static TValue GetOrDefault<TValue>([CanBeNull] this TValue[] array, int index, TValue defaultValue)
         {
             return array != null && index < array.Length && index >= 0 ? array[index] : defaultValue;
         }
@@ -22,8 +22,9 @@ namespace ProgressOnderwijsUtils
         /// <summary>
         /// Return an empty array if it's null
         /// </summary>
+        [NotNull]
         [Pure]
-        public static T[] EmptyIfNull<T>(this T[] array)
+        public static T[] EmptyIfNull<T>([CanBeNull] this T[] array)
         {
             return array ?? Array.Empty<T>();
         }
@@ -31,8 +32,9 @@ namespace ProgressOnderwijsUtils
         /// <summary>
         /// Like Enumerable.Select, but faster due to specialization for arrays.
         /// </summary>
+        [NotNull]
         [Pure]
-        public static TR[] ArraySelect<T, TR>(this T[] array, Func<T, TR> mappingFunction)
+        public static TR[] ArraySelect<T, TR>([NotNull] this T[] array, Func<T, TR> mappingFunction)
         {
             var output = new TR[array.Length];
             for (var i = 0; i < array.Length; ++i) {
@@ -41,8 +43,9 @@ namespace ProgressOnderwijsUtils
             return output;
         }
 
+        [NotNull]
         [Pure]
-        public static TR[] ArraySelect<T, TR>(this IReadOnlyList<T> array, Func<T, TR> mappingFunction)
+        public static TR[] ArraySelect<T, TR>([NotNull] this IReadOnlyList<T> array, Func<T, TR> mappingFunction)
         {
             var output = new TR[array.Count];
             for (var i = 0; i < output.Length; ++i) {
@@ -51,7 +54,7 @@ namespace ProgressOnderwijsUtils
             return output;
         }
 
-        public static T[] AppendArrays<T>(this T[] beginning, T[] end)
+        public static T[] AppendArrays<T>([CanBeNull] this T[] beginning, T[] end)
         {
             if (beginning == null) {
                 return end;

--- a/src/ProgressOnderwijsUtils/Extensions/DataRowExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/DataRowExtensions.cs
@@ -10,7 +10,7 @@ namespace ProgressOnderwijsUtils
     public static class DataRowExtensions
     {
         [Pure]
-        public static T Field<T>(this DataRowView row, string fieldname)
+        public static T Field<T>([NotNull] this DataRowView row, [NotNull] string fieldname)
         {
             return row.Row.Field<T>(fieldname);
         }

--- a/src/ProgressOnderwijsUtils/Extensions/DictionaryExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/DictionaryExtensions.cs
@@ -12,7 +12,7 @@ namespace ProgressOnderwijsUtils
         /// <summary>
         /// Casts the boxed objects to a typed representation.  Supports directly unboxing int's into (nullable) enums.
         /// </summary>
-        public static T Field<T>(this IDictionary<string, object> dict, string key)
+        public static T Field<T>([NotNull] this IDictionary<string, object> dict, [NotNull] string key)
         {
             return DBNullRemover.Cast<T>(dict[key]);
         }
@@ -21,7 +21,7 @@ namespace ProgressOnderwijsUtils
         /// Casts the boxed objects to a typed representation.  Supports directly unboxing int's into (nullable) enums.
         /// </summary>
         [UsefulToKeep("library method; interface is used, since method above is used")]
-        public static T Field<T>(this IReadOnlyDictionary<string, object> dict, string key)
+        public static T Field<T>([NotNull] this IReadOnlyDictionary<string, object> dict, string key)
         {
             return DBNullRemover.Cast<T>(dict[key]);
         }
@@ -33,14 +33,14 @@ namespace ProgressOnderwijsUtils
         /// <param name="key">The key whose value to get.</param>
         /// <param name="defaultValue">The default value of the key.</param>
         /// <returns>The value of the key, or the default if the dictionary does not contain the key.</returns>
-        public static TValue GetOrDefaultR<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dict, TKey key,
+        public static TValue GetOrDefaultR<TKey, TValue>([NotNull] this IReadOnlyDictionary<TKey, TValue> dict, [NotNull] TKey key,
             TValue defaultValue)
         {
             TValue result;
             return dict.TryGetValue(key, out result) ? result : defaultValue;
         }
 
-        public static TValue GetOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key,
+        public static TValue GetOrDefault<TKey, TValue>([NotNull] this IDictionary<TKey, TValue> dict, [NotNull] TKey key,
             TValue defaultValue)
         {
             TValue result;
@@ -70,7 +70,7 @@ namespace ProgressOnderwijsUtils
         /// <param name="key">The key whose value to get.</param>
         /// <param name="defaultValue">The default value of the key.</param>
         /// <returns>The value of the key, or the default if the dictionary does not contain the key.</returns>
-        public static TValue? GetOrDefaultR<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dict, TKey key,
+        public static TValue? GetOrDefaultR<TKey, TValue>([NotNull] this IReadOnlyDictionary<TKey, TValue> dict, [NotNull] TKey key,
             TValue? defaultValue)
             where TValue : struct
         {
@@ -86,7 +86,7 @@ namespace ProgressOnderwijsUtils
         /// <param name="defaultValue">The default value of the key.</param>
         /// <returns>The value of the key, or the default if the dictionary does not contain the key.</returns>
         [UsefulToKeep("library method; interface is used, since method above is used")]
-        public static TValue? GetOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key,
+        public static TValue? GetOrDefault<TKey, TValue>([NotNull] this IDictionary<TKey, TValue> dict, [NotNull] TKey key,
             TValue? defaultValue)
             where TValue : struct
         {
@@ -101,7 +101,7 @@ namespace ProgressOnderwijsUtils
         /// <param name="key">The key whose value to get.</param>
         /// <param name="defaultFactory">The factory method to call to create a default value if not found.</param>
         /// <returns>The value of the key, or the default if the dictionary does not contain the key.</returns>
-        public static TValue GetOrLazyDefault<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key,
+        public static TValue GetOrLazyDefault<TKey, TValue>([NotNull] this IDictionary<TKey, TValue> dict, [NotNull] TKey key,
             Func<TValue> defaultFactory)
         {
             TValue result;
@@ -115,7 +115,7 @@ namespace ProgressOnderwijsUtils
         /// <param name="key">The key whose value to get.</param>
         /// <param name="value">The default value to set if the key does not yet exists.</param>
         /// <returns>The value corresponding to the key in the dictionary (which may have just been added).</returns>
-        public static TValue GetOrAdd<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key, TValue value)
+        public static TValue GetOrAdd<TKey, TValue>([NotNull] this IDictionary<TKey, TValue> dict, [NotNull] TKey key, TValue value)
         {
             if (!dict.ContainsKey(key))
             {
@@ -131,7 +131,7 @@ namespace ProgressOnderwijsUtils
         /// <param name="key">The key whose value to get.</param>
         /// <param name="factory">The factory to create the value if the key does not yet exists.</param>
         /// <returns>The value corresponding to the key in the dictionary (which may have just been added).</returns>
-        public static TValue GetOrAdd<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key,
+        public static TValue GetOrAdd<TKey, TValue>([NotNull] this IDictionary<TKey, TValue> dict, [NotNull] TKey key,
             Func<TKey, TValue> factory)
         {
             TValue val;
@@ -144,7 +144,8 @@ namespace ProgressOnderwijsUtils
             return val;
         }
 
-        public static Dictionary<TKey, TValue> Clone<TKey, TValue>(this Dictionary<TKey, TValue> old)
+        [CanBeNull]
+        public static Dictionary<TKey, TValue> Clone<TKey, TValue>([CanBeNull] this Dictionary<TKey, TValue> old)
         {
             return old == null ? null : new Dictionary<TKey, TValue>(old, old.Comparer);
         }
@@ -155,7 +156,7 @@ namespace ProgressOnderwijsUtils
         /// <param name="old">This dictionary</param>
         /// <param name="others">The dictionary which should be merged into this array</param>
         public static Dictionary<TKey, TValue> Merge<TKey, TValue>([NotNull] this Dictionary<TKey, TValue> old,
-            params Dictionary<TKey, TValue>[] others)
+            [NotNull] params Dictionary<TKey, TValue>[] others)
         {
             if (old == null)
             {
@@ -169,6 +170,7 @@ namespace ProgressOnderwijsUtils
             return merged;
         }
 
+        [NotNull]
         public static ReadOnlyDictionary<TKey, TValue> AsReadOnly<TKey, TValue>(this IDictionary<TKey, TValue> dict)
         {
             return new ReadOnlyDictionary<TKey, TValue>(dict);

--- a/src/ProgressOnderwijsUtils/Extensions/DictionaryExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/DictionaryExtensions.cs
@@ -53,12 +53,12 @@ namespace ProgressOnderwijsUtils
         /// <param name="dict">The dictionary to extract  from</param>
         /// <param name="key">The key whose value to get.</param>
         /// <returns>The value of the key, or the default if the dictionary does not contain the key.</returns>
-        public static TValue GetOrDefaultR<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dict, TKey key)
+        public static TValue GetOrDefaultR<TKey, TValue>([NotNull] this IReadOnlyDictionary<TKey, TValue> dict, [NotNull] TKey key)
         {
             return GetOrDefaultR(dict, key, default(TValue));
         }
 
-        public static TValue GetOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key)
+        public static TValue GetOrDefault<TKey, TValue>([NotNull] this IDictionary<TKey, TValue> dict, [NotNull] TKey key)
         {
             return GetOrDefault(dict, key, default(TValue));
         }
@@ -155,6 +155,7 @@ namespace ProgressOnderwijsUtils
         /// </summary>
         /// <param name="old">This dictionary</param>
         /// <param name="others">The dictionary which should be merged into this array</param>
+        [CanBeNull]
         public static Dictionary<TKey, TValue> Merge<TKey, TValue>([NotNull] this Dictionary<TKey, TValue> old,
             [NotNull] params Dictionary<TKey, TValue>[] others)
         {

--- a/src/ProgressOnderwijsUtils/Extensions/EnumerableExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/EnumerableExtensions.cs
@@ -18,7 +18,7 @@ namespace ProgressOnderwijsUtils
         /// <returns>an int</returns>
         /// <remarks>If you just want to test existance the native "Contains" would be sufficient</remarks>
         [Pure]
-        public static int IndexOf<T>(this IEnumerable<T> list, T elem)
+        public static int IndexOf<T>([NotNull] this IEnumerable<T> list, T elem)
         {
             if (list == null) {
                 throw new ArgumentNullException(nameof(list));
@@ -34,7 +34,7 @@ namespace ProgressOnderwijsUtils
         }
 
         [Pure]
-        public static int IndexOf<T>(this IEnumerable<T> list, Func<T, bool> matcher)
+        public static int IndexOf<T>([NotNull] this IEnumerable<T> list, [NotNull] Func<T, bool> matcher)
         {
             if (list == null) {
                 throw new ArgumentNullException(nameof(list));
@@ -53,13 +53,13 @@ namespace ProgressOnderwijsUtils
         }
 
         [Pure]
-        public static bool None<TSource>(this IEnumerable<TSource> source)
+        public static bool None<TSource>([NotNull] this IEnumerable<TSource> source)
         {
             return !source.Any();
         }
 
         [Pure]
-        public static bool None<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
+        public static bool None<TSource>([NotNull] this IEnumerable<TSource> source, [NotNull] Func<TSource, bool> predicate)
         {
             return !source.Any(predicate);
         }
@@ -70,44 +70,48 @@ namespace ProgressOnderwijsUtils
             return condition ? source.Where(predicate) : source;
         }
 
+        [NotNull]
         [Pure]
-        public static IReadOnlyList<T> ToReadOnly<T>(this IEnumerable<T> list)
+        public static IReadOnlyList<T> ToReadOnly<T>([NotNull] this IEnumerable<T> list)
         {
             return list.ToArray();
         }
 
+        [NotNull]
         [Pure]
-        public static HashSet<T> ToSet<T>(this IEnumerable<T> list)
+        public static HashSet<T> ToSet<T>([NotNull] this IEnumerable<T> list)
         {
             return new HashSet<T>(list);
         }
 
+        [NotNull]
         [Pure]
-        public static HashSet<T> ToSet<T>(this IEnumerable<T> list, IEqualityComparer<T> comparer)
+        public static HashSet<T> ToSet<T>([NotNull] this IEnumerable<T> list, IEqualityComparer<T> comparer)
         {
             return new HashSet<T>(list, comparer);
         }
 
         [Pure]
-        public static bool SetEqual<T>(this IEnumerable<T> list, IEnumerable<T> other)
+        public static bool SetEqual<T>(this IEnumerable<T> list, [NotNull] IEnumerable<T> other)
         {
             return list.ToSet().SetEquals(other);
         }
 
         [Pure]
-        public static bool SetEqual<T>(this IEnumerable<T> list, IEnumerable<T> other, IEqualityComparer<T> comparer)
+        public static bool SetEqual<T>(this IEnumerable<T> list, [NotNull] IEnumerable<T> other, IEqualityComparer<T> comparer)
         {
             return list.ToSet(comparer).SetEquals(other);
         }
 
+        [NotNull]
         [Pure]
-        public static IEnumerable<T> EmptyIfNull<T>(this IEnumerable<T> list)
+        public static IEnumerable<T> EmptyIfNull<T>([CanBeNull] this IEnumerable<T> list)
         {
             return list ?? Enumerable.Empty<T>();
         }
 
         [Pure]
-        public static int GetSequenceHashCode<T>(IEnumerable<T> list, IEqualityComparer<T> elementComparer = null)
+        public static int GetSequenceHashCode<T>([NotNull] IEnumerable<T> list, [CanBeNull] IEqualityComparer<T> elementComparer = null)
         {
             var elemEquality = elementComparer ?? EqualityComparer<T>.Default;
             ulong hash = 3;
@@ -122,7 +126,7 @@ namespace ProgressOnderwijsUtils
             => ContainsDuplicates(list, EqualityComparer<T>.Default);
 
         [Pure]
-        public static bool ContainsDuplicates<T>(this IEnumerable<T> list, IEqualityComparer<T> comparer)
+        public static bool ContainsDuplicates<T>([NotNull] this IEnumerable<T> list, IEqualityComparer<T> comparer)
         {
             var set = new HashSet<T>(comparer);
             return !list.All(set.Add);
@@ -134,10 +138,11 @@ namespace ProgressOnderwijsUtils
             return list.ToSortedList(keySelector, valSelector, Comparer<TKey>.Default);
         }
 
+        [NotNull]
         [Pure]
         public static SortedList<TKey, TVal> ToSortedList<T, TKey, TVal>(
-            this IEnumerable<T> list,
-            Func<T, TKey> keySelector,
+            [NotNull] this IEnumerable<T> list,
+            [NotNull] Func<T, TKey> keySelector,
             Func<T, TVal> valSelector,
             IComparer<TKey> keyComparer)
         {
@@ -148,9 +153,10 @@ namespace ProgressOnderwijsUtils
             return retval;
         }
 
+        [NotNull]
         [Pure]
         public static Dictionary<TKey, TValue> ToGroupedDictionary<TElem, TKey, TValue>(
-            this IEnumerable<TElem> list,
+            [NotNull] this IEnumerable<TElem> list,
             Func<TElem, TKey> keyLookup,
             Func<TKey, IEnumerable<TElem>, TValue> groupMap
             )
@@ -171,8 +177,9 @@ namespace ProgressOnderwijsUtils
             return retval;
         }
 
+        [NotNull]
         [Pure]
-        public static string ToCsv<T>(this IEnumerable<T> items, bool useHeader = true, string delimiter = "\t", bool useQuotesForStrings = false)
+        public static string ToCsv<T>([NotNull] this IEnumerable<T> items, bool useHeader = true, string delimiter = "\t", bool useQuotesForStrings = false)
             where T : class
         {
             var csvBuilder = new StringBuilder();
@@ -188,8 +195,9 @@ namespace ProgressOnderwijsUtils
             return csvBuilder.ToString();
         }
 
+        [NotNull]
         [Pure]
-        static string ToCsvValue<T>(this T item, string delimiter, bool useQuotesForStrings)
+        static string ToCsvValue<T>([CanBeNull] this T item, [NotNull] string delimiter, bool useQuotesForStrings)
         {
             var csvValueWithoutQuotes = item?.ToString() ?? "";
 
@@ -212,7 +220,7 @@ namespace ProgressOnderwijsUtils
             }
         }
 
-        public static void ForEach<T>(this IEnumerable<T> list, CancellationToken cancel, Action<T> action)
+        public static void ForEach<T>([NotNull] this IEnumerable<T> list, CancellationToken cancel, Action<T> action)
         {
             foreach (var item in list) {
                 cancel.ThrowIfCancellationRequested();

--- a/src/ProgressOnderwijsUtils/Extensions/EnumerableExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/EnumerableExtensions.cs
@@ -92,13 +92,13 @@ namespace ProgressOnderwijsUtils
         }
 
         [Pure]
-        public static bool SetEqual<T>(this IEnumerable<T> list, [NotNull] IEnumerable<T> other)
+        public static bool SetEqual<T>([NotNull] this IEnumerable<T> list, [NotNull] IEnumerable<T> other)
         {
             return list.ToSet().SetEquals(other);
         }
 
         [Pure]
-        public static bool SetEqual<T>(this IEnumerable<T> list, [NotNull] IEnumerable<T> other, IEqualityComparer<T> comparer)
+        public static bool SetEqual<T>([NotNull] this IEnumerable<T> list, [NotNull] IEnumerable<T> other, IEqualityComparer<T> comparer)
         {
             return list.ToSet(comparer).SetEquals(other);
         }
@@ -122,7 +122,7 @@ namespace ProgressOnderwijsUtils
         }
 
         [Pure]
-        public static bool ContainsDuplicates<T>(this IEnumerable<T> list)
+        public static bool ContainsDuplicates<T>([NotNull] this IEnumerable<T> list)
             => ContainsDuplicates(list, EqualityComparer<T>.Default);
 
         [Pure]
@@ -132,8 +132,9 @@ namespace ProgressOnderwijsUtils
             return !list.All(set.Add);
         }
 
+        [NotNull]
         [Pure]
-        public static SortedList<TKey, TVal> ToSortedList<T, TKey, TVal>(this IEnumerable<T> list, Func<T, TKey> keySelector, Func<T, TVal> valSelector)
+        public static SortedList<TKey, TVal> ToSortedList<T, TKey, TVal>([NotNull] this IEnumerable<T> list, [NotNull] Func<T, TKey> keySelector, Func<T, TVal> valSelector)
         {
             return list.ToSortedList(keySelector, valSelector, Comparer<TKey>.Default);
         }
@@ -233,7 +234,7 @@ namespace ProgressOnderwijsUtils
             => DistinctArray<T>.FromPossiblyNotDistinct(items);
 
         [Pure]
-        public static DistinctArray<T> ToDistinctArray<T>(this IEnumerable<T> items, IEqualityComparer<T> comparer)
+        public static DistinctArray<T> ToDistinctArray<T>([NotNull] this IEnumerable<T> items, IEqualityComparer<T> comparer)
             => DistinctArray<T>.FromPossiblyNotDistinct(items, comparer);
 
         [Pure]
@@ -241,7 +242,7 @@ namespace ProgressOnderwijsUtils
             => DistinctArray<T>.FromDistinct(items);
 
         [Pure]
-        public static DistinctArray<T> ToDistinctArrayFromDistinct<T>(this IEnumerable<T> items, IEqualityComparer<T> comparer)
+        public static DistinctArray<T> ToDistinctArrayFromDistinct<T>([NotNull] this IEnumerable<T> items, IEqualityComparer<T> comparer)
             => DistinctArray<T>.FromDistinct(items, comparer);
     }
 }

--- a/src/ProgressOnderwijsUtils/Extensions/EnumerableExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/EnumerableExtensions.cs
@@ -230,7 +230,7 @@ namespace ProgressOnderwijsUtils
         }
 
         [Pure]
-        public static DistinctArray<T> ToDistinctArray<T>(this IEnumerable<T> items)
+        public static DistinctArray<T> ToDistinctArray<T>([NotNull] this IEnumerable<T> items)
             => DistinctArray<T>.FromPossiblyNotDistinct(items);
 
         [Pure]
@@ -238,7 +238,7 @@ namespace ProgressOnderwijsUtils
             => DistinctArray<T>.FromPossiblyNotDistinct(items, comparer);
 
         [Pure]
-        public static DistinctArray<T> ToDistinctArrayFromDistinct<T>(this IEnumerable<T> items)
+        public static DistinctArray<T> ToDistinctArrayFromDistinct<T>([NotNull] this IEnumerable<T> items)
             => DistinctArray<T>.FromDistinct(items);
 
         [Pure]

--- a/src/ProgressOnderwijsUtils/Extensions/EnumerableOfStringExtension.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/EnumerableOfStringExtension.cs
@@ -11,7 +11,8 @@ namespace ProgressOnderwijsUtils
         /// </summary>
         /// <param name="strings">string sequence</param>
         /// <returns>a string</returns>
-        public static string JoinStrings(this IEnumerable<string> strings) => JoinStrings(strings, "");
+        [NotNull]
+        public static string JoinStrings([NotNull] this IEnumerable<string> strings) => JoinStrings(strings, "");
 
         //don't use optional params to allow usage in expression trees
         /// <summary>

--- a/src/ProgressOnderwijsUtils/Extensions/EnumerableOfStringExtension.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/EnumerableOfStringExtension.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -19,10 +20,12 @@ namespace ProgressOnderwijsUtils
         /// <param name="strings">string sequence</param>
         /// <param name="separator">separator string</param>
         /// <returns>a string</returns>
-        public static string JoinStrings(this IEnumerable<string> strings, string separator)
+        [NotNull]
+        public static string JoinStrings([NotNull] this IEnumerable<string> strings, string separator)
             => string.Join(separator, strings);
 
-        public static string JoinStringsLimitLength(this IReadOnlyCollection<string> strings, string separator,
+        [NotNull]
+        public static string JoinStringsLimitLength([NotNull] this IReadOnlyCollection<string> strings, string separator,
             int maxCount)
         {
             return string.Join(separator, strings.Take(maxCount)) + (strings.Count > maxCount ? separator + "..." : "");

--- a/src/ProgressOnderwijsUtils/Extensions/FileInfoExtension.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/FileInfoExtension.cs
@@ -7,9 +7,10 @@ namespace ProgressOnderwijsUtils
     [CodeThatsOnlyUsedForTests]
     public static class FileInfoExtension
     {
+        [NotNull]
         [Pure]
         [CodeThatsOnlyUsedForTests]
-        public static string ReadToEnd(this FileInfo file)
+        public static string ReadToEnd([NotNull] this FileInfo file)
         {
             using (var reader = file.OpenText())
                 return reader.ReadToEnd();
@@ -20,7 +21,7 @@ namespace ProgressOnderwijsUtils
         /// </summary>
         [Pure]
         [CodeThatsOnlyUsedForTests]
-        public static bool SameContents(this FileInfo one, FileInfo other)
+        public static bool SameContents([NotNull] this FileInfo one, [NotNull] FileInfo other)
         {
             if (other == null) {
                 throw new ArgumentNullException(nameof(other));

--- a/src/ProgressOnderwijsUtils/Extensions/GenericExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/GenericExtensions.cs
@@ -18,7 +18,7 @@ namespace ProgressOnderwijsUtils
         /// Vandaag.In(weekdays.thursday,weekdays.friday); //false
         /// </remarks>
         [Pure]
-        public static bool In<T>(this T obj, params T[] values)
+        public static bool In<T>(this T obj, [NotNull] params T[] values)
             where T : struct, IConvertible, IComparable
         {
             return values.Contains(obj);
@@ -67,11 +67,11 @@ namespace ProgressOnderwijsUtils
         }
 
         [Pure]
-        public static bool In(this string obj, params string[] values) => values.Contains(obj);
+        public static bool In(this string obj, [NotNull] params string[] values) => values.Contains(obj);
 
         [UsefulToKeep("overload")]
         [Pure]
-        public static bool In<T>(this T? obj, params T?[] values)
+        public static bool In<T>(this T? obj, [NotNull] params T?[] values)
             where T : struct, IConvertible, IComparable
         {
             return values.Contains(obj);

--- a/src/ProgressOnderwijsUtils/Extensions/GetResourceExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/GetResourceExtensions.cs
@@ -6,7 +6,8 @@ namespace ProgressOnderwijsUtils
 {
     public static class GetResourceExtensions
     {
+        [CanBeNull]
         [Pure]
-        public static Stream GetResource(this Type type, string filename) => type.Assembly.GetManifestResourceStream(type, filename);
+        public static Stream GetResource([NotNull] this Type type, string filename) => type.Assembly.GetManifestResourceStream(type, filename);
     }
 }

--- a/src/ProgressOnderwijsUtils/Extensions/HttpResponseExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/HttpResponseExtensions.cs
@@ -1,15 +1,16 @@
 ﻿using System.Web;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
     public static class HttpResponseExtensions
     {
-        public static void AddContentDispositionHeader(this HttpResponse response, string fileName)
+        public static void AddContentDispositionHeader([NotNull] this HttpResponse response, string fileName)
         {
             response.AddHeader("Content-Disposition", $"attachment;filename=\"{fileName}\";");
         }
 
-        public static void AddContentDispositionHeader(this HttpResponseBase response, string fileName)
+        public static void AddContentDispositionHeader([NotNull] this HttpResponseBase response, string fileName)
         {
             response.AddHeader("Content-Disposition", $"attachment;filename=\"{fileName}\";");
         }

--- a/src/ProgressOnderwijsUtils/Extensions/SetExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/SetExtensions.cs
@@ -6,6 +6,7 @@ namespace ProgressOnderwijsUtils
 {
     public static class SetExtensions
     {
+        [NotNull]
         [Pure]
         public static ReadOnlySet<T> AsReadOnly<T>(this ISet<T> set)
         {

--- a/src/ProgressOnderwijsUtils/Extensions/StreamExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/StreamExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -8,6 +9,7 @@ namespace ProgressOnderwijsUtils
         /// Reads the specified number of bytes.
         /// </summary>
         /// <exception cref="EndOfStreamException">thrown when EOF is reached before the needed number of bytes are read</exception>
+        [NotNull]
         public static byte[] ReadUntil(this Stream stream, int numberOfBytesToRead)
         {
             var result = new byte[numberOfBytesToRead];

--- a/src/ProgressOnderwijsUtils/Extensions/StringExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/StringExtensions.cs
@@ -14,10 +14,11 @@ namespace ProgressOnderwijsUtils
         /// <param name="s">string to check</param>
         /// <returns>true if string is empty or is null, false otherwise</returns>
         [Pure]
-        public static bool IsNullOrWhiteSpace(this string s) => string.IsNullOrWhiteSpace(s);
+        public static bool IsNullOrWhiteSpace([CanBeNull] this string s) => string.IsNullOrWhiteSpace(s);
 
+        [CanBeNull]
         [Pure]
-        public static string NullIfWhiteSpace(this string str)
+        public static string NullIfWhiteSpace([CanBeNull] this string str)
         {
             if (string.IsNullOrWhiteSpace(str)) {
                 return null;
@@ -31,23 +32,26 @@ namespace ProgressOnderwijsUtils
         /// <summary>
         /// HTML-alike whitespace collapsing of this string; however, this method also trims.
         /// </summary>
+        [NotNull]
         [Pure]
         public static string NormalizeWhitespace(this string str) => str.CollapseWhitespace().Trim();
 
         /// <summary>
         /// HTML-alike whitespace collapsing of this string. This method does not trim.
         /// </summary>
+        [NotNull]
         [Pure]
-        public static string CollapseWhitespace(this string str) => COLLAPSE_WHITESPACE.Replace(str, " ");
+        public static string CollapseWhitespace([NotNull] this string str) => COLLAPSE_WHITESPACE.Replace(str, " ");
 
         [Pure]
         public static bool EqualsOrdinalCaseInsensitive(this string a, string b) => StringComparer.OrdinalIgnoreCase.Equals(a, b);
 
         [Pure]
-        public static bool Contains(this string str, string value, StringComparison compare) => str.IndexOf(value, compare) >= 0;
+        public static bool Contains([NotNull] this string str, [NotNull] string value, StringComparison compare) => str.IndexOf(value, compare) >= 0;
 
+        [CanBeNull]
         [Pure]
-        public static string TrimToLength(this string s, int maxlength)
+        public static string TrimToLength([CanBeNull] this string s, int maxlength)
         {
             if (s == null || s.Length <= maxlength) {
                 return s;
@@ -57,7 +61,7 @@ namespace ProgressOnderwijsUtils
         }
 
         [Pure]
-        public static string Replace(this string s, IEnumerable<KeyValuePair<string, string>> replacements) => replacements.Aggregate(s, (current, replacement) => current.Replace(replacement.Key, replacement.Value));
+        public static string Replace(this string s, [NotNull] IEnumerable<KeyValuePair<string, string>> replacements) => replacements.Aggregate(s, (current, replacement) => current.Replace(replacement.Key, replacement.Value));
 
         /// <summary>
         /// Zet string met alleen hoofdletters om 

--- a/src/ProgressOnderwijsUtils/Extensions/StringExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/StringExtensions.cs
@@ -34,7 +34,7 @@ namespace ProgressOnderwijsUtils
         /// </summary>
         [NotNull]
         [Pure]
-        public static string NormalizeWhitespace(this string str) => str.CollapseWhitespace().Trim();
+        public static string NormalizeWhitespace([NotNull] this string str) => str.CollapseWhitespace().Trim();
 
         /// <summary>
         /// HTML-alike whitespace collapsing of this string. This method does not trim.

--- a/src/ProgressOnderwijsUtils/Extensions/StringFormatter.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/StringFormatter.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Globalization;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
     public static class StringFormatter
     {
-        public static string FormatString(this CultureInfo culture, FormattableString interpolatedString)
+        [NotNull]
+        public static string FormatString(this CultureInfo culture, [NotNull] FormattableString interpolatedString)
         {
             return interpolatedString.ToString(culture);
         }

--- a/src/ProgressOnderwijsUtils/Extensions/StringUtils.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/StringUtils.cs
@@ -107,6 +107,7 @@ namespace ProgressOnderwijsUtils
         [Pure]
         public static string SepaTekenset([NotNull] string s) => SepaStripperRegexes.sepaStripper.Replace(s, "");
 
+        [CanBeNull]
         [Pure]
         public static string SepaTekensetEnModificaties(string s)
         {
@@ -125,7 +126,7 @@ namespace ProgressOnderwijsUtils
         public static string Capitalize([NotNull] string name) => name.Substring(0, 1).ToUpperInvariant() + name.Substring(1);
 
         [Pure]
-        public static int LevenshteinDistance(string s, string t) => LevenshteinDistance(s, t, 1);
+        public static int LevenshteinDistance([NotNull] string s, [NotNull] string t) => LevenshteinDistance(s, t, 1);
 
 
         [Pure]

--- a/src/ProgressOnderwijsUtils/Extensions/StringUtils.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/StringUtils.cs
@@ -15,8 +15,9 @@ namespace ProgressOnderwijsUtils
         /// </summary>
         /// <param name="input">the string to change</param>
         /// <returns>the changed string</returns>
+        [NotNull]
         [Pure]
-        public static string VerwijderDiakrieten(string input)
+        public static string VerwijderDiakrieten([NotNull] string input)
         {
             return
                 new string(
@@ -51,9 +52,10 @@ namespace ProgressOnderwijsUtils
                 sepaStripper = new Regex(@"[^a-zA-z0-9 /-?:().,'+]+", CommonOptions);
         }
 
+        [NotNull]
         [Pure]
         [CodeThatsOnlyUsedForTests]
-        public static string PrettyPrintCamelCased(string rawString)
+        public static string PrettyPrintCamelCased([NotNull] string rawString)
         {
             var withSpace =
                 PrettyPrintValues.capLetter.Replace(
@@ -64,7 +66,7 @@ namespace ProgressOnderwijsUtils
         }
 
         [Pure]
-        static bool IsUpperAscii(string str)
+        static bool IsUpperAscii([NotNull] string str)
         {
             foreach (var c in str) {
                 if (c < 'A' || c > 'Z') {
@@ -74,8 +76,9 @@ namespace ProgressOnderwijsUtils
             return true;
         }
 
+        [NotNull]
         [Pure]
-        static string DecapitalizeAscii(string str)
+        static string DecapitalizeAscii([NotNull] string str)
         {
             if (str[0] >= 'A' && str[0] <= 'Z') {
                 return (char)(str[0] + ('a' - 'A')) + str.Substring(1);
@@ -84,8 +87,9 @@ namespace ProgressOnderwijsUtils
             }
         }
 
+        [NotNull]
         [Pure]
-        public static string PrettyCapitalizedPrintCamelCased(string rawString)
+        public static string PrettyCapitalizedPrintCamelCased([NotNull] string rawString)
         {
             var withSpace =
                 PrettyPrintValues.capLetter.Replace(
@@ -95,11 +99,13 @@ namespace ProgressOnderwijsUtils
             return PrettyPrintValues.whiteSpaceSequence.Replace(withSpace, " ");
         }
 
+        [NotNull]
         [Pure]
-        public static string VervangRingelS(string str, bool upper) => str.Replace("ß", upper ? "SS" : "ss");
+        public static string VervangRingelS([NotNull] string str, bool upper) => str.Replace("ß", upper ? "SS" : "ss");
 
+        [NotNull]
         [Pure]
-        public static string SepaTekenset(string s) => SepaStripperRegexes.sepaStripper.Replace(s, "");
+        public static string SepaTekenset([NotNull] string s) => SepaStripperRegexes.sepaStripper.Replace(s, "");
 
         [Pure]
         public static string SepaTekensetEnModificaties(string s)
@@ -114,15 +120,16 @@ namespace ProgressOnderwijsUtils
             return s;
         }
 
+        [NotNull]
         [Pure]
-        public static string Capitalize(string name) => name.Substring(0, 1).ToUpperInvariant() + name.Substring(1);
+        public static string Capitalize([NotNull] string name) => name.Substring(0, 1).ToUpperInvariant() + name.Substring(1);
 
         [Pure]
         public static int LevenshteinDistance(string s, string t) => LevenshteinDistance(s, t, 1);
 
 
         [Pure]
-        public static int LevenshteinDistance(string s, string t, int substitutionCost)
+        public static int LevenshteinDistance([NotNull] string s, [NotNull] string t, int substitutionCost)
         {
             //modified from:http://www.merriampark.com/ldcsharp.htm by Eamon Nerbonne
             var n = s.Length; //length of s
@@ -151,8 +158,9 @@ namespace ProgressOnderwijsUtils
 
         [Pure]
         [CodeThatsOnlyUsedForTests]
-        public static double LevenshteinDistanceScaled(string s, string t) => LevenshteinDistance(s, t) / (double)Math.Max(1, Math.Max(s.Length, t.Length));
+        public static double LevenshteinDistanceScaled([NotNull] string s, [NotNull] string t) => LevenshteinDistance(s, t) / (double)Math.Max(1, Math.Max(s.Length, t.Length));
 
+        [NotNull]
         [Pure]
         public static string ToFlatDebugString<T>(IEnumerable<T> self)
         {
@@ -206,8 +214,9 @@ namespace ProgressOnderwijsUtils
         [Pure]
         static bool isVowel(char c) => c == 'a' || c == 'e' || c == 'i' || c == 'o' || c == 'u' || c == 'A' || c == 'E' || c == 'I' || c == 'O' || c == 'U';
 
+        [NotNull]
         [Pure]
-        public static string Depluralize(string pluralstring)
+        public static string Depluralize([NotNull] string pluralstring)
         {
             if (pluralstring.EndsWith("s")) {
                 return pluralstring.Remove(pluralstring.Length - 1);

--- a/src/ProgressOnderwijsUtils/Extensions/ToStringInvariantExtension.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/ToStringInvariantExtension.cs
@@ -6,6 +6,7 @@ namespace ProgressOnderwijsUtils
 {
     public static class ToStringInvariantExtension
     {
+        [NotNull]
         [Pure]
         public static string ToStringInvariant<T>(this T val)
             where T : struct, IConvertible
@@ -13,6 +14,7 @@ namespace ProgressOnderwijsUtils
             return val.ToString(CultureInfo.InvariantCulture);
         }
 
+        [NotNull]
         [Pure]
         public static string ToStringInvariant<T>(this T val, string format)
             where T : struct, IFormattable
@@ -20,6 +22,7 @@ namespace ProgressOnderwijsUtils
             return val.ToString(format, CultureInfo.InvariantCulture);
         }
 
+        [NotNull]
         [Pure]
         public static string ToStringInvariant<T>(this T? val)
             where T : struct, IConvertible
@@ -27,6 +30,7 @@ namespace ProgressOnderwijsUtils
             return val == null ? "" : val.Value.ToString(CultureInfo.InvariantCulture);
         }
 
+        [NotNull]
         [Pure]
         public static string ToStringInvariant<T>(this T? val, string format)
             where T : struct, IFormattable
@@ -34,6 +38,7 @@ namespace ProgressOnderwijsUtils
             return val == null ? "" : val.Value.ToString(format, CultureInfo.InvariantCulture);
         }
 
+        [CanBeNull]
         [Pure]
         public static string ToStringInvariantOrNull<T>(this T? val)
             where T : struct, IConvertible
@@ -41,6 +46,7 @@ namespace ProgressOnderwijsUtils
             return val == null ? null : val.Value.ToString(CultureInfo.InvariantCulture);
         }
 
+        [CanBeNull]
         [Pure]
         [UsefulToKeep("Library function, other overloads used")]
         public static string ToStringInvariantOrNull<T>(this T? val, string format)

--- a/src/ProgressOnderwijsUtils/Extensions/TreeExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/TreeExtensions.cs
@@ -7,13 +7,13 @@ namespace ProgressOnderwijsUtils
     public static class TreeExtensions
     {
         [Pure]
-        public static RootedTree<T> RootHere<T>(this Tree<T> tree)
+        public static RootedTree<T> RootHere<T>([NotNull] this Tree<T> tree)
         {
             return RootedTree<T>.RootTree(tree);
         }
 
         [Pure]
-        public static IEnumerable<T> PreorderTraversal<T>(this T tree) where T : IRecursiveStructure<T>
+        public static IEnumerable<T> PreorderTraversal<T>([NotNull] this T tree) where T : IRecursiveStructure<T>
         {
             yield return tree;
 

--- a/src/ProgressOnderwijsUtils/Extensions/TreeExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/TreeExtensions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using JetBrains.Annotations;
 using ProgressOnderwijsUtils.Collections;
 
@@ -12,6 +13,7 @@ namespace ProgressOnderwijsUtils
             return RootedTree<T>.RootTree(tree);
         }
 
+        [ItemNotNull]
         [Pure]
         public static IEnumerable<T> PreorderTraversal<T>([NotNull] this T tree) where T : IRecursiveStructure<T>
         {
@@ -26,7 +28,9 @@ namespace ProgressOnderwijsUtils
                     var children = todo.Peek();
                     if (children.MoveNext()) {
                         var currentNode = children.Current;
+                        // ReSharper disable once AssignNullToNotNullAttribute (todo only contains enumerators containing non-null trees; see IRecursiveStructure.Children)
                         yield return currentNode;
+                        // ReSharper disable once PossibleNullReferenceException (todo only contains enumerators containing non-null trees)
                         todo.Push(currentNode.Children.GetEnumerator());
                     } else {
                         children.Dispose();

--- a/src/ProgressOnderwijsUtils/Extensions/TypeExtension.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/TypeExtension.cs
@@ -12,13 +12,15 @@ namespace ProgressOnderwijsUtils
         /// If type is Nullable&lt;T&gt;, returns typeof(T).  For non-Nullable&lt;&gt; types, returns null;
         /// </summary>
         [Pure]
-        public static Type IfNullableGetNonNullableType(this Type type) => type.IsNullableValueType() ? type.GetGenericArguments()[0] : null;
+        [CanBeNull]
+        public static Type IfNullableGetNonNullableType([NotNull] this Type type) => type.IsNullableValueType() ? type.GetGenericArguments()[0] : null;
 
         /// <summary>
         /// If type is Nullable&lt;T&gt;, returns typeof(T).  For non-Nullable&lt;&gt; types, returns the type itself - this might also be a reference type, so the resulting type may still permit the value null.
         /// </summary>
         [Pure]
-        public static Type GetNonNullableType(this Type type) => type.IsNullableValueType() ? type.GetGenericArguments()[0] : type;
+        [NotNull]
+        public static Type GetNonNullableType([NotNull] this Type type) => type.IsNullableValueType() ? type.GetGenericArguments()[0] : type;
 
         /// <summary>
         /// For enums, nullable types and nullable enums, return non-nullable underlying type;
@@ -27,8 +29,9 @@ namespace ProgressOnderwijsUtils
         /// e.g. typeof(string) => typeof(string)
         /// 
         /// </summary>
+        [NotNull]
         [Pure]
-        public static Type GetNonNullableUnderlyingType(this Type type)
+        public static Type GetNonNullableUnderlyingType([NotNull] this Type type)
         {
             var nonNullableType = type.GetNonNullableType();
             if (nonNullableType.IsEnum) {
@@ -42,7 +45,8 @@ namespace ProgressOnderwijsUtils
         /// Nullability is unaltered; Non-enum types are unaltered.
         /// </summary>
         [Pure]
-        public static Type GetUnderlyingType(this Type type)
+        [NotNull]
+        public static Type GetUnderlyingType([NotNull] this Type type)
         {
             var maybeNonNullable = type.IfNullableGetNonNullableType();
             if (!(maybeNonNullable ?? type).IsEnum) {
@@ -55,19 +59,21 @@ namespace ProgressOnderwijsUtils
         }
 
         [Pure]
-        public static bool CanBeNull(this Type type) => !type.IsValueType || IsNullableValueType(type);
+        public static bool CanBeNull([NotNull] this Type type) => !type.IsValueType || IsNullableValueType(type);
 
         [Pure]
-        public static bool IsNullableValueType(this Type type) => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+        public static bool IsNullableValueType([NotNull] this Type type) => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
 
         /// <summary>
         /// If type is non-Nullable value type T, returns typeof(Nullable&lt;T&gt;).  For Nullable&lt;&gt; or reference types, returns null;
         /// </summary>
+        [CanBeNull]
         [Pure]
-        public static Type MakeNullableType(this Type type) => type.CanBeNull() ? null : typeof(Nullable<>).MakeGenericType(type);
+        public static Type MakeNullableType([NotNull] this Type type) => type.CanBeNull() ? null : typeof(Nullable<>).MakeGenericType(type);
 
+        [ItemNotNull]
         [Pure]
-        public static IEnumerable<Type> BaseTypes(this Type type)
+        public static IEnumerable<Type> BaseTypes([CanBeNull] this Type type)
         {
             if (null == type) {
                 yield break;
@@ -79,8 +85,9 @@ namespace ProgressOnderwijsUtils
             }
         }
 
+        [NotNull]
         [Pure]
-        public static string GetNonGenericName(this Type type)
+        public static string GetNonGenericName([NotNull] this Type type)
         {
             var typename = type.FullName;
             // ReSharper disable PossibleNullReferenceException
@@ -93,7 +100,6 @@ namespace ProgressOnderwijsUtils
         public static string FriendlyName(this Type type) => type.ToCSharpFriendlyTypeName();
 
         [Pure]
-        [CodeThatsOnlyUsedForTests]
         public static T Attr<T>(this MemberInfo mi) where T : Attribute
         {
             var customAttributes = mi.GetCustomAttributes(typeof(T), true);

--- a/src/ProgressOnderwijsUtils/Extensions/TypeExtension.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/TypeExtension.cs
@@ -100,7 +100,7 @@ namespace ProgressOnderwijsUtils
         public static string FriendlyName(this Type type) => type.ToCSharpFriendlyTypeName();
 
         [Pure]
-        public static T Attr<T>(this MemberInfo mi) where T : Attribute
+        public static T Attr<T>([NotNull] this MemberInfo mi) where T : Attribute
         {
             var customAttributes = mi.GetCustomAttributes(typeof(T), true);
             if (customAttributes.Length == 0) {

--- a/src/ProgressOnderwijsUtils/Extensions/XmlExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/XmlExtensions.cs
@@ -1,11 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Xml;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
     public static class XmlExtensions
     {
-        public static IDictionary<string, string> GetAttributes(this XmlReader reader)
+        [NotNull]
+        public static IDictionary<string, string> GetAttributes([NotNull] this XmlReader reader)
         {
             var result = new Dictionary<string, string>();
             if (reader.HasAttributes) {

--- a/src/ProgressOnderwijsUtils/HandlerUtils.cs
+++ b/src/ProgressOnderwijsUtils/HandlerUtils.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -12,6 +13,7 @@ namespace ProgressOnderwijsUtils
         /// Only one output event can be called simultaneously, so if the handler takes longer than "delay" then the next call will start after the previous has ended.
         /// Only one such 
         /// </summary>
+        [NotNull]
         public static Action Debounce(TimeSpan delay, Action handler)
         {
             var sync = new object();

--- a/src/ProgressOnderwijsUtils/HashCodeHelper.cs
+++ b/src/ProgressOnderwijsUtils/HashCodeHelper.cs
@@ -1,8 +1,10 @@
-﻿namespace ProgressOnderwijsUtils
+﻿using JetBrains.Annotations;
+
+namespace ProgressOnderwijsUtils
 {
     public static class HashCodeHelper
     {
-        public static int ComputeHash(params object[] obj)
+        public static int ComputeHash([NotNull] params object[] obj)
         {
             ulong res = 0;
             for (uint i = 0; i < obj.Length; i++) {

--- a/src/ProgressOnderwijsUtils/Html/CustomHtmlElement.cs
+++ b/src/ProgressOnderwijsUtils/Html/CustomHtmlElement.cs
@@ -4,7 +4,7 @@ namespace ProgressOnderwijsUtils.Html
 {
     public struct CustomHtmlElement : IHtmlTagAllowingContent<CustomHtmlElement>
     {
-        public CustomHtmlElement(string tagName, HtmlAttribute[] attributes, HtmlFragment[] childNodes)
+        public CustomHtmlElement(string tagName, [CanBeNull] HtmlAttribute[] attributes, [CanBeNull] HtmlFragment[] childNodes)
             : this(tagName,
                 attributes == null || attributes.Length == 0 ? HtmlAttributes.Empty : HtmlAttributes.FromArray(attributes),
                 childNodes == null || childNodes.Length == 0 ? null : childNodes) { }
@@ -30,7 +30,9 @@ namespace ProgressOnderwijsUtils.Html
         [Pure]
         public HtmlFragment AsFragment() => this;
 
+        [NotNull]
         string IHtmlTag.TagStart => "<" + TagName;
+        [NotNull]
         string IHtmlTag.EndTag => Contents != null || !TagDescription.LookupTag(TagName).IsSelfClosing ? "</" + TagName + ">" : "";
 
         /// <summary>
@@ -44,7 +46,8 @@ namespace ProgressOnderwijsUtils.Html
                 : HtmlTagAlterations.ReplaceAttributesAndContents(tagDescription.EmptyValue, Attributes, Contents);
         }
 
-        IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>(THtmlTagAlteration change) => change.ChangeWithContent(this);
+        [NotNull]
+        IHtmlTag IHtmlTag.ApplyChange<THtmlTagAlteration>([NotNull] THtmlTagAlteration change) => change.ChangeWithContent(this);
         CustomHtmlElement IHtmlTag<CustomHtmlElement>.WithAttributes(HtmlAttributes replacementAttributes) => new CustomHtmlElement(TagName, replacementAttributes, Contents);
         CustomHtmlElement IHtmlTagAllowingContent<CustomHtmlElement>.WithContents(HtmlFragment[] replacementContents) => new CustomHtmlElement(TagName, Attributes, replacementContents);
     }

--- a/src/ProgressOnderwijsUtils/Html/HtmlAttribute.cs
+++ b/src/ProgressOnderwijsUtils/Html/HtmlAttribute.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils.Html
 {
@@ -74,6 +75,7 @@ namespace ProgressOnderwijsUtils.Html
             }
 
             public HtmlAttribute Current => attributes[pos];
+            [NotNull]
             object IEnumerator.Current => attributes[pos];
             public void Dispose() { }
             public bool MoveNext() => ++pos < count;
@@ -81,7 +83,7 @@ namespace ProgressOnderwijsUtils.Html
         }
 
         public static HtmlAttributes Empty => default(HtmlAttributes);
-        public static HtmlAttributes FromArray(HtmlAttribute[] arr) => new HtmlAttributes(arr, arr.Length);
+        public static HtmlAttributes FromArray([NotNull] HtmlAttribute[] arr) => new HtmlAttributes(arr, arr.Length);
         public override string ToString() => string.Join("; ", this);
     }
 }

--- a/src/ProgressOnderwijsUtils/Html/HtmlFragment.cs
+++ b/src/ProgressOnderwijsUtils/Html/HtmlFragment.cs
@@ -32,7 +32,7 @@ namespace ProgressOnderwijsUtils.Html
         public static HtmlFragment HtmlElement(string tagName, HtmlAttribute[] attributes, HtmlFragment[] childNodes) => HtmlElement(new CustomHtmlElement(tagName, attributes, childNodes));
 
         [Pure]
-        public static HtmlFragment Fragment(params HtmlFragment[] htmlEls)
+        public static HtmlFragment Fragment([CanBeNull] params HtmlFragment[] htmlEls)
             => htmlEls == null || htmlEls.Length == 0
                 ? Empty
                 : htmlEls.Length == 1
@@ -40,7 +40,7 @@ namespace ProgressOnderwijsUtils.Html
                     : new HtmlFragment(htmlEls);
 
         [Pure]
-        public static HtmlFragment Fragment<T>(IEnumerable<T> htmlEls)
+        public static HtmlFragment Fragment<T>([NotNull] IEnumerable<T> htmlEls)
             where T : IConvertibleToFragment
             => Fragment(htmlEls.Select(el => el.AsFragment()).Where(f => !f.IsEmpty).ToArray());
 

--- a/src/ProgressOnderwijsUtils/Html/HtmlTagAlterations.cs
+++ b/src/ProgressOnderwijsUtils/Html/HtmlTagAlterations.cs
@@ -1,18 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils.Html
 {
     public static class HtmlTagAlterations
     {
-        public static IHtmlTag ReplaceAttributes(IHtmlTag tag, HtmlAttributes attributes) => tag.ApplyChange(new HtmlTagAtributeAlteration(attributes));
-        public static IHtmlTag ReplaceAttributes(IHtmlTag tag, IEnumerable<HtmlAttribute> attributes) => tag.ApplyChange(new HtmlTagAtributeAlteration(attributes.ToHtmlAttributes()));
-        public static IHtmlTagAllowingContent ReplaceContents(IHtmlTagAllowingContent tag, HtmlFragment[] children) => (IHtmlTagAllowingContent)tag.ApplyChange(new HtmlTagContentAlteration(children));
+        public static IHtmlTag ReplaceAttributes([NotNull] IHtmlTag tag, HtmlAttributes attributes) => tag.ApplyChange(new HtmlTagAtributeAlteration(attributes));
+        public static IHtmlTag ReplaceAttributes([NotNull] IHtmlTag tag, IEnumerable<HtmlAttribute> attributes) => tag.ApplyChange(new HtmlTagAtributeAlteration(attributes.ToHtmlAttributes()));
+        public static IHtmlTagAllowingContent ReplaceContents([NotNull] IHtmlTagAllowingContent tag, HtmlFragment[] children) => (IHtmlTagAllowingContent)tag.ApplyChange(new HtmlTagContentAlteration(children));
 
         public static IHtmlTag ReplaceAttributesAndContents(IHtmlTag tag, IEnumerable<HtmlAttribute> attributes, HtmlFragment[] children)
             => ReplaceAttributesAndContents(tag, attributes.ToHtmlAttributes(), children);
 
-        public static IHtmlTag ReplaceAttributesAndContents(IHtmlTag tag, HtmlAttributes attributes, HtmlFragment[] children)
+        public static IHtmlTag ReplaceAttributesAndContents([NotNull] IHtmlTag tag, HtmlAttributes attributes, [CanBeNull] HtmlFragment[] children)
         {
             if (children != null && children.Length > 0 && !(tag is IHtmlTagAllowingContent)) {
                 throw new InvalidOperationException("Cannot insert content into empty tag");

--- a/src/ProgressOnderwijsUtils/Html/HtmlTagAlterations.cs
+++ b/src/ProgressOnderwijsUtils/Html/HtmlTagAlterations.cs
@@ -7,10 +7,10 @@ namespace ProgressOnderwijsUtils.Html
     public static class HtmlTagAlterations
     {
         public static IHtmlTag ReplaceAttributes([NotNull] IHtmlTag tag, HtmlAttributes attributes) => tag.ApplyChange(new HtmlTagAtributeAlteration(attributes));
-        public static IHtmlTag ReplaceAttributes([NotNull] IHtmlTag tag, IEnumerable<HtmlAttribute> attributes) => tag.ApplyChange(new HtmlTagAtributeAlteration(attributes.ToHtmlAttributes()));
+        public static IHtmlTag ReplaceAttributes([NotNull] IHtmlTag tag, [NotNull] IEnumerable<HtmlAttribute> attributes) => tag.ApplyChange(new HtmlTagAtributeAlteration(attributes.ToHtmlAttributes()));
         public static IHtmlTagAllowingContent ReplaceContents([NotNull] IHtmlTagAllowingContent tag, HtmlFragment[] children) => (IHtmlTagAllowingContent)tag.ApplyChange(new HtmlTagContentAlteration(children));
 
-        public static IHtmlTag ReplaceAttributesAndContents(IHtmlTag tag, IEnumerable<HtmlAttribute> attributes, HtmlFragment[] children)
+        public static IHtmlTag ReplaceAttributesAndContents([NotNull] IHtmlTag tag, [NotNull] IEnumerable<HtmlAttribute> attributes, HtmlFragment[] children)
             => ReplaceAttributesAndContents(tag, attributes.ToHtmlAttributes(), children);
 
         public static IHtmlTag ReplaceAttributesAndContents([NotNull] IHtmlTag tag, HtmlAttributes attributes, [CanBeNull] HtmlFragment[] children)

--- a/src/ProgressOnderwijsUtils/Html/HtmlTagHelpers.cs
+++ b/src/ProgressOnderwijsUtils/Html/HtmlTagHelpers.cs
@@ -10,7 +10,7 @@ namespace ProgressOnderwijsUtils.Html
     public static class HtmlTagHelpers
     {
         [Pure]
-        public static THtmlTag Attributes<THtmlTag>(this THtmlTag htmlTagExpr, IEnumerable<HtmlAttribute> attributes)
+        public static THtmlTag Attributes<THtmlTag>(this THtmlTag htmlTagExpr, [NotNull] IEnumerable<HtmlAttribute> attributes)
             where THtmlTag : struct, IHtmlTag<THtmlTag>
         {
             foreach (var attribute in attributes) {
@@ -20,7 +20,7 @@ namespace ProgressOnderwijsUtils.Html
         }
 
         [Pure]
-        public static THtmlTag Contents<THtmlTag, TContent>(this THtmlTag htmlTagExpr, IEnumerable<TContent> contents)
+        public static THtmlTag Contents<THtmlTag, TContent>(this THtmlTag htmlTagExpr, [NotNull] IEnumerable<TContent> contents)
             where THtmlTag : struct, IHtmlTagAllowingContent<THtmlTag>
             where TContent : IConvertibleToFragment
             => htmlTagExpr.Content(contents.Select(el => el.AsFragment()).ToArray());
@@ -48,12 +48,12 @@ namespace ProgressOnderwijsUtils.Html
             => attributeOrNull == null ? htmlTagExpr : htmlTagExpr.Attribute(attributeOrNull.Value);
 
         [Pure]
-        public static THtmlTag Attribute<THtmlTag>(this THtmlTag htmlTagExpr, string attrName, string attrValue)
+        public static THtmlTag Attribute<THtmlTag>(this THtmlTag htmlTagExpr, string attrName, [CanBeNull] string attrValue)
             where THtmlTag : struct, IHtmlTag<THtmlTag>
             => attrValue == null ? htmlTagExpr : htmlTagExpr.WithAttributes(htmlTagExpr.Attributes.Add(attrName, attrValue));
 
         [Pure]
-        public static HtmlFragment WrapInHtmlFragment<T>(this IEnumerable<T> htmlEls)
+        public static HtmlFragment WrapInHtmlFragment<T>([NotNull] this IEnumerable<T> htmlEls)
             where T : IConvertibleToFragment
             => HtmlFragment.Fragment(htmlEls.Select(el => el.AsFragment()).Where(frag=>!frag.IsEmpty).ToArray());
 
@@ -61,7 +61,7 @@ namespace ProgressOnderwijsUtils.Html
             where TContent : struct, IConvertibleToFragment
             => htmlFragmentOrNull?.AsFragment() ?? HtmlFragment.Empty;
 
-        public static HtmlFragment JoinHtml<TFragments>(this IEnumerable<TFragments> htmlEls, HtmlFragment joiner)
+        public static HtmlFragment JoinHtml<TFragments>([NotNull] this IEnumerable<TFragments> htmlEls, HtmlFragment joiner)
             where TFragments : IConvertibleToFragment
         {
             using (var enumerator = htmlEls.GetEnumerator()) {
@@ -82,9 +82,10 @@ namespace ProgressOnderwijsUtils.Html
             }
         }
 
+        [NotNull]
         public static HtmlFragment[] Children(this IHtmlTag element) => (element as IHtmlTagAllowingContent)?.Contents ?? Array.Empty<HtmlFragment>();
 
-        public static HtmlAttributes ToHtmlAttributes(this IEnumerable<HtmlAttribute> attributes)
+        public static HtmlAttributes ToHtmlAttributes([NotNull] this IEnumerable<HtmlAttribute> attributes)
             => attributes as HtmlAttributes? ?? HtmlAttributes.FromArray(attributes as HtmlAttribute[] ?? attributes.ToArray());
     }
 }

--- a/src/ProgressOnderwijsUtils/Html/HtmlTagHelpers.cs
+++ b/src/ProgressOnderwijsUtils/Html/HtmlTagHelpers.cs
@@ -61,7 +61,7 @@ namespace ProgressOnderwijsUtils.Html
             where TContent : struct, IConvertibleToFragment
             => htmlFragmentOrNull?.AsFragment() ?? HtmlFragment.Empty;
 
-        public static HtmlFragment JoinHtml<TFragments>([NotNull] this IEnumerable<TFragments> htmlEls, HtmlFragment joiner)
+        public static HtmlFragment JoinHtml<TFragments>([NotNull, ItemNotNull] this IEnumerable<TFragments> htmlEls, HtmlFragment joiner)
             where TFragments : IConvertibleToFragment
         {
             using (var enumerator = htmlEls.GetEnumerator()) {
@@ -70,12 +70,14 @@ namespace ProgressOnderwijsUtils.Html
                 }
                 var retval = FastArrayBuilder<HtmlFragment>.Create();
                 var joinerIsNonEmpty = !joiner.IsEmpty;
+                // ReSharper disable once PossibleNullReferenceException
                 var firstNode = enumerator.Current.AsFragment();
                 retval.Add(firstNode);
                 while (enumerator.MoveNext()) {
                     if (joinerIsNonEmpty) {
                         retval.Add(joiner);
                     }
+                    // ReSharper disable once PossibleNullReferenceException
                     retval.Add(enumerator.Current.AsFragment());
                 }
                 return HtmlFragment.Fragment(retval.ToArray());

--- a/src/ProgressOnderwijsUtils/Html/HtmlToCSharp.cs
+++ b/src/ProgressOnderwijsUtils/Html/HtmlToCSharp.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using ExpressionToCodeLib;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils.Html
 {
@@ -48,7 +49,7 @@ namespace ProgressOnderwijsUtils.Html
             }
         }
 
-        static void AppendCommaSeparatedFragments(ref FastShortStringBuilder stringBuilder, HtmlFragment[] fragments, int subIndent)
+        static void AppendCommaSeparatedFragments(ref FastShortStringBuilder stringBuilder, [NotNull] HtmlFragment[] fragments, int subIndent)
         {
             var isSubsequent = false;
             foreach (var fragment in fragments) {

--- a/src/ProgressOnderwijsUtils/Html/HtmlToCSharp.cs
+++ b/src/ProgressOnderwijsUtils/Html/HtmlToCSharp.cs
@@ -7,6 +7,7 @@ namespace ProgressOnderwijsUtils.Html
 {
     public static class HtmlToCSharp
     {
+        [NotNull]
         public static string ToCSharp(this HtmlFragment fragment)
         {
             var builder = FastShortStringBuilder.Create();

--- a/src/ProgressOnderwijsUtils/Html/HtmlToStringExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Html/HtmlToStringExtensions.cs
@@ -8,6 +8,7 @@ namespace ProgressOnderwijsUtils.Html
 {
     public static class HtmlToStringExtensions
     {
+        [NotNull]
         public static string SerializeToString([NotNull] this IConvertibleToFragment rootElem)
         {
             var fastStringBuilder = FastShortStringBuilder.Create(1u << 16);
@@ -18,6 +19,7 @@ namespace ProgressOnderwijsUtils.Html
 
         public static string ToCSharp([NotNull] this IConvertibleToFragment rootElem) => rootElem.AsFragment().ToCSharp();
 
+        [NotNull]
         public static string SerializeToStringWithoutDoctype([NotNull] this IConvertibleToFragment rootElem)
         {
             var fastStringBuilder = FastShortStringBuilder.Create(1u << 16);

--- a/src/ProgressOnderwijsUtils/Html/HtmlToStringExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Html/HtmlToStringExtensions.cs
@@ -2,12 +2,13 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils.Html
 {
     public static class HtmlToStringExtensions
     {
-        public static string SerializeToString(this IConvertibleToFragment rootElem)
+        public static string SerializeToString([NotNull] this IConvertibleToFragment rootElem)
         {
             var fastStringBuilder = FastShortStringBuilder.Create(1u << 16);
             fastStringBuilder.AppendText("<!DOCTYPE html>");
@@ -15,16 +16,16 @@ namespace ProgressOnderwijsUtils.Html
             return fastStringBuilder.FinishBuilding();
         }
 
-        public static string ToCSharp(this IConvertibleToFragment rootElem) => rootElem.AsFragment().ToCSharp();
+        public static string ToCSharp([NotNull] this IConvertibleToFragment rootElem) => rootElem.AsFragment().ToCSharp();
 
-        public static string SerializeToStringWithoutDoctype(this IConvertibleToFragment rootElem)
+        public static string SerializeToStringWithoutDoctype([NotNull] this IConvertibleToFragment rootElem)
         {
             var fastStringBuilder = FastShortStringBuilder.Create(1u << 16);
             AppendToBuilder(ref fastStringBuilder, rootElem.AsFragment());
             return fastStringBuilder.FinishBuilding();
         }
 
-        public static void SaveHtmlFragmentToStream(this HtmlFragment rootElem, Stream outputStream, Encoding contentEncoding)
+        public static void SaveHtmlFragmentToStream(this HtmlFragment rootElem, Stream outputStream, [NotNull] Encoding contentEncoding)
         {
             var fastStringBuilder = FastShortStringBuilder.Create(1u << 16);
             fastStringBuilder.AppendText("<!DOCTYPE html>");
@@ -65,7 +66,7 @@ namespace ProgressOnderwijsUtils.Html
             }
         }
 
-        static void AppendTagContentAndEnd(ref FastShortStringBuilder stringBuilder, IHtmlTagAllowingContent htmlTagAllowingContent)
+        static void AppendTagContentAndEnd(ref FastShortStringBuilder stringBuilder, [NotNull] IHtmlTagAllowingContent htmlTagAllowingContent)
         {
             var contents = htmlTagAllowingContent.Contents ?? Array.Empty<HtmlFragment>();
             if (htmlTagAllowingContent.TagName.EqualsOrdinalCaseInsensitive("SCRIPT") || htmlTagAllowingContent.TagName.EqualsOrdinalCaseInsensitive("STYLE")) {
@@ -119,7 +120,7 @@ namespace ProgressOnderwijsUtils.Html
             }
         }
 
-        static void AppendEscapedText(ref FastShortStringBuilder stringBuilder, string stringContent)
+        static void AppendEscapedText(ref FastShortStringBuilder stringBuilder, [NotNull] string stringContent)
         {
             var uptoIndex = 0;
             for (var textIndex = 0; textIndex < stringContent.Length; textIndex++) {
@@ -146,7 +147,7 @@ namespace ProgressOnderwijsUtils.Html
             stringBuilder.AppendText(stringContent, uptoIndex, stringContent.Length - uptoIndex);
         }
 
-        static void AppendEscapedAttributeValue(ref FastShortStringBuilder stringBuilder, string attrValue)
+        static void AppendEscapedAttributeValue(ref FastShortStringBuilder stringBuilder, [NotNull] string attrValue)
         {
             var uptoIndex = 0;
             for (var textIndex = 0; textIndex < attrValue.Length; textIndex++) {

--- a/src/ProgressOnderwijsUtils/Html/HtmlToStringExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Html/HtmlToStringExtensions.cs
@@ -17,6 +17,7 @@ namespace ProgressOnderwijsUtils.Html
             return fastStringBuilder.FinishBuilding();
         }
 
+        [NotNull]
         public static string ToCSharp([NotNull] this IConvertibleToFragment rootElem) => rootElem.AsFragment().ToCSharp();
 
         [NotNull]

--- a/src/ProgressOnderwijsUtils/Html/HtmlToTextContent.cs
+++ b/src/ProgressOnderwijsUtils/Html/HtmlToTextContent.cs
@@ -1,7 +1,10 @@
+using JetBrains.Annotations;
+
 namespace ProgressOnderwijsUtils.Html
 {
     public static class HtmlToTextContent
     {
+        [NotNull]
         public static string TextContent(this HtmlFragment fragment)
         {
             var fastStringBuilder = FastShortStringBuilder.Create();

--- a/src/ProgressOnderwijsUtils/Html/TagDescription.cs
+++ b/src/ProgressOnderwijsUtils/Html/TagDescription.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils.Html
 {
@@ -30,6 +31,7 @@ namespace ProgressOnderwijsUtils.Html
                     StringComparer.OrdinalIgnoreCase
                 );
 
+        [NotNull]
         static Dictionary<string, string> AttributeLookup(Type tagType, IHtmlTag emptyValue)
         {
             return typeof(AttributeConstructionMethods)
@@ -47,7 +49,7 @@ namespace ProgressOnderwijsUtils.Html
                     StringComparer.OrdinalIgnoreCase);
         }
 
-        public static TagDescription LookupTag(string tagName)
+        public static TagDescription LookupTag([NotNull] string tagName)
             =>
                 ByTagName.TryGetValue(tagName, out var desc)
                     ? desc

--- a/src/ProgressOnderwijsUtils/HtmlEntityLookup.cs
+++ b/src/ProgressOnderwijsUtils/HtmlEntityLookup.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -9,7 +10,7 @@ namespace ProgressOnderwijsUtils
         /// </summary>
         /// <param name="entity">an entity reference without the preceding '&' and terminating ';'</param>
         /// <returns>the character corresponding to the entity, or null if no such entity is defined in HTML</returns>
-        public static char? Lookup(string entity) => lookup.GetOrDefaultR(entity, default(char?));
+        public static char? Lookup([NotNull] string entity) => lookup.GetOrDefaultR(entity, default(char?));
 
         /// <summary>
         /// All known HTML entities.  Includes xml entities; e.g. "lt", "gt" and "amp".

--- a/src/ProgressOnderwijsUtils/ImageTools.cs
+++ b/src/ProgressOnderwijsUtils/ImageTools.cs
@@ -102,7 +102,7 @@ namespace ProgressOnderwijsUtils
         /// <param name="targetHeight">The target height</param>
         /// <returns>The bytes of the resulting JPEG, or NULL if the original is corrupt or too large.</returns>
         [CanBeNull]
-        public static byte[] Downscale_Clip_ConvertToJpeg(byte[] origImageData, int targetWidth, int targetHeight)
+        public static byte[] Downscale_Clip_ConvertToJpeg([NotNull] byte[] origImageData, int targetWidth, int targetHeight)
         {
             using (var uploadedImage = ToImage(origImageData)) {
                 var oldHeight = uploadedImage.Height;
@@ -154,7 +154,7 @@ namespace ProgressOnderwijsUtils
             }
         }
 
-        public static void SaveResizedImage(byte[] pasfoto, int targetWidth, int targetHeight, Stream outputStream)
+        public static void SaveResizedImage([NotNull] byte[] pasfoto, int targetWidth, int targetHeight, [NotNull] Stream outputStream)
         {
             using (var fromDatabase = ToImage(pasfoto))
                 if (fromDatabase.Height == targetHeight) {

--- a/src/ProgressOnderwijsUtils/ImageTools.cs
+++ b/src/ProgressOnderwijsUtils/ImageTools.cs
@@ -3,6 +3,7 @@ using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
+using JetBrains.Annotations;
 
 //this is not recommended?? downsides are unclear though some suggest it might be slow.
 
@@ -21,7 +22,7 @@ namespace ProgressOnderwijsUtils
         /// <summary>
         /// Sets a graphics object to use high quality primitives (mostly for various scaling/blending operations)
         /// </summary>
-        public static void setHQ(Graphics g)
+        public static void setHQ([NotNull] Graphics g)
         {
             g.SmoothingMode = SmoothingMode.HighQuality;
             g.PixelOffsetMode = PixelOffsetMode.HighQuality;
@@ -29,7 +30,8 @@ namespace ProgressOnderwijsUtils
             g.InterpolationMode = InterpolationMode.HighQualityBicubic;
         }
 
-        public static Bitmap Resize(Image oldImage, int newWidth, int newHeight)
+        [NotNull]
+        public static Bitmap Resize([NotNull] Image oldImage, int newWidth, int newHeight)
         {
             Bitmap bitmap = null;
             try {
@@ -56,7 +58,8 @@ namespace ProgressOnderwijsUtils
         /// <param name="newWidth">The target width</param>
         /// <param name="newHeight">The target height</param>
         /// <returns>A new Bitmap (don't forget to Dispose it!)</returns>
-        public static Bitmap DownscaleAndClip(Image oldImage, int newWidth, int newHeight)
+        [NotNull]
+        public static Bitmap DownscaleAndClip([NotNull] Image oldImage, int newWidth, int newHeight)
         {
             var oldWidth = oldImage.Width;
             var oldHeight = oldImage.Height;
@@ -98,6 +101,7 @@ namespace ProgressOnderwijsUtils
         /// <param name="targetWidth">The target width</param>
         /// <param name="targetHeight">The target height</param>
         /// <returns>The bytes of the resulting JPEG, or NULL if the original is corrupt or too large.</returns>
+        [CanBeNull]
         public static byte[] Downscale_Clip_ConvertToJpeg(byte[] origImageData, int targetWidth, int targetHeight)
         {
             using (var uploadedImage = ToImage(origImageData)) {
@@ -116,7 +120,8 @@ namespace ProgressOnderwijsUtils
         }
 
         const int MAX_IMAGE_DIMENSION = 10000; //10 000 by 10 000 is quite insane ;-)
-        public static Image ToImage(byte[] arr) => Image.FromStream(new MemoryStream(arr), true, true);
+        [NotNull]
+        public static Image ToImage([NotNull] byte[] arr) => Image.FromStream(new MemoryStream(arr), true, true);
 
         /// <summary>
         /// Given a width and a height, and a aspect ratio, computes the clipping rectangle fitting within that width and height but of the right aspect ratio.
@@ -140,7 +145,7 @@ namespace ProgressOnderwijsUtils
             return new Rectangle(clipX, clipY, clipWidth, clipHeight);
         }
 
-        public static void SaveImageAsJpeg(Image image, Stream outputStream, int? quality = null)
+        public static void SaveImageAsJpeg([NotNull] Image image, [NotNull] Stream outputStream, int? quality = null)
         {
             var jpgInfo = ImageCodecInfo.GetImageEncoders().First(codecInfo => codecInfo.MimeType == "image/jpeg");
             using (var encParams = new EncoderParameters(1)) {

--- a/src/ProgressOnderwijsUtils/InstalledFileStore.cs
+++ b/src/ProgressOnderwijsUtils/InstalledFileStore.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -12,7 +13,8 @@ namespace ProgressOnderwijsUtils
         const string PrivateBinPath = @"bin;bin\Release";
 #endif
 
-        public static string FileLocation(string name)
+        [NotNull]
+        public static string FileLocation([NotNull] string name)
         {
             var searchPaths = new[] { string.Empty }
                 .Concat((AppDomain.CurrentDomain.RelativeSearchPath ?? PrivateBinPath).Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))

--- a/src/ProgressOnderwijsUtils/LineScanner.cs
+++ b/src/ProgressOnderwijsUtils/LineScanner.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -7,11 +8,12 @@ namespace ProgressOnderwijsUtils
         readonly string[] lines;
         int position;
 
-        public LineScanner(string s)
+        public LineScanner([NotNull] string s)
         {
             lines = Regex.Split(s, "\r\n|\n");
         }
 
+        [CanBeNull]
         public string GetLine() => position != lines.Length ? lines[position++] : null;
 
         public void PushBack()

--- a/src/ProgressOnderwijsUtils/Log4Net/ILogExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Log4Net/ILogExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JetBrains.Annotations;
 using log4net;
 
 namespace ProgressOnderwijsUtils.Log4Net
@@ -8,133 +9,133 @@ namespace ProgressOnderwijsUtils.Log4Net
         // ReSharper disable UnusedMember.Global
         // Utility methods, and we want people to see those as alternatives,
         // since logging might be expensive, and it's good to see the alternative
-        public static void Debug(this ILog log, Func<object> msg)
+        public static void Debug([NotNull] this ILog log, Func<object> msg)
         {
             if (log.IsDebugEnabled) {
                 log.Debug(msg());
             }
         }
 
-        public static void Debug(this ILog log, Func<object> msg, Exception exception)
+        public static void Debug([NotNull] this ILog log, Func<object> msg, Exception exception)
         {
             if (log.IsDebugEnabled) {
                 log.Debug(msg(), exception);
             }
         }
 
-        public static void Debug(this Lazy<ILog> log, Func<object> msg)
+        public static void Debug([NotNull] this Lazy<ILog> log, Func<object> msg)
         {
             if (log.Value.IsDebugEnabled) {
                 log.Value.Debug(msg());
             }
         }
 
-        public static void Debug(this Lazy<ILog> log, object msg)
+        public static void Debug([NotNull] this Lazy<ILog> log, object msg)
         {
             log.Value.Debug(msg);
         }
 
-        public static void DebugFormat(this Lazy<ILog> log, string format, params object[] args)
+        public static void DebugFormat([NotNull] this Lazy<ILog> log, string format, params object[] args)
         {
             log.Value.DebugFormat(format, args);
         }
 
-        public static void Info(this ILog log, Func<object> msg)
+        public static void Info([NotNull] this ILog log, Func<object> msg)
         {
             if (log.IsInfoEnabled) {
                 log.Info(msg());
             }
         }
 
-        public static void Info(this ILog log, Func<object> msg, Exception exception)
+        public static void Info([NotNull] this ILog log, Func<object> msg, Exception exception)
         {
             if (log.IsInfoEnabled) {
                 log.Info(msg(), exception);
             }
         }
 
-        public static void Info(this Lazy<ILog> log, Func<object> msg)
+        public static void Info([NotNull] this Lazy<ILog> log, Func<object> msg)
         {
             if (log.Value.IsInfoEnabled) {
                 log.Value.Info(msg());
             }
         }
 
-        public static void Info(this Lazy<ILog> log, object msg)
+        public static void Info([NotNull] this Lazy<ILog> log, object msg)
         {
             log.Value.Info(msg);
         }
 
-        public static void Warn(this ILog log, Func<object> msg)
+        public static void Warn([NotNull] this ILog log, Func<object> msg)
         {
             if (log.IsWarnEnabled) {
                 log.Warn(msg());
             }
         }
 
-        public static void Warn(this ILog log, Func<object> msg, Exception exception)
+        public static void Warn([NotNull] this ILog log, Func<object> msg, Exception exception)
         {
             if (log.IsWarnEnabled) {
                 log.Warn(msg(), exception);
             }
         }
 
-        public static void Warn(this Lazy<ILog> log, Func<object> msg)
+        public static void Warn([NotNull] this Lazy<ILog> log, Func<object> msg)
         {
             if (log.Value.IsWarnEnabled) {
                 log.Value.Warn(msg());
             }
         }
 
-        public static void Warn(this Lazy<ILog> log, object msg)
+        public static void Warn([NotNull] this Lazy<ILog> log, object msg)
         {
             log.Value.Warn(msg);
         }
 
-        public static void WarnFormat(this Lazy<ILog> log, string format, params object[] args)
+        public static void WarnFormat([NotNull] this Lazy<ILog> log, string format, params object[] args)
         {
             log.Value.WarnFormat(format, args);
         }
 
-        public static void Error(this ILog log, Func<object> msg)
+        public static void Error([NotNull] this ILog log, Func<object> msg)
         {
             if (log.IsErrorEnabled) {
                 log.Error(msg());
             }
         }
 
-        public static void Error(this ILog log, Func<object> msg, Exception exception)
+        public static void Error([NotNull] this ILog log, Func<object> msg, Exception exception)
         {
             if (log.IsErrorEnabled) {
                 log.Error(msg(), exception);
             }
         }
 
-        public static void Error(this Lazy<ILog> log, Func<object> msg)
+        public static void Error([NotNull] this Lazy<ILog> log, Func<object> msg)
         {
             if (log.Value.IsErrorEnabled) {
                 log.Value.Error(msg());
             }
         }
 
-        public static void Error(this Lazy<ILog> log, object msg)
+        public static void Error([NotNull] this Lazy<ILog> log, object msg)
         {
             log.Value.Error(msg);
         }
 
-        public static void ErrorFormat(this Lazy<ILog> log, string format, params object[] args)
+        public static void ErrorFormat([NotNull] this Lazy<ILog> log, string format, params object[] args)
         {
             log.Value.ErrorFormat(format, args);
         }
 
-        public static void Fatal(this ILog log, Func<object> msg)
+        public static void Fatal([NotNull] this ILog log, Func<object> msg)
         {
             if (log.IsFatalEnabled) {
                 log.Fatal(msg());
             }
         }
 
-        public static void Fatal(this ILog log, Func<object> msg, Exception exception)
+        public static void Fatal([NotNull] this ILog log, Func<object> msg, Exception exception)
         {
             if (log.IsFatalEnabled) {
                 log.Fatal(msg(), exception);

--- a/src/ProgressOnderwijsUtils/Log4Net/Logger.cs
+++ b/src/ProgressOnderwijsUtils/Log4Net/Logger.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Reflection;
 using System.Threading;
+using JetBrains.Annotations;
 using log4net;
 
 namespace ProgressOnderwijsUtils.Log4Net
@@ -18,7 +19,7 @@ namespace ProgressOnderwijsUtils.Log4Net
 
         public static Lazy<ILog> For<T>() => LoggerCache<T>.Log;
 
-        public static Lazy<ILog> For(Type type)
+        public static Lazy<ILog> For([NotNull] Type type)
         {
             return dict.GetOrAdd(
                 type,

--- a/src/ProgressOnderwijsUtils/MetaObject/MetaInfo.cs
+++ b/src/ProgressOnderwijsUtils/MetaObject/MetaInfo.cs
@@ -54,7 +54,7 @@ namespace ProgressOnderwijsUtils
         }
 
         [NotNull]
-        public IMetaProperty<T> GetByExpression<TProp>(Expression<Func<T, TProp>> propertyExpression)
+        public IMetaProperty<T> GetByExpression<TProp>([NotNull] Expression<Func<T, TProp>> propertyExpression)
         {
             var memberInfo = MetaObject.GetMemberInfo(propertyExpression);
             var retval = MetaProperties.SingleOrDefault(mp => mp.PropertyInfo == memberInfo); //TODO:get by name.

--- a/src/ProgressOnderwijsUtils/MetaObject/MetaInfo.cs
+++ b/src/ProgressOnderwijsUtils/MetaObject/MetaInfo.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -52,6 +53,7 @@ namespace ProgressOnderwijsUtils
             return metaProperties;
         }
 
+        [NotNull]
         public IMetaProperty<T> GetByExpression<TProp>(Expression<Func<T, TProp>> propertyExpression)
         {
             var memberInfo = MetaObject.GetMemberInfo(propertyExpression);

--- a/src/ProgressOnderwijsUtils/MetaObject/MetaObject.cs
+++ b/src/ProgressOnderwijsUtils/MetaObject/MetaObject.cs
@@ -14,7 +14,7 @@ namespace ProgressOnderwijsUtils
     public static class MetaObject
     {
         [Pure]
-        public static IMetaPropCache<IMetaProperty> GetMetaProperties(this IMetaObject metaobj) => GetCache(metaobj.GetType());
+        public static IMetaPropCache<IMetaProperty> GetMetaProperties([NotNull] this IMetaObject metaobj) => GetCache(metaobj.GetType());
 
         // ReSharper disable once UnusedParameter.Global
         [Pure]
@@ -62,8 +62,9 @@ namespace ProgressOnderwijsUtils
             }
         }
 
+        [NotNull]
         [Pure]
-        public static MemberInfo GetMemberInfo<TObject, TProperty>(Expression<Func<TObject, TProperty>> property)
+        public static MemberInfo GetMemberInfo<TObject, TProperty>([NotNull] Expression<Func<TObject, TProperty>> property)
         {
             var bodyExpr = property.Body;
 
@@ -121,7 +122,7 @@ namespace ProgressOnderwijsUtils
         static IMetaPropCache<IMetaProperty> GetCache(Type t) => (IMetaPropCache<IMetaProperty>)genGetCache.MakeGenericMethod(t).Invoke(null, null);
 
         [Pure]
-        public static ParameterizedSql SqlColumnName(this IMetaProperty mp)
+        public static ParameterizedSql SqlColumnName([NotNull] this IMetaProperty mp)
         {
             return SQL($@"[{ParameterizedSql.CreateDynamic(mp.Name)}]");
         }

--- a/src/ProgressOnderwijsUtils/MetaObject/MetaObject.cs
+++ b/src/ProgressOnderwijsUtils/MetaObject/MetaObject.cs
@@ -20,6 +20,7 @@ namespace ProgressOnderwijsUtils
         [Pure]
         public static MetaInfo<T> GetMetaProperties<T>() where T : IMetaObject => MetaInfo<T>.Instance;
 
+        [NotNull]
         [Pure]
         [CodeThatsOnlyUsedForTests]
         public static IMetaProperty<TMetaObject> GetByExpression<TMetaObject, T>(Expression<Func<TMetaObject, T>> propertyExpression)
@@ -33,7 +34,7 @@ namespace ProgressOnderwijsUtils
         {
             [UsefulToKeep("library method for getting base-class metaproperty")]
             [Pure]
-            public static IReadonlyMetaProperty<TMetaObject> Get<TParent, T>(Expression<Func<TParent, T>> propertyExpression)
+            public static IReadonlyMetaProperty<TMetaObject> Get<TParent, T>([NotNull] Expression<Func<TParent, T>> propertyExpression)
             {
                 var memberInfo = GetMemberInfo(propertyExpression);
                 if (typeof(TParent).IsClass || typeof(TParent) == typeof(TMetaObject)) {

--- a/src/ProgressOnderwijsUtils/MetaObject/MetaObject.cs
+++ b/src/ProgressOnderwijsUtils/MetaObject/MetaObject.cs
@@ -23,7 +23,7 @@ namespace ProgressOnderwijsUtils
         [NotNull]
         [Pure]
         [CodeThatsOnlyUsedForTests]
-        public static IMetaProperty<TMetaObject> GetByExpression<TMetaObject, T>(Expression<Func<TMetaObject, T>> propertyExpression)
+        public static IMetaProperty<TMetaObject> GetByExpression<TMetaObject, T>([NotNull] Expression<Func<TMetaObject, T>> propertyExpression)
             where TMetaObject : IMetaObject
         {
             return MetaInfo<TMetaObject>.Instance.GetByExpression(propertyExpression);

--- a/src/ProgressOnderwijsUtils/MetaObject/MetaObjectBulkCopy.cs
+++ b/src/ProgressOnderwijsUtils/MetaObject/MetaObjectBulkCopy.cs
@@ -61,7 +61,7 @@ namespace ProgressOnderwijsUtils
             }
         }
 
-        public static void WriteMetaObjectsToServer<T>(this SqlBulkCopy bulkCopy, IEnumerable<T> metaObjects, SqlConnection sqlconn, string tableName) where T : IMetaObject, IPropertiesAreUsedImplicitly
+        public static void WriteMetaObjectsToServer<T>([NotNull] this SqlBulkCopy bulkCopy, [NotNull] IEnumerable<T> metaObjects, [NotNull] SqlConnection sqlconn, [NotNull] string tableName) where T : IMetaObject, IPropertiesAreUsedImplicitly
         {
             bulkCopy.WriteMetaObjectsToServerAsync(metaObjects, sqlconn, tableName, CancellationToken.None).Wait();
         }
@@ -75,7 +75,8 @@ namespace ProgressOnderwijsUtils
             return !match.Success ? default(int?) : int.Parse(match.Groups[1].Value) - 1;
         }
 
-        static FieldMapping[] ApplyMetaObjectColumnMapping<T>(SqlBulkCopy bulkCopy, MetaObjectDataReader<T> objectReader, SqlConnection sqlconn, string tableName) where T : IMetaObject
+        [NotNull]
+        static FieldMapping[] ApplyMetaObjectColumnMapping<T>([NotNull] SqlBulkCopy bulkCopy, [NotNull] MetaObjectDataReader<T> objectReader, [NotNull] SqlConnection sqlconn, string tableName) where T : IMetaObject
         {
             var dataColumns = ColumnDefinition.GetFromTable(sqlconn, tableName);
             var clrColumns = ColumnDefinition.GetFromReader(objectReader);

--- a/src/ProgressOnderwijsUtils/MetaObject/MetaObjectBulkCopy.cs
+++ b/src/ProgressOnderwijsUtils/MetaObject/MetaObjectBulkCopy.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using ExpressionToCodeLib;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -20,7 +21,7 @@ namespace ProgressOnderwijsUtils
         /// <param name="metaObjects">The list of entities to insert</param>
         /// <param name="sqlconn">The Sql connection to write to</param>
         /// <param name="tableName">The name of the table to import into; must be a valid sql identifier (i.e. you must escape special characters if any).</param>
-        public static void BulkCopyToSqlServer<T>(this IEnumerable<T> metaObjects, SqlCommandCreationContext sqlconn, string tableName) where T : IMetaObject, IPropertiesAreUsedImplicitly
+        public static void BulkCopyToSqlServer<T>(this IEnumerable<T> metaObjects, [NotNull] SqlCommandCreationContext sqlconn, string tableName) where T : IMetaObject, IPropertiesAreUsedImplicitly
         {
             using (var bulkCopy = new SqlBulkCopy(sqlconn.Connection, SqlBulkCopyOptions.CheckConstraints, null)) {
                 bulkCopy.BulkCopyTimeout = sqlconn.CommandTimeoutInS;
@@ -31,7 +32,7 @@ namespace ProgressOnderwijsUtils
         /// <summary>
         /// Writes meta-objects to the server.  If you use this method, it must be the only "WriteToServer" method you call on this bulk-copy instance because it sets the column mapping.
         /// </summary>
-        public static async Task WriteMetaObjectsToServerAsync<T>(this SqlBulkCopy bulkCopy, IEnumerable<T> metaObjects, SqlConnection sqlconn, string tableName, CancellationToken cancellationToken) where T : IMetaObject, IPropertiesAreUsedImplicitly
+        public static async Task WriteMetaObjectsToServerAsync<T>([NotNull] this SqlBulkCopy bulkCopy, [NotNull] IEnumerable<T> metaObjects, [NotNull] SqlConnection sqlconn, [NotNull] string tableName, CancellationToken cancellationToken) where T : IMetaObject, IPropertiesAreUsedImplicitly
         {
             if (metaObjects == null) {
                 throw new ArgumentNullException(nameof(metaObjects));
@@ -67,7 +68,7 @@ namespace ProgressOnderwijsUtils
 
         static readonly Regex colidMessageRegex = new Regex(@"Received an invalid column length from the bcp client for colid ([0-9]+).", RegexOptions.Compiled);
 
-        static int? ParseDestinationColumnIndexFromMessage(string message)
+        static int? ParseDestinationColumnIndexFromMessage([NotNull] string message)
         {
             //note: sql colid is 1-based!
             var match = colidMessageRegex.Match(message);

--- a/src/ProgressOnderwijsUtils/MetaObject/MetaObjectBulkCopy.cs
+++ b/src/ProgressOnderwijsUtils/MetaObject/MetaObjectBulkCopy.cs
@@ -21,7 +21,7 @@ namespace ProgressOnderwijsUtils
         /// <param name="metaObjects">The list of entities to insert</param>
         /// <param name="sqlconn">The Sql connection to write to</param>
         /// <param name="tableName">The name of the table to import into; must be a valid sql identifier (i.e. you must escape special characters if any).</param>
-        public static void BulkCopyToSqlServer<T>(this IEnumerable<T> metaObjects, [NotNull] SqlCommandCreationContext sqlconn, string tableName) where T : IMetaObject, IPropertiesAreUsedImplicitly
+        public static void BulkCopyToSqlServer<T>([NotNull] this IEnumerable<T> metaObjects, [NotNull] SqlCommandCreationContext sqlconn, [NotNull] string tableName) where T : IMetaObject, IPropertiesAreUsedImplicitly
         {
             using (var bulkCopy = new SqlBulkCopy(sqlconn.Connection, SqlBulkCopyOptions.CheckConstraints, null)) {
                 bulkCopy.BulkCopyTimeout = sqlconn.CommandTimeoutInS;

--- a/src/ProgressOnderwijsUtils/MetaObject/MetaProperty.cs
+++ b/src/ProgressOnderwijsUtils/MetaObject/MetaProperty.cs
@@ -158,28 +158,28 @@ namespace ProgressOnderwijsUtils
         class OutCaster<TOut> : IOutCaster
         {
             [NotNull]
-            public Func<TObj, object> GetterBoxed<TObj>(MethodInfo method)
+            public Func<TObj, object> GetterBoxed<TObj>([NotNull] MethodInfo method)
             {
                 var f = MkDelegate<Func<TObj, TOut>>(method);
                 return o => f(o);
             }
 
             [NotNull]
-            public Func<TObj, object> StructGetterBoxed<TObj>(MethodInfo method)
+            public Func<TObj, object> StructGetterBoxed<TObj>([NotNull] MethodInfo method)
             {
                 var f = MkDelegate<StructGetterDel<TObj, TOut>>(method);
                 return o => f(ref o);
             }
 
             [NotNull]
-            public Setter<TObj> SetterChecked<TObj>(MethodInfo method)
+            public Setter<TObj> SetterChecked<TObj>([NotNull] MethodInfo method)
             {
                 var f = MkDelegate<Action<TObj, TOut>>(method);
                 return (ref TObj o, object v) => f(o, (TOut)v);
             }
 
             [NotNull]
-            public Setter<TObj> StructSetterChecked<TObj>(MethodInfo method)
+            public Setter<TObj> StructSetterChecked<TObj>([NotNull] MethodInfo method)
             {
                 var f = MkDelegate<StructSetterDel<TObj, TOut>>(method);
                 return (ref TObj o, object v) => f(ref o, (TOut)v);

--- a/src/ProgressOnderwijsUtils/MetaObject/MetaProperty.cs
+++ b/src/ProgressOnderwijsUtils/MetaObject/MetaProperty.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq.Expressions;
 using System.Reflection;
 using ExpressionToCodeLib;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -39,6 +40,7 @@ namespace ProgressOnderwijsUtils
             public string Name { get; }
             public IReadOnlyList<object> CustomAttributes { get; }
             public int Index { get; }
+            [NotNull]
             public Type DataType => PropertyInfo.PropertyType;
             public PropertyInfo PropertyInfo { get; }
             public bool CanRead => getterMethod != null;
@@ -49,6 +51,7 @@ namespace ProgressOnderwijsUtils
             public Setter<TOwner> Setter => setter ?? (setter = MkSetter(setterMethod, PropertyInfo.PropertyType));
             Func<object, object> untypedGetter;
 
+            [CanBeNull]
             public Func<object, object> UntypedGetter
             {
                 get {
@@ -67,9 +70,10 @@ namespace ProgressOnderwijsUtils
                 return typedObj;
             }
 
+            [NotNull]
             public Expression PropertyAccessExpression(Expression paramExpr) => Expression.Property(paramExpr, PropertyInfo);
 
-            public Impl(PropertyInfo pi, int implicitOrder, object[] attrs)
+            public Impl([NotNull] PropertyInfo pi, int implicitOrder, [NotNull] object[] attrs)
             {
                 PropertyInfo = pi;
                 Name = pi.Name;
@@ -87,7 +91,7 @@ namespace ProgressOnderwijsUtils
 
             public override string ToString() => typeof(TOwner).ToCSharpFriendlyTypeName() + "." + Name;
 
-            static Setter<TOwner> MkSetter(MethodInfo setterMethod, Type propertyType)
+            static Setter<TOwner> MkSetter([CanBeNull] MethodInfo setterMethod, Type propertyType)
             {
                 if (setterMethod == null) {
                     return null;
@@ -109,7 +113,7 @@ namespace ProgressOnderwijsUtils
                 //		).Compile();
             }
 
-            static Func<TOwner, object> MkGetter(MethodInfo getterMethod, Type propertyType)
+            static Func<TOwner, object> MkGetter([CanBeNull] MethodInfo getterMethod, Type propertyType)
             {
                 //TODO:optimize: this is still a hotspot :-(
                 if (getterMethod == null) {
@@ -133,7 +137,8 @@ namespace ProgressOnderwijsUtils
             readonly MethodInfo getterMethod;
         }
 
-        static T MkDelegate<T>(MethodInfo mi)
+        [NotNull]
+        static T MkDelegate<T>([NotNull] MethodInfo mi)
         {
             return (T)(object)Delegate.CreateDelegate(typeof(T), mi);
         }
@@ -152,24 +157,28 @@ namespace ProgressOnderwijsUtils
 
         class OutCaster<TOut> : IOutCaster
         {
+            [NotNull]
             public Func<TObj, object> GetterBoxed<TObj>(MethodInfo method)
             {
                 var f = MkDelegate<Func<TObj, TOut>>(method);
                 return o => f(o);
             }
 
+            [NotNull]
             public Func<TObj, object> StructGetterBoxed<TObj>(MethodInfo method)
             {
                 var f = MkDelegate<StructGetterDel<TObj, TOut>>(method);
                 return o => f(ref o);
             }
 
+            [NotNull]
             public Setter<TObj> SetterChecked<TObj>(MethodInfo method)
             {
                 var f = MkDelegate<Action<TObj, TOut>>(method);
                 return (ref TObj o, object v) => f(o, (TOut)v);
             }
 
+            [NotNull]
             public Setter<TObj> StructSetterChecked<TObj>(MethodInfo method)
             {
                 var f = MkDelegate<StructSetterDel<TObj, TOut>>(method);
@@ -180,7 +189,7 @@ namespace ProgressOnderwijsUtils
         static readonly OutCaster<object> outCasterObject = new OutCaster<object>();
         static readonly ConcurrentDictionary<Type, IOutCaster> CasterFactoryCache = new ConcurrentDictionary<Type, IOutCaster>();
 
-        static IOutCaster GetCaster(Type propType)
+        static IOutCaster GetCaster([NotNull] Type propType)
         {
             return CasterFactoryCache.GetOrAdd(propType, type => (IOutCaster)Activator.CreateInstance(typeof(OutCaster<>).MakeGenericType(type)));
         }

--- a/src/ProgressOnderwijsUtils/ProcessCpuTimer.cs
+++ b/src/ProgressOnderwijsUtils/ProcessCpuTimer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -21,6 +22,7 @@ namespace ProgressOnderwijsUtils
         public TimeSpan CpuTime() => currentProcess.TotalProcessorTime - start;
 
         public TimeSpan WallClockTime() => wallclock.Elapsed;
+        [NotNull]
         public static ProcessCpuTimer StartNew() => new ProcessCpuTimer();
     }
 }

--- a/src/ProgressOnderwijsUtils/Radius/RadiusAttribute.cs
+++ b/src/ProgressOnderwijsUtils/Radius/RadiusAttribute.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Net;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils.Radius
 {
@@ -62,6 +63,7 @@ namespace ProgressOnderwijsUtils.Radius
     {
         public RadiusAttributeType AttributeType { get; }
         public byte[] AttributeValue { get; set; }
+        [NotNull]
         public byte[] Paket => new[] { (byte)(int)AttributeType, (byte)(AttributeValue.Length + 2) }.Concat(AttributeValue).ToArray();
         public int Length => AttributeValue.Length + 2;
 
@@ -74,6 +76,7 @@ namespace ProgressOnderwijsUtils.Radius
             }
         }
 
-        public static RadiusAttribute NASIPAddress(IPAddress addr) => new RadiusAttribute(RadiusAttributeType.NASIPAddress, addr.GetAddressBytes());
+        [NotNull]
+        public static RadiusAttribute NASIPAddress([NotNull] IPAddress addr) => new RadiusAttribute(RadiusAttributeType.NASIPAddress, addr.GetAddressBytes());
     }
 }

--- a/src/ProgressOnderwijsUtils/Radius/RadiusClient.cs
+++ b/src/ProgressOnderwijsUtils/Radius/RadiusClient.cs
@@ -61,7 +61,7 @@ namespace ProgressOnderwijsUtils.Radius
         const int udpTimeoutMs = 1000;
 
         //see http://tools.ietf.org/html/rfc2138
-        public static RadiusAuthResults Authenticate(string serverHostname, byte[] sharedSecret, byte[] username, byte[] password, [NotNull] params RadiusAttribute[] extraAttributes)
+        public static RadiusAuthResults Authenticate(string serverHostname, [NotNull] byte[] sharedSecret, byte[] username, [NotNull] byte[] password, [NotNull] params RadiusAttribute[] extraAttributes)
         {
             byte requestCode = 1; //means "Access-Request"
             var secureRandom = new RNGCryptoServiceProvider();

--- a/src/ProgressOnderwijsUtils/Radius/RadiusClient.cs
+++ b/src/ProgressOnderwijsUtils/Radius/RadiusClient.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Security.Cryptography;
+using JetBrains.Annotations;
 
 //see http://tools.ietf.org/html/rfc2138 or http://en.wikipedia.org/wiki/RADIUS
 //really basic idea: each packet is 1 byte code, 1 byte "identifier" (random sequence number),
@@ -40,14 +41,15 @@ namespace ProgressOnderwijsUtils.Radius
     public static class RadiusClient
     {
         //Utility function to make working with RNGCryptoServiceProvider easier
-        public static byte[] NextBytes(this RNGCryptoServiceProvider secureRandom, int byteCount)
+        [NotNull]
+        public static byte[] NextBytes([NotNull] this RNGCryptoServiceProvider secureRandom, int byteCount)
         {
             var data = new byte[byteCount];
             secureRandom.GetBytes(data);
             return data;
         }
 
-        public static byte NextByte(this RNGCryptoServiceProvider secureRandom)
+        public static byte NextByte([NotNull] this RNGCryptoServiceProvider secureRandom)
         {
             var data = new byte[1];
             secureRandom.GetBytes(data);
@@ -59,7 +61,7 @@ namespace ProgressOnderwijsUtils.Radius
         const int udpTimeoutMs = 1000;
 
         //see http://tools.ietf.org/html/rfc2138
-        public static RadiusAuthResults Authenticate(string serverHostname, byte[] sharedSecret, byte[] username, byte[] password, params RadiusAttribute[] extraAttributes)
+        public static RadiusAuthResults Authenticate(string serverHostname, byte[] sharedSecret, byte[] username, byte[] password, [NotNull] params RadiusAttribute[] extraAttributes)
         {
             byte requestCode = 1; //means "Access-Request"
             var secureRandom = new RNGCryptoServiceProvider();
@@ -103,7 +105,8 @@ namespace ProgressOnderwijsUtils.Radius
             }
         }
 
-        static byte[] AuthNetworkHelper(string serverHostname, byte[] request)
+        [NotNull]
+        static byte[] AuthNetworkHelper([NotNull] string serverHostname, [NotNull] byte[] request)
         {
             using (var udpClient = new UdpClient()) {
                 udpClient.Client.SendTimeout = udpTimeoutMs;
@@ -120,7 +123,7 @@ namespace ProgressOnderwijsUtils.Radius
             }
         }
 
-        static RadiusAuthResults ProcessServerResponse(byte[] response, byte requestIdentifier, byte[] requestAuthenticator, byte[] sharedSecret)
+        static RadiusAuthResults ProcessServerResponse([NotNull] byte[] response, byte requestIdentifier, byte[] requestAuthenticator, byte[] sharedSecret)
         {
             // Checking the minimum paket length of 20 bytes
             if (response.Length < 20) {
@@ -169,7 +172,8 @@ namespace ProgressOnderwijsUtils.Radius
             }
         }
 
-        public static byte[] HashPapPassword(byte[] password, byte[] sharedSecret, byte[] requestAuthenticator)
+        [NotNull]
+        public static byte[] HashPapPassword([NotNull] byte[] password, [NotNull] byte[] sharedSecret, [NotNull] byte[] requestAuthenticator)
         {
             using (var md5 = new MD5CryptoServiceProvider()) {
                 //Hashed password in generated in 16-byte chunks; for each 16-bytes an "unguessable" pad is generated which 

--- a/src/ProgressOnderwijsUtils/RandomHelper.cs
+++ b/src/ProgressOnderwijsUtils/RandomHelper.cs
@@ -72,9 +72,11 @@ namespace ProgressOnderwijsUtils
             }
         }
 
+        [NotNull]
         public string GetStringOfLatinLower(int length) => GetString(length, 'a', 'z');
         [NotNull]
         public string GetStringCapitalized(int length) => GetString(1, 'A', 'Z') + GetString(length - 1, 'a', 'z');
+        [NotNull]
         public string GetStringOfLatinUpperOrLower(int length) => GetStringUpperAndLower(length, 'a', 'z');
         [NotNull]
         public string GetStringOfNumbers(int length) => GetString(1, '1', '9') + GetString(length - 1, '0', '9');

--- a/src/ProgressOnderwijsUtils/RandomHelper.cs
+++ b/src/ProgressOnderwijsUtils/RandomHelper.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using JetBrains.Annotations;
 using MoreLinq;
 
 namespace ProgressOnderwijsUtils
@@ -9,6 +10,7 @@ namespace ProgressOnderwijsUtils
     public sealed class RandomHelper
     {
         public static readonly RandomHelper Secure = new RandomHelper(new RNGCryptoServiceProvider().GetBytes);
+        [NotNull]
         public static RandomHelper Insecure(int seed) => new RandomHelper(new Random(seed).NextBytes);
         readonly Action<byte[]> fillWithRandomBytes;
 
@@ -17,6 +19,7 @@ namespace ProgressOnderwijsUtils
             this.fillWithRandomBytes = fillWithRandomBytes;
         }
 
+        [NotNull]
         public byte[] GetBytes(int numBytes)
         {
             var bytes = new byte[numBytes];
@@ -70,10 +73,13 @@ namespace ProgressOnderwijsUtils
         }
 
         public string GetStringOfLatinLower(int length) => GetString(length, 'a', 'z');
+        [NotNull]
         public string GetStringCapitalized(int length) => GetString(1, 'A', 'Z') + GetString(length - 1, 'a', 'z');
         public string GetStringOfLatinUpperOrLower(int length) => GetStringUpperAndLower(length, 'a', 'z');
+        [NotNull]
         public string GetStringOfNumbers(int length) => GetString(1, '1', '9') + GetString(length - 1, '0', '9');
 
+        [NotNull]
         public string GetString(int length, char min, char max)
         {
             var letters = (uint)max - min + 1;
@@ -84,6 +90,7 @@ namespace ProgressOnderwijsUtils
             return sb.ToString();
         }
 
+        [NotNull]
         public string GetStringUpperAndLower(int length, char min, char max)
         {
             var letters = (uint)max - min + 1;
@@ -98,11 +105,13 @@ namespace ProgressOnderwijsUtils
         static readonly char[] UriPrintableCharacters =
             Enumerable.Range('A', 26).Concat(Enumerable.Range('a', 26)).Concat(Enumerable.Range('0', 10)).Select(i => (char)i).Concat("_-~").ToArray();
 
+        [NotNull]
         public string GetStringOfUriPrintableCharacters(int length)
         {
             return new string(Enumerable.Range(0, length).Select(_ => UriPrintableCharacters[GetUInt32((uint)UriPrintableCharacters.Length)]).ToArray());
         }
 
+        [NotNull]
         public static string GetPasswordString(int length)
         {
             return System.Web.Security.Membership.GeneratePassword(length, 0);

--- a/src/ProgressOnderwijsUtils/ResourceStore.cs
+++ b/src/ProgressOnderwijsUtils/ResourceStore.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -26,6 +27,7 @@ namespace ProgressOnderwijsUtils
 
         public Stream GetResource(string filename) => typeof(T).GetResource(filename);
 
+        [ItemNotNull]
         public IEnumerable<string> GetResourceNames()
         {
             var nsPrefix = typeof(T).Namespace + ".";

--- a/src/ProgressOnderwijsUtils/ResourceStore.cs
+++ b/src/ProgressOnderwijsUtils/ResourceStore.cs
@@ -25,6 +25,7 @@ namespace ProgressOnderwijsUtils
             }
         }
 
+        [CanBeNull]
         public Stream GetResource(string filename) => typeof(T).GetResource(filename);
 
         [ItemNotNull]

--- a/src/ProgressOnderwijsUtils/SerializationCloner.cs
+++ b/src/ProgressOnderwijsUtils/SerializationCloner.cs
@@ -1,14 +1,16 @@
 ﻿using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
     [CodeThatsOnlyUsedForTests]
     public static class SerializationCloner
     {
+        [NotNull]
         [CodeThatsOnlyUsedForTests]
-        public static T Clone<T>(T obj)
+        public static T Clone<T>([NotNull] T obj)
         {
             if (!typeof(T).IsSerializable) {
                 throw new ArgumentException("Type " + typeof(T) + " is not serializable and cannot be cloned", nameof(obj));

--- a/src/ProgressOnderwijsUtils/SimplerHash.cs
+++ b/src/ProgressOnderwijsUtils/SimplerHash.cs
@@ -1,5 +1,6 @@
 ﻿using System.Security.Cryptography;
 using System.Text;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -7,12 +8,13 @@ namespace ProgressOnderwijsUtils
     {
         public static bool MD5VerifyHash(string plainText, string hashString) => hashString == MD5ComputeHash(plainText);
 
-        public static string MD5ComputeHash(string plainText)
+        public static string MD5ComputeHash([NotNull] string plainText)
         {
             return MakeMD5(Encoding.UTF8.GetBytes(plainText));
         }
 
-        static string MakeMD5(byte[] data)
+        [NotNull]
+        static string MakeMD5([NotNull] byte[] data)
         {
             using (var md5computer = MD5.Create()) {
                 var md5 = md5computer.ComputeHash(data);

--- a/src/ProgressOnderwijsUtils/SimplerHash.cs
+++ b/src/ProgressOnderwijsUtils/SimplerHash.cs
@@ -6,8 +6,9 @@ namespace ProgressOnderwijsUtils
 {
     public static class SimplerHash
     {
-        public static bool MD5VerifyHash(string plainText, string hashString) => hashString == MD5ComputeHash(plainText);
+        public static bool MD5VerifyHash([NotNull] string plainText, string hashString) => hashString == MD5ComputeHash(plainText);
 
+        [NotNull]
         public static string MD5ComputeHash([NotNull] string plainText)
         {
             return MakeMD5(Encoding.UTF8.GetBytes(plainText));

--- a/src/ProgressOnderwijsUtils/SingleSignOn/AuthnRequest.cs
+++ b/src/ProgressOnderwijsUtils/SingleSignOn/AuthnRequest.cs
@@ -4,6 +4,7 @@ using System.IO.Compression;
 using System.Text;
 using System.Xml;
 using System.Xml.Linq;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils.SingleSignOn
 {
@@ -22,6 +23,7 @@ namespace ProgressOnderwijsUtils.SingleSignOn
             ForceAuthn = false;
         }
 
+        [NotNull]
         public string Encode()
         {
             var xml = Encoding.UTF8.GetBytes(ToXml().ToString());
@@ -32,6 +34,7 @@ namespace ProgressOnderwijsUtils.SingleSignOn
             }
         }
 
+        [NotNull]
         XElement ToXml()
         {
             return new XElement(

--- a/src/ProgressOnderwijsUtils/SingleSignOn/Saml20MetaData.cs
+++ b/src/ProgressOnderwijsUtils/SingleSignOn/Saml20MetaData.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
+using JetBrains.Annotations;
 using ProgressOnderwijsUtils;
 
 namespace ProgressOnderwijsUtils.SingleSignOn
@@ -14,6 +15,7 @@ namespace ProgressOnderwijsUtils.SingleSignOn
             this.md = md;
         }
 
+        [NotNull]
         public IEnumerable<string> GetEntities()
         {
             return (

--- a/src/ProgressOnderwijsUtils/SingleSignOn/SsoProcessor.cs
+++ b/src/ProgressOnderwijsUtils/SingleSignOn/SsoProcessor.cs
@@ -53,7 +53,7 @@ namespace ProgressOnderwijsUtils.SingleSignOn
             return null;
         }
 
-        public static SsoAttributes GetAttributes(XElement assertion, X509Certificate2 certificate)
+        public static SsoAttributes GetAttributes(XElement assertion, [NotNull] X509Certificate2 certificate)
         {
             LOG.Debug(() => $"GetAttributes(assertion='{assertion}')");
 

--- a/src/ProgressOnderwijsUtils/SingleSignOn/SsoProcessor.cs
+++ b/src/ProgressOnderwijsUtils/SingleSignOn/SsoProcessor.cs
@@ -24,6 +24,7 @@ namespace ProgressOnderwijsUtils.SingleSignOn
         const string ROLE = "urn:mace:dir:attribute-def:eduPersonAffiliation";
         static readonly Lazy<ILog> LOG = LazyLog.For(typeof(SsoProcessor));
 
+        [NotNull]
         public static string GetRedirectUrl(AuthnRequest request)
         {
             var qs = CreateQueryString(request, null, request.Issuer.certificate);
@@ -37,6 +38,7 @@ namespace ProgressOnderwijsUtils.SingleSignOn
             return samlResponse != null ? XDocument.Parse(Encoding.UTF8.GetString(Convert.FromBase64String(samlResponse)), LoadOptions.PreserveWhitespace).Root : null;
         }
 
+        [CanBeNull]
         public static XElement GetAssertion(XElement response, X509Certificate2 certificate)
         {
             LOG.Debug(() => $"GetAssertion(response='{response}')");
@@ -78,7 +80,7 @@ namespace ProgressOnderwijsUtils.SingleSignOn
         }
 
         [NotNull]
-        static string CreateUrl(AuthnRequest req, NameValueCollection qs)
+        static string CreateUrl(AuthnRequest req, [NotNull] NameValueCollection qs)
         {
             var builder = new UriBuilder(req.Destination);
             if (string.IsNullOrEmpty(builder.Query)) {
@@ -103,7 +105,7 @@ namespace ProgressOnderwijsUtils.SingleSignOn
         }
 
         [NotNull]
-        static string Signature(NameValueCollection qs, AsymmetricAlgorithm key)
+        static string Signature([NotNull] NameValueCollection qs, AsymmetricAlgorithm key)
         {
             var data = Encoding.UTF8.GetBytes(ToQueryString(qs));
             var result = ((RSACryptoServiceProvider)key).SignData(data, new SHA1CryptoServiceProvider());
@@ -124,7 +126,7 @@ namespace ProgressOnderwijsUtils.SingleSignOn
         }
 
         [NotNull]
-        static string GetAttribute(XElement assertion, string key)
+        static string GetAttribute([NotNull] XElement assertion, string key)
         {
             var result = GetNullableAttribute(assertion, key);
             if (result == null) {
@@ -205,7 +207,7 @@ namespace ProgressOnderwijsUtils.SingleSignOn
             }
         }
 
-        static void Validate([NotNull] XElement assertion, X509Certificate2 cer)
+        static void Validate([NotNull] XElement assertion, [NotNull] X509Certificate2 cer)
         {
             ValidateSchema(assertion);
 

--- a/src/ProgressOnderwijsUtils/SqlErrorParser.cs
+++ b/src/ProgressOnderwijsUtils/SqlErrorParser.cs
@@ -121,7 +121,8 @@ namespace ProgressOnderwijsUtils
             return null;
         }
 
-        public static ISqlErrorParseResult Parse(SqlError error)
+        [CanBeNull]
+        public static ISqlErrorParseResult Parse([NotNull] SqlError error)
             => TryParseKeyConstraintViolation(error)
                 ?? TryParseDuplicateKeyUniqueIndex(error)
                     ?? TryParseCannotInsertNull(error)

--- a/src/ProgressOnderwijsUtils/SqlErrorParser.cs
+++ b/src/ProgressOnderwijsUtils/SqlErrorParser.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Data.SqlClient;
 using System.Text.RegularExpressions;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -63,7 +64,8 @@ namespace ProgressOnderwijsUtils
             RegexOptions.Compiled
             );
 
-        static ISqlErrorParseResult TryParseKeyConstraintViolation(SqlError error)
+        [CanBeNull]
+        static ISqlErrorParseResult TryParseKeyConstraintViolation([NotNull] SqlError error)
         {
             var match = keyConstraintViolationRegex.Match(error.Message);
             if (match.Success) {
@@ -77,7 +79,8 @@ namespace ProgressOnderwijsUtils
             return null;
         }
 
-        static ISqlErrorParseResult TryParseDuplicateKeyUniqueIndex(SqlError error)
+        [CanBeNull]
+        static ISqlErrorParseResult TryParseDuplicateKeyUniqueIndex([NotNull] SqlError error)
         {
             var match = duplicateKeyUniqueIndexRegex.Match(error.Message);
             if (match.Success) {
@@ -90,7 +93,8 @@ namespace ProgressOnderwijsUtils
             return null;
         }
 
-        static ISqlErrorParseResult TryParseCannotInsertNull(SqlError error)
+        [CanBeNull]
+        static ISqlErrorParseResult TryParseCannotInsertNull([NotNull] SqlError error)
         {
             var match = cannotInsertNullRegex.Match(error.Message);
             if (match.Success) {
@@ -103,7 +107,8 @@ namespace ProgressOnderwijsUtils
             return null;
         }
 
-        static ISqlErrorParseResult TryParseGenericConstraintViolation(SqlError error)
+        [CanBeNull]
+        static ISqlErrorParseResult TryParseGenericConstraintViolation([NotNull] SqlError error)
         {
             var match = genericConstraintViolationRegex.Match(error.Message);
             if (match.Success) {

--- a/src/ProgressOnderwijsUtils/TopologicalSort.cs
+++ b/src/ProgressOnderwijsUtils/TopologicalSort.cs
@@ -10,7 +10,8 @@ namespace ProgressOnderwijsUtils
         /// Orders a DAG (directed acyclic graph), children before parents.  If two nodes are not related, they remain in the same order as in the seeds.
         /// All DAG nodes reachable via listChildrenOf are returned, not just the seeds - the output sequence can thus be larger than the input.
         /// </summary>
-        public static T[] OrderByTopology<T>(this IEnumerable<T> seeds, Func<T, IEnumerable<T>> listChildrenOf)
+        [NotNull]
+        public static T[] OrderByTopology<T>([NotNull] this IEnumerable<T> seeds, Func<T, IEnumerable<T>> listChildrenOf)
             => seeds.OrderByTopology(listChildrenOf, EqualityComparer<T>.Default);
 
         /// <summary>

--- a/src/ProgressOnderwijsUtils/TopologicalSort.cs
+++ b/src/ProgressOnderwijsUtils/TopologicalSort.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -16,7 +17,8 @@ namespace ProgressOnderwijsUtils
         /// Orders a DAG (directed acyclic graph), children before parents.  If two nodes are not related, they remain in the same order as in the seeds.
         /// All DAG nodes reachable via listChildrenOf are returned, not just the seeds - the output sequence can thus be larger than the input.
         /// </summary>
-        public static T[] OrderByTopology<T>(this IEnumerable<T> seeds, Func<T, IEnumerable<T>> listChildren, IEqualityComparer<T> comparer)
+        [NotNull]
+        public static T[] OrderByTopology<T>([NotNull] this IEnumerable<T> seeds, Func<T, IEnumerable<T>> listChildren, IEqualityComparer<T> comparer)
         {
             var list = new List<T>();
             var visited = new HashSet<T>(comparer);
@@ -26,7 +28,7 @@ namespace ProgressOnderwijsUtils
             return list.ToArray();
         }
 
-        static void TopologicalSortVisit<T>(HashSet<T> visited, List<T> output, T r, Func<T, IEnumerable<T>> listChildrenOf)
+        static void TopologicalSortVisit<T>([NotNull] HashSet<T> visited, List<T> output, T r, Func<T, IEnumerable<T>> listChildrenOf)
         {
             if (visited.Add(r)) {
                 foreach (var kid in listChildrenOf(r)) {

--- a/src/ProgressOnderwijsUtils/Utils.cs
+++ b/src/ProgressOnderwijsUtils/Utils.cs
@@ -8,6 +8,7 @@ using System.Linq.Expressions;
 using System.Net.Mail;
 using System.Text;
 using System.Threading;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -40,7 +41,7 @@ namespace ProgressOnderwijsUtils
 
     public static class DisposableExtensions
     {
-        public static T Using<TDisposable, T>(this TDisposable disposable, Func<TDisposable, T> func) where TDisposable : IDisposable
+        public static T Using<TDisposable, T>(this TDisposable disposable, [NotNull] Func<TDisposable, T> func) where TDisposable : IDisposable
         {
             using (disposable)
                 return func(disposable);
@@ -63,7 +64,8 @@ namespace ProgressOnderwijsUtils
             return x == y || delta / magnitude < relativeEpsilon;
         }
 
-        public static Lazy<T> Lazy<T>(Func<T> factory)
+        [NotNull]
+        public static Lazy<T> Lazy<T>([NotNull] Func<T> factory)
         {
             return new Lazy<T>(factory, LazyThreadSafetyMode.ExecutionAndPublication);
         }
@@ -107,7 +109,7 @@ namespace ProgressOnderwijsUtils
             return TransitiveClosure(elems, edgeLookup, EqualityComparer<T>.Default);
         }
 
-        public static HashSet<T> TransitiveClosure<T>(IEnumerable<T> elems, Func<T, IEnumerable<T>> edgeLookup, IEqualityComparer<T> comparer)
+        public static HashSet<T> TransitiveClosure<T>([NotNull] IEnumerable<T> elems, Func<T, IEnumerable<T>> edgeLookup, IEqualityComparer<T> comparer)
         {
             var distinctNewlyReachable = elems.ToArray();
             var set = distinctNewlyReachable.ToSet(comparer);
@@ -122,7 +124,7 @@ namespace ProgressOnderwijsUtils
             return TransitiveClosure(elems, multiEdgeLookup, EqualityComparer<T>.Default);
         }
 
-        public static HashSet<T> TransitiveClosure<T>(IEnumerable<T> elems, Func<IEnumerable<T>, IEnumerable<T>> multiEdgeLookup, IEqualityComparer<T> comparer)
+        public static HashSet<T> TransitiveClosure<T>([NotNull] IEnumerable<T> elems, Func<IEnumerable<T>, IEnumerable<T>> multiEdgeLookup, IEqualityComparer<T> comparer)
         {
             var distinctNewlyReachable = elems.ToArray();
             var set = distinctNewlyReachable.ToSet(comparer);
@@ -132,7 +134,7 @@ namespace ProgressOnderwijsUtils
             return set;
         }
 
-        public static bool IsRetriableConnectionFailure(Exception e)
+        public static bool IsRetriableConnectionFailure([CanBeNull] Exception e)
         {
             if (e == null) {
                 return false;
@@ -196,7 +198,8 @@ namespace ProgressOnderwijsUtils
             return v;
         } //purely for delegate type inference
         // ReSharper restore UnusedMember.Global
-        public static string GetSqlExceptionDetailsString(Exception exception)
+        [CanBeNull]
+        public static string GetSqlExceptionDetailsString([NotNull] Exception exception)
         {
             var sql = exception as SqlException ?? exception.InnerException as SqlException;
             return sql == null ? null : $"[code='{sql.ErrorCode:x}'; number='{sql.Number}'; state='{sql.State}']";
@@ -218,7 +221,7 @@ namespace ProgressOnderwijsUtils
         /// waarbij nulwaarden voor datum of maand worden omgezet naar de waarde 1
         /// Alleen voor KVA4
         /// </summary>
-        public static DateTime? SLMaybeIncompleteDateConversion(string incompleteDate)
+        public static DateTime? SLMaybeIncompleteDateConversion([CanBeNull] string incompleteDate)
         {
             if (incompleteDate != null) {
                 var incompleteDateFragments = incompleteDate.Split('-');
@@ -240,6 +243,7 @@ namespace ProgressOnderwijsUtils
         /// Deze eigenschap geldt wanneer je m verifieert in C#, JS, SQL (, etc?)
         /// (want er worden alleen letters in 1 case en cijfers gebruikt)
         /// </summary>
+        [NotNull]
         public static string ToSortableShortString(long value)
         {
             var sb = new StringBuilder();
@@ -257,7 +261,7 @@ namespace ProgressOnderwijsUtils
             }
         }
 
-        static void SssHelper(StringBuilder target, long value, int index)
+        static void SssHelper([NotNull] StringBuilder target, long value, int index)
         {
             if (value != 0) {
                 var digit = (int)(value % 36);
@@ -269,7 +273,7 @@ namespace ProgressOnderwijsUtils
             }
         }
 
-        static void SssNegHelper(StringBuilder target, long value, int index)
+        static void SssNegHelper([NotNull] StringBuilder target, long value, int index)
         {
             if (value != 0) {
                 var digit = (int)(value % 36); //in range -35..0!!
@@ -290,7 +294,8 @@ namespace ProgressOnderwijsUtils
         ///   - rounding differences may exist for doubles like 1.005 which are not precisely representable.
         ///   - numbers over (2^64 - 2^10)/(2^precision) are slow.
         /// </summary>
-        public static string ToFixedPointString(double number, CultureInfo culture, int precision)
+        [NotNull]
+        public static string ToFixedPointString(double number, [NotNull] CultureInfo culture, int precision)
         {
             //TODO:add tests
             var fI = culture.NumberFormat;
@@ -433,7 +438,7 @@ namespace ProgressOnderwijsUtils
         readonly Func<T, T, bool> equals;
         readonly Func<T, int> hashCode;
 
-        public EqualsEqualityComparer(Func<T, T, bool> equals, Func<T, int> hashCode = null)
+        public EqualsEqualityComparer(Func<T, T, bool> equals, [CanBeNull] Func<T, int> hashCode = null)
         {
             this.equals = equals;
             this.hashCode = hashCode;

--- a/src/ProgressOnderwijsUtils/Utils.cs
+++ b/src/ProgressOnderwijsUtils/Utils.cs
@@ -104,6 +104,7 @@ namespace ProgressOnderwijsUtils
             other = tmp;
         }
 
+        [NotNull]
         public static HashSet<T> TransitiveClosure<T>([NotNull] IEnumerable<T> elems, Func<T, IEnumerable<T>> edgeLookup)
         {
             return TransitiveClosure(elems, edgeLookup, EqualityComparer<T>.Default);
@@ -120,6 +121,7 @@ namespace ProgressOnderwijsUtils
             return set;
         }
 
+        [NotNull]
         public static HashSet<T> TransitiveClosure<T>([NotNull] IEnumerable<T> elems, Func<IEnumerable<T>, IEnumerable<T>> multiEdgeLookup)
         {
             return TransitiveClosure(elems, multiEdgeLookup, EqualityComparer<T>.Default);

--- a/src/ProgressOnderwijsUtils/Utils.cs
+++ b/src/ProgressOnderwijsUtils/Utils.cs
@@ -104,11 +104,12 @@ namespace ProgressOnderwijsUtils
             other = tmp;
         }
 
-        public static HashSet<T> TransitiveClosure<T>(IEnumerable<T> elems, Func<T, IEnumerable<T>> edgeLookup)
+        public static HashSet<T> TransitiveClosure<T>([NotNull] IEnumerable<T> elems, Func<T, IEnumerable<T>> edgeLookup)
         {
             return TransitiveClosure(elems, edgeLookup, EqualityComparer<T>.Default);
         }
 
+        [NotNull]
         public static HashSet<T> TransitiveClosure<T>([NotNull] IEnumerable<T> elems, Func<T, IEnumerable<T>> edgeLookup, IEqualityComparer<T> comparer)
         {
             var distinctNewlyReachable = elems.ToArray();
@@ -119,11 +120,12 @@ namespace ProgressOnderwijsUtils
             return set;
         }
 
-        public static HashSet<T> TransitiveClosure<T>(IEnumerable<T> elems, Func<IEnumerable<T>, IEnumerable<T>> multiEdgeLookup)
+        public static HashSet<T> TransitiveClosure<T>([NotNull] IEnumerable<T> elems, Func<IEnumerable<T>, IEnumerable<T>> multiEdgeLookup)
         {
             return TransitiveClosure(elems, multiEdgeLookup, EqualityComparer<T>.Default);
         }
 
+        [NotNull]
         public static HashSet<T> TransitiveClosure<T>([NotNull] IEnumerable<T> elems, Func<IEnumerable<T>, IEnumerable<T>> multiEdgeLookup, IEqualityComparer<T> comparer)
         {
             var distinctNewlyReachable = elems.ToArray();
@@ -251,7 +253,7 @@ namespace ProgressOnderwijsUtils
             return sb.ToString();
         }
 
-        public static void AppendSortableShortString(this StringBuilder target, long value)
+        public static void AppendSortableShortString([NotNull] this StringBuilder target, long value)
         {
             //This function is used on a hot-path in Programma and Resultaten export - it needs to be fast.
             if (value < 0) {

--- a/src/ProgressOnderwijsUtils/ValueBase.cs
+++ b/src/ProgressOnderwijsUtils/ValueBase.cs
@@ -40,9 +40,10 @@ namespace ProgressOnderwijsUtils
         public bool Equals(T other) => other != null && FieldwiseEquality<T>.Instance((T)this, other);
         public override bool Equals(object obj) => obj is T && Equals((T)obj);
         public override int GetHashCode() => FieldwiseHasher<T>.Instance((T)this);
+        [NotNull]
         public T Copy() => (T)MemberwiseClone();
 
-        public T CopyWith(Action<T> action)
+        public T CopyWith([NotNull] Action<T> action)
         {
             var copied = Copy();
             action(copied);
@@ -61,7 +62,8 @@ namespace ProgressOnderwijsUtils
     {
         public static readonly Func<T, string> Func = byPublicMembers();
 
-        static MemberExpression MemberAccessExpression(Expression expr, MemberInfo mi)
+        [NotNull]
+        static MemberExpression MemberAccessExpression(Expression expr, [NotNull] MemberInfo mi)
         {
             return mi is FieldInfo ? Expression.Field(expr, (FieldInfo)mi) : Expression.Property(expr, (PropertyInfo)mi);
         }
@@ -69,6 +71,7 @@ namespace ProgressOnderwijsUtils
         [UsedImplicitly]
         static string ToString(object o) => ObjectToCode.ComplexObjectToPseudoCode(o);
 
+        [NotNull]
         static Func<T, string> byPublicMembers()
         {
             var concatMethod = ((Func<string[], string>)string.Concat).Method;
@@ -117,7 +120,8 @@ namespace ProgressOnderwijsUtils
             return Expression.Lambda<Func<T, string>>(toStringExpr, parA).Compile();
         }
 
-        static string FriendlyMemberName(MemberInfo fi)
+        [NotNull]
+        static string FriendlyMemberName([NotNull] MemberInfo fi)
         {
             bool isPublic;
             if (fi is FieldInfo) {

--- a/src/ProgressOnderwijsUtils/ValueBase.cs
+++ b/src/ProgressOnderwijsUtils/ValueBase.cs
@@ -43,6 +43,7 @@ namespace ProgressOnderwijsUtils
         [NotNull]
         public T Copy() => (T)MemberwiseClone();
 
+        [NotNull]
         public T CopyWith([NotNull] Action<T> action)
         {
             var copied = Copy();

--- a/src/ProgressOnderwijsUtils/WebSupport/CompressedUtf8String.cs
+++ b/src/ProgressOnderwijsUtils/WebSupport/CompressedUtf8String.cs
@@ -1,12 +1,14 @@
 ﻿using System.IO;
 using System.IO.Compression;
 using System.Text;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils.WebSupport
 {
     public sealed class CompressedUtf8String
     {
-        static byte[] ReadFully(Stream stream)
+        [NotNull]
+        static byte[] ReadFully([NotNull] Stream stream)
         {
             using (var ms = new MemoryStream()) {
                 stream.CopyTo(ms);
@@ -14,6 +16,7 @@ namespace ProgressOnderwijsUtils.WebSupport
             }
         }
 
+        [NotNull]
         public string StringData
         {
             get {
@@ -30,7 +33,7 @@ namespace ProgressOnderwijsUtils.WebSupport
             GzippedUtf8String = compressedData;
         }
 
-        public CompressedUtf8String(string stringData)
+        public CompressedUtf8String([NotNull] string stringData)
         {
             using (var compressedData = new MemoryStream()) {
                 var encodedData = Encoding.UTF8.GetBytes(stringData);

--- a/src/ProgressOnderwijsUtils/WebSupport/RemoveServerHeadersModule.cs
+++ b/src/ProgressOnderwijsUtils/WebSupport/RemoveServerHeadersModule.cs
@@ -1,4 +1,5 @@
 ﻿using System.Web;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils.WebSupport
 {
@@ -9,7 +10,7 @@ namespace ProgressOnderwijsUtils.WebSupport
             app.BeginRequest += (o, args) => RemoveIdentifyingHeaders((HttpApplication)o);
         }
 
-        static void RemoveIdentifyingHeaders(HttpApplication sender)
+        static void RemoveIdentifyingHeaders([NotNull] HttpApplication sender)
         {
             var context = sender.Context;
             var responseHeaders = context.Response.Headers;

--- a/src/ProgressOnderwijsUtils/WebSupport/SecurityModules.cs
+++ b/src/ProgressOnderwijsUtils/WebSupport/SecurityModules.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils.WebSupport
 {
@@ -12,7 +13,7 @@ namespace ProgressOnderwijsUtils.WebSupport
         /// <summary>
         /// Configures the app to redirect HTTP to HTTPS, use HSTS, remove some unnecessarily identifying server headers, and mark session cookies as HttpOnly+Secure.
         /// </summary>
-        public static void RegisterCommonSecurityModules(HttpApplication app) {
+        public static void RegisterCommonSecurityModules([NotNull] HttpApplication app) {
             new HstsAndHttpsRedirectModule().Init(app);
             new RemoveServerHeadersModule().Init(app);
             new SecureHttpOnlySessionCookieModule().Init(app);

--- a/src/ProgressOnderwijsUtils/XmlCompression.cs
+++ b/src/ProgressOnderwijsUtils/XmlCompression.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Text;
 using System.Xml;
 using System.Xml.Linq;
@@ -14,6 +15,9 @@ namespace ProgressOnderwijsUtils
         /// </summary>
         public static void CleanupNamespaces([NotNull] XDocument doc)
         {
+            if (doc.Root == null) {
+                throw new InvalidOperationException("empty documents not supported");
+            }
             var usedNamespaces = doc.Descendants().Select(el => el.Name.Namespace).ToSet();
             usedNamespaces.UnionWith(doc.Descendants().Attributes().Select(attr => attr.Name.Namespace));
 

--- a/src/ProgressOnderwijsUtils/XmlCompression.cs
+++ b/src/ProgressOnderwijsUtils/XmlCompression.cs
@@ -81,7 +81,7 @@ namespace ProgressOnderwijsUtils
         /// A null dictionary is permitted, which means "compress without dictionary".
         /// </param>
         /// <returns>The deflate-compressed document.</returns>
-        public static byte[] ToCompressedUtf8(XDocument doc, byte[] dictionary)
+        public static byte[] ToCompressedUtf8([NotNull] XDocument doc, byte[] dictionary)
         {
             CleanupNamespaces(doc);
             RemoveComments(doc);

--- a/src/ProgressOnderwijsUtils/XmlCompression.cs
+++ b/src/ProgressOnderwijsUtils/XmlCompression.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using System.Xml;
 using System.Xml.Linq;
+using JetBrains.Annotations;
 using ZlibWithDictionary;
 
 namespace ProgressOnderwijsUtils
@@ -11,7 +12,7 @@ namespace ProgressOnderwijsUtils
         /// <summary>
         /// Removes unused namespaces and makes sure the XMLSchema and XMLSchema-instance namespaces are mapped to the conventional prefix.
         /// </summary>
-        public static void CleanupNamespaces(XDocument doc)
+        public static void CleanupNamespaces([NotNull] XDocument doc)
         {
             var usedNamespaces = doc.Descendants().Select(el => el.Name.Namespace).ToSet();
             usedNamespaces.UnionWith(doc.Descendants().Attributes().Select(attr => attr.Name.Namespace));
@@ -38,7 +39,7 @@ namespace ProgressOnderwijsUtils
             }
         }
 
-        public static void RemoveComments(XDocument doc)
+        public static void RemoveComments([NotNull] XDocument doc)
         {
             foreach (var comment in doc.DescendantNodes().OfType<XComment>().ToArray()) {
                 comment.Remove();
@@ -55,7 +56,8 @@ namespace ProgressOnderwijsUtils
             OmitXmlDeclaration = true,
         };
 
-        public static byte[] ToUtf8(XDocument doc)
+        [NotNull]
+        public static byte[] ToUtf8([NotNull] XDocument doc)
         {
             var sb = new StringBuilder();
             using (var xw = XmlWriter.Create(sb, xmlWriterSettings))
@@ -64,7 +66,8 @@ namespace ProgressOnderwijsUtils
             return Encoding.UTF8.GetBytes(sb.ToString());
         }
 
-        public static XDocument FromUtf8(byte[] utf8EncodedXml)
+        [NotNull]
+        public static XDocument FromUtf8([NotNull] byte[] utf8EncodedXml)
             => XDocument.Parse(Encoding.UTF8.GetString(utf8EncodedXml));
 
         /// <summary>
@@ -90,6 +93,7 @@ namespace ProgressOnderwijsUtils
         /// <summary>
         /// Loads an XDocument that was saved with 'SaveUsingDeflateWithDictionary'.  You must provide the same dictionary used during compression. 
         /// </summary>
+        [NotNull]
         public static XDocument FromCompressedUtf8(byte[] compressedBytes, byte[] dictionary)
         {
             var bytes = DeflateCompression.ZlibDecompressWithDictionary(compressedBytes, dictionary);

--- a/src/ProgressOnderwijsUtils/XmlSerializableBase.cs
+++ b/src/ProgressOnderwijsUtils/XmlSerializableBase.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Serialization;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -12,7 +13,8 @@ namespace ProgressOnderwijsUtils
         public static T Deserialize<T>(string xml) => XmlSerializerHelper<T>.Deserialize(xml);
         public static T Deserialize<T>(XDocument xml) => XmlSerializerHelper<T>.Deserialize(xml);
 
-        public static string SerializeToString(object o)
+        [NotNull]
+        public static string SerializeToString([NotNull] object o)
         {
             using (var writer = new StringWriter()) {
                 using (var xw = XmlWriter.Create(writer))
@@ -27,7 +29,8 @@ namespace ProgressOnderwijsUtils
             }
         }
 
-        public static XDocument SerializeToXDocument(object o)
+        [NotNull]
+        public static XDocument SerializeToXDocument([NotNull] object o)
         {
             var doc = new XDocument();
             using (var xw = doc.CreateWriter())
@@ -52,22 +55,23 @@ namespace ProgressOnderwijsUtils
     {
         public static readonly XmlSerializer serializer = new XmlSerializer(typeof(T));
 
-        public static T Deserialize(XDocument from)
+        public static T Deserialize([NotNull] XDocument from)
         {
             using (var reader = from.CreateReader())
                 return Deserialize(reader);
         }
 
-        public static T Deserialize(XmlReader from) => (T)serializer.Deserialize(from);
+        public static T Deserialize([NotNull] XmlReader from) => (T)serializer.Deserialize(from);
 
-        public static T Deserialize(string from)
+        public static T Deserialize([NotNull] string from)
         {
             using (var reader = new StringReader(from))
                 return (T)serializer.Deserialize(reader);
         }
 
+        [NotNull]
         [CodeThatsOnlyUsedForTests]
-        public static string Serialize(T val)
+        public static string Serialize([NotNull] T val)
         {
             using (var writer = new StringWriter()) {
                 serializer.Serialize(writer, val);
@@ -77,7 +81,7 @@ namespace ProgressOnderwijsUtils
 
         internal XmlSerializerHelper() { }
 
-        void IXmlSerializeHelper.SerializeToInst(XmlWriter xw, object val)
+        void IXmlSerializeHelper.SerializeToInst([NotNull] XmlWriter xw, [NotNull] object val)
         {
             serializer.Serialize(xw, val);
         }

--- a/src/ProgressOnderwijsUtils/XmlSerializableBase.cs
+++ b/src/ProgressOnderwijsUtils/XmlSerializableBase.cs
@@ -10,8 +10,8 @@ namespace ProgressOnderwijsUtils
 {
     public static class XmlSerializerHelper
     {
-        public static T Deserialize<T>(string xml) => XmlSerializerHelper<T>.Deserialize(xml);
-        public static T Deserialize<T>(XDocument xml) => XmlSerializerHelper<T>.Deserialize(xml);
+        public static T Deserialize<T>([NotNull] string xml) => XmlSerializerHelper<T>.Deserialize(xml);
+        public static T Deserialize<T>([NotNull] XDocument xml) => XmlSerializerHelper<T>.Deserialize(xml);
 
         [NotNull]
         public static string SerializeToString([NotNull] object o)

--- a/test/ProgressOnderwijsUtilsTests/ApprovalTest.cs
+++ b/test/ProgressOnderwijsUtilsTests/ApprovalTest.cs
@@ -4,6 +4,7 @@ using ApprovalTests.Approvers;
 using ApprovalTests.Core;
 using ApprovalTests.Reporters;
 using ApprovalTests.Writers;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtilsTests
 {
@@ -15,7 +16,7 @@ namespace ProgressOnderwijsUtilsTests
             public string Name { get; set; }
         }
 
-        public static void Verify(string text, object IGNORE_PAST_THIS = null, [CallerFilePath] string filepath = null, [CallerMemberName] string membername = null)
+        public static void Verify(string text, [CanBeNull] object IGNORE_PAST_THIS = null, [CanBeNull] [CallerFilePath] string filepath = null, [CanBeNull] [CallerMemberName] string membername = null)
         {
             var writer = WriterFactory.CreateTextWriter(text);
             var filename = Path.GetFileNameWithoutExtension(filepath);

--- a/test/ProgressOnderwijsUtilsTests/ImageToolsTests.cs
+++ b/test/ProgressOnderwijsUtilsTests/ImageToolsTests.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using ExpressionToCodeLib;
+using JetBrains.Annotations;
 using ProgressOnderwijsUtils;
 using Xunit;
 
@@ -16,6 +17,7 @@ namespace ProgressOnderwijsUtilsTests
     
     public class ImageToolsTests
     {
+        [NotNull]
         static Bitmap GetRainbow()
         {
             return (Bitmap)Image.FromStream(
@@ -24,7 +26,7 @@ namespace ProgressOnderwijsUtilsTests
                 );
         }
 
-        static void AssertImagesSimilar(Bitmap img1, Bitmap img2)
+        static void AssertImagesSimilar([NotNull] Bitmap img1, Bitmap img2)
         {
             PAssert.That(() => img1.Size == img2.Size);
 

--- a/test/ProgressOnderwijsUtilsTests/NonceStoreTest.cs
+++ b/test/ProgressOnderwijsUtilsTests/NonceStoreTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using ExpressionToCodeLib;
+using JetBrains.Annotations;
 using Xunit;
 using ProgressOnderwijsUtils;
 
@@ -9,6 +10,7 @@ namespace ProgressOnderwijsUtilsTests
 {
     public class NonceStoreTest
     {
+        [NotNull]
         public static object[][] NonceStoreItemEqualityData()
         {
             return new[]

--- a/test/ProgressOnderwijsUtilsTests/OrderByTopologyTest.cs
+++ b/test/ProgressOnderwijsUtilsTests/OrderByTopologyTest.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using ExpressionToCodeLib;
+using JetBrains.Annotations;
 using Xunit;
 using ProgressOnderwijsUtils;
 
@@ -10,6 +11,7 @@ namespace ProgressOnderwijsUtilsTests
     {
         public readonly string Name;
         readonly IReadOnlyList<string> Dependencies;
+        [NotNull]
         public IEnumerable<DagNode> Children(Dictionary<string, DagNode> lookup) => Dependencies.Select(name => lookup.GetOrDefault(name, new DagNode(name)));
 
         public DagNode(string name, params string[] dependencies)

--- a/test/ProgressOnderwijsUtilsTests/TableValuedParameterTest.cs
+++ b/test/ProgressOnderwijsUtilsTests/TableValuedParameterTest.cs
@@ -4,6 +4,7 @@ using System.Data.Common;
 using System.Linq;
 using System.Text;
 using ExpressionToCodeLib;
+using JetBrains.Annotations;
 using ProgressOnderwijsUtils;
 using ProgressOnderwijsUtils.Internal;
 using Xunit;
@@ -113,7 +114,7 @@ namespace ProgressOnderwijsUtilsTests
                 Assert_DataReader_GetBytes_works(reader);
         }
 
-        static void Assert_DataReader_GetBytes_works(DbDataReader reader)
+        static void Assert_DataReader_GetBytes_works([NotNull] DbDataReader reader)
         {
             PAssert.That(() => reader.Read());
 

--- a/test/ProgressOnderwijsUtilsTests/XmlCompressionTest.cs
+++ b/test/ProgressOnderwijsUtilsTests/XmlCompressionTest.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text;
 using System.Xml.Linq;
 using ExpressionToCodeLib;
+using JetBrains.Annotations;
 using Xunit;
 using ProgressOnderwijsUtils;
 
@@ -160,7 +161,7 @@ namespace ProgressOnderwijsUtilsTests
             AssertCompressionCompressesAndRoundTrips(docString, null);
         }
 
-        static void AssertCompressionCompressesAndRoundTrips(string docString, byte[] dictionary)
+        static void AssertCompressionCompressesAndRoundTrips([NotNull] string docString, byte[] dictionary)
         {
             var doc = XDocument.Parse(docString);
             var compressedBytes = XmlCompression.ToCompressedUtf8(doc, dictionary);

--- a/tools/MicroOrmBench/DapperBench.cs
+++ b/tools/MicroOrmBench/DapperBench.cs
@@ -1,12 +1,13 @@
 using System;
 using System.Linq;
 using Dapper;
+using JetBrains.Annotations;
 
 namespace MicroOrmBench
 {
     static class DapperExecutor
     {
-        public static void RunQuery(Benchmarker benchmarker)
+        public static void RunQuery([NotNull] Benchmarker benchmarker)
         {
             benchmarker.BenchSQLite("Dapper (sqlite)", (ctx, rows) =>
                 ctx.Query<ExampleObject>(ExampleObject.RawSqliteQueryString, new { Arg = ExampleObject.someInt64Value, Top = rows, Num2 = 2, Hehe = "hehe" }).Count()
@@ -17,7 +18,7 @@ namespace MicroOrmBench
             );
         }
 
-        public static void RunWideQuery(Benchmarker benchmarker)
+        public static void RunWideQuery([NotNull] Benchmarker benchmarker)
         {
             benchmarker.BenchSqlServer("Dapper (26-col)", (ctx, rows) =>
                 ctx.Connection.Query<WideExampleObject>(WideExampleObject.RawQueryString, new { Top = rows, }).Count()

--- a/tools/MicroOrmBench/HandrolledAdoNetExecutor.cs
+++ b/tools/MicroOrmBench/HandrolledAdoNetExecutor.cs
@@ -6,13 +6,14 @@ using System.Data.SqlClient;
 using System.Data.SqlTypes;
 using System.Data.SQLite;
 using System.Runtime.CompilerServices;
+using JetBrains.Annotations;
 using ProgressOnderwijsUtils;
 
 namespace MicroOrmBench
 {
     static class HandrolledAdoNetExecutor
     {
-        public static void RunQuery(Benchmarker benchmarker)
+        public static void RunQuery([NotNull] Benchmarker benchmarker)
         {
             benchmarker.BenchSQLite("Raw (sqlite, cached)", ExecuteSqliteQueryCached);
             benchmarker.BenchSQLite("Raw (sqlite)", ExecuteSqliteQuery);
@@ -20,7 +21,7 @@ namespace MicroOrmBench
             benchmarker.BenchSqlServer("Raw (SqlDbTypes)", ExecuteQuery2);
         }
 
-        static int ExecuteQuery(SqlCommandCreationContext ctx, int rows)
+        static int ExecuteQuery([NotNull] SqlCommandCreationContext ctx, int rows)
         {
             using (var cmd = new SqlCommand()) {
                 cmd.CommandText = ExampleObject.RawQueryString;
@@ -123,7 +124,7 @@ namespace MicroOrmBench
 
         static readonly ConcurrentDictionary<SQLiteConnection, Dictionary<string, SQLiteCommand>> connCmdCache = new ConcurrentDictionary<SQLiteConnection, Dictionary<string, SQLiteCommand>>();
 
-        static int ExecuteSqliteQueryCached(SQLiteConnection ctx, int rows)
+        static int ExecuteSqliteQueryCached([NotNull] SQLiteConnection ctx, int rows)
         {
             if (!connCmdCache.TryGetValue(ctx, out var cmdCache)) {
                 cmdCache = connCmdCache.GetOrAdd(ctx, conn => {
@@ -191,7 +192,7 @@ namespace MicroOrmBench
         }
 
         // ReSharper disable once UnusedMember.Local
-        static int ExecuteQuery2(SqlCommandCreationContext ctx, int rows)
+        static int ExecuteQuery2([NotNull] SqlCommandCreationContext ctx, int rows)
         {
             using (var cmd = new SqlCommand()) {
                 cmd.CommandText = ExampleObject.RawQueryString;
@@ -247,16 +248,17 @@ namespace MicroOrmBench
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool? ToNullableBool(this SqlBoolean num) => num.IsNull ? default(bool?) : num.Value;
 
+        [CanBeNull]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         // ReSharper disable once UnusedMember.Local
         static string ToNullableString(this SqlString str) => str.IsNull ? default(string) : str.Value;
 
-        public static void RunWideQuery(Benchmarker benchmarker)
+        public static void RunWideQuery([NotNull] Benchmarker benchmarker)
         {
             benchmarker.BenchSqlServer("Raw (26-col)", ExecuteWideQuery);
         }
 
-        static int ExecuteWideQuery(SqlCommandCreationContext ctx, int rows)
+        static int ExecuteWideQuery([NotNull] SqlCommandCreationContext ctx, int rows)
         {
             using (var cmd = new SqlCommand()) {
                 cmd.CommandText = WideExampleObject.RawQueryString;

--- a/tools/MicroOrmBench/ParameterizedSqlExecutor.cs
+++ b/tools/MicroOrmBench/ParameterizedSqlExecutor.cs
@@ -1,12 +1,13 @@
 using System.Linq;
 using Dapper;
+using JetBrains.Annotations;
 using ProgressOnderwijsUtils;
 
 namespace MicroOrmBench
 {
     static class ParameterizedSqlExecutor
     {
-        public static void RunQuery(Benchmarker benchmarker)
+        public static void RunQuery([NotNull] Benchmarker benchmarker)
         {
             benchmarker.BenchSqlServer("ParameterizedSql",
                 (ctx, rows) => ExampleObject.ParameterizedSqlForRows(rows)
@@ -15,7 +16,7 @@ namespace MicroOrmBench
                 ;
         }
 
-        public static void RunWideQuery(Benchmarker benchmarker)
+        public static void RunWideQuery([NotNull] Benchmarker benchmarker)
         {
             benchmarker.BenchSqlServer("ParameterizedSql (26-col)",
                 (ctx, rows) => WideExampleObject.ParameterizedSqlForRows(rows)
@@ -24,7 +25,7 @@ namespace MicroOrmBench
                 ;
         }
 
-        public static void ConstructWithoutExecuting(Benchmarker benchmarker)
+        public static void ConstructWithoutExecuting([NotNull] Benchmarker benchmarker)
         {
             benchmarker.BenchSqlServer("ParameterizedSql noexec",
                 (ctx, rows) =>

--- a/tools/MicroOrmBench/Program.cs
+++ b/tools/MicroOrmBench/Program.cs
@@ -1,4 +1,6 @@
-﻿namespace MicroOrmBench
+﻿using JetBrains.Annotations;
+
+namespace MicroOrmBench
 {
     static class Program
     {
@@ -10,7 +12,7 @@
             RunCurrentBenchmarks(benchmarker);
         }
 
-        static void RunCurrentBenchmarks(Benchmarker benchmarker)
+        static void RunCurrentBenchmarks([NotNull] Benchmarker benchmarker)
         {
             //HandrolledAdoNetExecutor.RunQuery(benchmarker);
             //DapperExecutor.RunQuery(benchmarker);


### PR DESCRIPTION
motivation: we now have nullability warnings on in PNet.

This may be a little overzelous in any case, but after looking through the PNet warnings it appears that a few are caused by lack of annotations here.  Hence adding these should make some warnings in PNet go away (and possibly make more useful warnings appear).