### PR TITLE
resource store is non null

### DIFF
--- a/src/ProgressOnderwijsUtils/ResourceStore.cs
+++ b/src/ProgressOnderwijsUtils/ResourceStore.cs
@@ -25,8 +25,8 @@ namespace ProgressOnderwijsUtils
             }
         }
 
-        [CanBeNull]
-        public Stream GetResource(string filename) => typeof(T).GetResource(filename);
+        [NotNull]
+        public Stream GetResource(string filename) => typeof(T).GetResource(filename) ?? throw new KeyNotFoundException("Resource not found: " + filename);
 
         [ItemNotNull]
         public IEnumerable<string> GetResourceNames()

--- a/src/ProgressOnderwijsUtils/ResourceStore.cs
+++ b/src/ProgressOnderwijsUtils/ResourceStore.cs
@@ -7,6 +7,7 @@ namespace ProgressOnderwijsUtils
 {
     public interface IResourceStore
     {
+        bool ResourceExists(string filename);
         Stream GetResource(string filename);
         IEnumerable<string> GetResourceNames();
     }
@@ -27,6 +28,8 @@ namespace ProgressOnderwijsUtils
 
         [NotNull]
         public Stream GetResource(string filename) => typeof(T).GetResource(filename) ?? throw new KeyNotFoundException("Resource not found: " + filename);
+
+        public bool ResourceExists(string filename) => typeof(T).GetResource(filename) != null;
 
         [ItemNotNull]
         public IEnumerable<string> GetResourceNames()


### PR DESCRIPTION
In PNet, ResourceStore is always used in a non-null fashion. Requiring a bunch of null checks is impractical; better to check once here.

Alternative API suggestions welcome.