### PR TITLE
Improve SqlCommandTracer

### DIFF
--- a/ProgressOnderwijsUtils.sln.DotSettings
+++ b/ProgressOnderwijsUtils.sln.DotSettings
@@ -12,6 +12,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ParameterOnlyUsedForPreconditionCheck_002ELocal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ReplaceWithStringIsNullOrEmpty/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedAutoPropertyAccessor_002EGlobal/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedMember_002EGlobal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseNullPropagationWhenPossible/@EntryIndexedValue">SUGGESTION</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UsePatternMatching/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/JsInspections/LanguageLevel/@EntryValue">ECMAScript 2016</s:String>

--- a/src/ProgressOnderwijsUtils/Data/CommandFactory.cs
+++ b/src/ProgressOnderwijsUtils/Data/CommandFactory.cs
@@ -198,7 +198,7 @@ namespace ProgressOnderwijsUtils
         FastShortStringBuilder debugText;
 
         [NotNull]
-        public string RegisterParameterAndGetName<T>([NotNull] T o) where T : IQueryParameter => SqlCommandTracer.InsecureSqlDebugString(o.EquatableValue, true);
+        public string RegisterParameterAndGetName<T>([NotNull] T o) where T : IQueryParameter => SqlCommandDebugStringifier.InsecureSqlDebugString(o.EquatableValue, true);
 
         public void AppendSql([NotNull] string sql, int startIndex, int length) => debugText.AppendText(sql, startIndex, length);
 

--- a/src/ProgressOnderwijsUtils/Data/MetaObjectDataReader.cs
+++ b/src/ProgressOnderwijsUtils/Data/MetaObjectDataReader.cs
@@ -24,6 +24,8 @@ namespace ProgressOnderwijsUtils
         readonly IEnumerator<T> metaObjects;
         readonly IReadOnlyList<T> objectsOrNull_ForDebugging;
         T current;
+        int rowsProcessed;
+        public int RowsProcessed => rowsProcessed;
 
         public MetaObjectDataReader([NotNull] IEnumerable<T> objects)
         {
@@ -43,6 +45,7 @@ namespace ProgressOnderwijsUtils
             var hasnext = metaObjects.MoveNext();
             if (hasnext) {
                 current = metaObjects.Current;
+                rowsProcessed++;
             }
             return hasnext;
         }

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -28,7 +28,8 @@ namespace ProgressOnderwijsUtils
                 try {
                     return action(cmd.Command);
                 } catch (Exception e) {
-                    throw new ParameterizedSqlExecutionException(exceptionMessage() + "\n\nCOMMAND TIMEOUT: " + cmd.Command.CommandTimeout + " s\n\nQUERY:\n\n" + SqlCommandTracer.DebugFriendlyCommandText(cmd.Command, SqlCommandTracerOptions.IncludeArgumentValuesInLog), e);
+                    var debugFriendlyCommandText = SqlCommandDebugStringifier.DebugFriendlyCommandText(cmd.Command, SqlTracerAgumentInclusion.IncludingArgumentValues);
+                    throw new ParameterizedSqlExecutionException(exceptionMessage() + "\n\nCOMMAND TIMEOUT: " + cmd.Command.CommandTimeout + " s\n\nQUERY:\n\n" + debugFriendlyCommandText, e);
                 }
         }
 
@@ -161,7 +162,7 @@ namespace ProgressOnderwijsUtils
         static string QueryExecutionErrorMessage<T>([NotNull] SqlCommand cmd, [CanBeNull] [CallerMemberName] string caller = null) where T : IMetaObject, new()
         {
             return caller + "<" + typeof(T).ToCSharpFriendlyTypeName() + ">() failed. \n\nQUERY:\n\n"
-                + SqlCommandTracer.DebugFriendlyCommandText(cmd, SqlCommandTracerOptions.IncludeArgumentValuesInLog);
+                + SqlCommandDebugStringifier.DebugFriendlyCommandText(cmd, SqlTracerAgumentInclusion.IncludingArgumentValues);
         }
 
         /// <summary>

--- a/src/ProgressOnderwijsUtils/Data/SqlCommandDebugStringifier.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlCommandDebugStringifier.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Globalization;
+using System.Linq;
+using ExpressionToCodeLib;
+using JetBrains.Annotations;
+
+namespace ProgressOnderwijsUtils
+{
+    public static class SqlCommandDebugStringifier {
+        [NotNull]
+        public static string DebugFriendlyCommandText([NotNull] SqlCommand sqlCommand, SqlTracerAgumentInclusion includeSensitiveInfo)
+            => CommandParamStringOrEmpty(sqlCommand, includeSensitiveInfo) + sqlCommand.CommandText;
+
+        [NotNull]
+        static string CommandParamStringOrEmpty(SqlCommand sqlCommand, SqlTracerAgumentInclusion includeSensitiveInfo)
+        {
+            if (includeSensitiveInfo == SqlTracerAgumentInclusion.IncludingArgumentValues) {
+                return CommandParamString(sqlCommand);
+            } else {
+                return "";
+            }
+        }
+
+        [NotNull]
+        static string CommandParamString([NotNull] SqlCommand sqlCommand)
+            => sqlCommand.Parameters.Cast<SqlParameter>().Select(DeclareParameter).JoinStrings();
+
+        [NotNull]
+        static string DeclareParameter([NotNull] SqlParameter par)
+        {
+            var declareVariable = "DECLARE " + par.ParameterName + " AS " + SqlParamTypeString(par);
+            if (par.SqlDbType != SqlDbType.Structured) {
+                return declareVariable
+                    + " = " + InsecureSqlDebugString(par.Value, true) + ";\n";
+            } else {
+                return declareVariable
+                    + "/*" + par.Value.GetType().ToCSharpFriendlyTypeName() + "*/;\n"
+                    + "insert into " + par.ParameterName + " values "
+                    + ValuesClauseForTableValuedParameter((par.Value as IOptionalObjectListForDebugging)?.ContentsForDebuggingOrNull());
+            }
+        }
+
+        [NotNull]
+        static string ValuesClauseForTableValuedParameter([CanBeNull] IReadOnlyList<object> tableValue)
+        {
+            if (tableValue == null) {
+                return "(/* UNKNOWN? */);\n";
+            }
+            const int maxValuesToInsert = 20;
+            var valuesString = tableValue.Take(maxValuesToInsert).Select(v => $"({InsecureSqlDebugString(v, false)})").JoinStrings(", ");
+            var valueCountCommentIfNecessary = (tableValue.Count <= maxValuesToInsert ? "" : "\n    /* ... and more; " + tableValue.Count + " total */") + ";\n";
+            return valuesString + valueCountCommentIfNecessary;
+        }
+
+        [NotNull]
+        static string SqlParamTypeString([NotNull] SqlParameter par)
+            => par.SqlDbType == SqlDbType.Structured
+                ? par.TypeName
+                : par.SqlDbType + (par.SqlDbType == SqlDbType.NVarChar ? "(max)" : "");
+
+        [NotNull]
+        public static string InsecureSqlDebugString([CanBeNull] object p, bool includeReadableEnumValue)
+        {
+            if (p is DBNull || p == null) {
+                return "NULL";
+            } else if (p is DateTime) {
+                return "'" + ((DateTime)p).ToUniversalTime().ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff'Z'", CultureInfo.InvariantCulture) + "'";
+            } else if (p is string) {
+                return "'" + ((string)p).Replace("'", "''") + "'";
+            } else if (p is long) {
+                return ((long)p).ToStringInvariant();
+            } else if (p is int) {
+                return ((int)p).ToStringInvariant();
+            } else if (p is bool) {
+                return (bool)p ? "1" : "0";
+            } else if (p is Enum) {
+                return ((IConvertible)p).ToInt64(null).ToStringInvariant() + (includeReadableEnumValue ? "/*" + ObjectToCode.PlainObjectToCode(p) + "*/" : "");
+            } else if (p is IFormattable) {
+                return ((IFormattable)p).ToString(null, CultureInfo.InvariantCulture);
+            } else {
+                try {
+                    return "{!" + p + "!}";
+                } catch (Exception e) {
+                    return $"[[Exception in {nameof(SqlCommandTracer)}.{nameof(InsecureSqlDebugString)}: {e.Message}]]";
+                }
+            }
+        }
+    }
+}

--- a/src/ProgressOnderwijsUtils/Data/SqlCommandTracer.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlCommandTracer.cs
@@ -1,255 +1,133 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Data.SqlClient;
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
-using System.Threading;
-using ExpressionToCodeLib;
 using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
-    public interface ISqlCommandTracer
+    public struct SqlTraceEvent
     {
-        IEnumerable<Tuple<string, TimeSpan>> AllCommands { get; }
-        TimeSpan TotalDuration { get; }
-        int CommandCount { get; }
-        TimeSpan SlowestCommandDuration { get; }
-        void FinishDisposableTimer(Func<string> commandText, TimeSpan duration);
-        IDisposable StartCommandTimer(string commandText);
-        IDisposable StartCommandTimer(SqlCommand sqlCommand);
-        void StartTracing();
-        void StopTracing();
+        public string EventContent;
+        public TimeSpan Duration;
+        public TimeSpan CumulativeElapsedTime;
     }
 
-    public enum SqlCommandTracerOptions
+    public interface ISqlCommandTracer
     {
-        ExcludeArgumentValuesFromLog,
-        IncludeArgumentValuesInLog
+        [NotNull]
+        SqlTraceEvent[] ListAllCommands();
+
+        void RegisterEvent(string commandText, TimeSpan duration);
+        SqlTracerAgumentInclusion ArgumentInclusion { get; }
+        bool IsTracing { get; }
+    }
+
+    public enum SqlTracerAgumentInclusion
+    {
+        ExcludingArgumentValues,
+        IncludingArgumentValues,
     }
 
     public static class SqlCommandTracer
     {
         [NotNull]
-        public static ISqlCommandTracer CreateAlwaysOnTracer(SqlCommandTracerOptions includeSensitiveInfo)
-            => new SqlCommandTracerImpl(includeSensitiveInfo);
-
-        public static ISqlCommandTracer CreateAlwaysOffTracer() => NoopTracer.Instance;
+        public static ISqlCommandTracer CreateAlwaysOnTracer(SqlTracerAgumentInclusion agumentInclusion) => new AlwaysOnTracer(agumentInclusion);
 
         [NotNull]
-        public static ISqlCommandTracer CreateTogglableTracer(SqlCommandTracerOptions includeSensitiveInfo)
-            => new ResettableCommandTracer(() => CreateAlwaysOnTracer(includeSensitiveInfo));
+        public static ISqlCommandTracer CreateAlwaysOffTracer(SqlTracerAgumentInclusion agumentInclusion) => new AlwaysOffTracer(agumentInclusion);
 
-        sealed class NoopTracer : ISqlCommandTracer
+        [NotNull]
+        public static ISqlCommandTracer WrapTracer([NotNull] ISqlCommandTracer originalTracer) => new WrappingTracer(originalTracer);
+
+        sealed class AlwaysOffTracer : ISqlCommandTracer
         {
-            public static readonly NoopTracer Instance = new NoopTracer();
-
-            [NotNull]
-            public IEnumerable<Tuple<string, TimeSpan>> AllCommands => Array.Empty<Tuple<string, TimeSpan>>();
-
-            public TimeSpan TotalDuration => TimeSpan.Zero;
-            public int CommandCount => 0;
-            public TimeSpan SlowestCommandDuration => TimeSpan.Zero;
-            public void FinishDisposableTimer(Func<string> commandText, TimeSpan duration) { }
-
-            [CanBeNull]
-            public IDisposable StartCommandTimer(string commandText) => null;
-
-            [CanBeNull]
-            public IDisposable StartCommandTimer(SqlCommand sqlCommand) => null;
-
-            public void StartTracing() { }
-            public void StopTracing() { }
+            public AlwaysOffTracer(SqlTracerAgumentInclusion agumentInclusion) => ArgumentInclusion = agumentInclusion;
+            public SqlTraceEvent[] ListAllCommands() => Array.Empty<SqlTraceEvent>();
+            public void RegisterEvent(string commandText, TimeSpan duration) { }
+            public SqlTracerAgumentInclusion ArgumentInclusion { get; }
+            public bool IsTracing => false;
         }
 
-        [NotNull]
-        public static string DebugFriendlyCommandText([NotNull] SqlCommand sqlCommand, SqlCommandTracerOptions includeSensitiveInfo)
-            => CommandParamStringOrEmpty(sqlCommand, includeSensitiveInfo) + sqlCommand.CommandText;
-
-        [NotNull]
-        static string CommandParamStringOrEmpty(SqlCommand sqlCommand, SqlCommandTracerOptions includeSensitiveInfo)
+        sealed class AlwaysOnTracer : ISqlCommandTracer
         {
-            if (includeSensitiveInfo == SqlCommandTracerOptions.IncludeArgumentValuesInLog) {
-                return CommandParamString(sqlCommand);
-            } else {
-                return "";
-            }
-        }
+            readonly Stopwatch ElapsedTime = Stopwatch.StartNew();
+            readonly List<SqlTraceEvent> allqueries = new List<SqlTraceEvent>();
 
-        [NotNull]
-        static string CommandParamString([NotNull] SqlCommand sqlCommand)
-            => sqlCommand.Parameters.Cast<SqlParameter>().Select(DeclareParameter).JoinStrings();
-
-        [NotNull]
-        static string DeclareParameter([NotNull] SqlParameter par)
-        {
-            var declareVariable = "DECLARE " + par.ParameterName + " AS " + SqlParamTypeString(par);
-            if (par.SqlDbType != SqlDbType.Structured) {
-                return declareVariable
-                    + " = " + InsecureSqlDebugString(par.Value, true) + ";\n";
-            } else {
-                return declareVariable
-                    + "/*" + par.Value.GetType().ToCSharpFriendlyTypeName() + "*/;\n"
-                    + "insert into " + par.ParameterName + " values "
-                    + ValuesClauseForTableValuedParameter((par.Value as IOptionalObjectListForDebugging)?.ContentsForDebuggingOrNull());
-            }
-        }
-
-        [NotNull]
-        static string ValuesClauseForTableValuedParameter([CanBeNull] IReadOnlyList<object> tableValue)
-        {
-            if (tableValue == null) {
-                return "(/* UNKNOWN? */);\n";
-            }
-            const int maxValuesToInsert = 20;
-            var valuesString = tableValue.Take(maxValuesToInsert).Select(v => $"({InsecureSqlDebugString(v, false)})").JoinStrings(", ");
-            var valueCountCommentIfNecessary = (tableValue.Count <= maxValuesToInsert ? "" : "\n    /* ... and more; " + tableValue.Count + " total */") + ";\n";
-            return valuesString + valueCountCommentIfNecessary;
-        }
-
-        [NotNull]
-        static string SqlParamTypeString([NotNull] SqlParameter par)
-            => par.SqlDbType == SqlDbType.Structured
-                ? par.TypeName
-                : par.SqlDbType + (par.SqlDbType == SqlDbType.NVarChar ? "(max)" : "");
-
-        [NotNull]
-        public static string InsecureSqlDebugString([CanBeNull] object p, bool includeReadableEnumValue)
-        {
-            if (p is DBNull || p == null) {
-                return "NULL";
-            } else if (p is DateTime) {
-                return "'" + ((DateTime)p).ToUniversalTime().ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff'Z'", CultureInfo.InvariantCulture) + "'";
-            } else if (p is string) {
-                return "'" + ((string)p).Replace("'", "''") + "'";
-            } else if (p is long) {
-                return ((long)p).ToStringInvariant();
-            } else if (p is int) {
-                return ((int)p).ToStringInvariant();
-            } else if (p is bool) {
-                return (bool)p ? "1" : "0";
-            } else if (p is Enum) {
-                return ((IConvertible)p).ToInt64(null).ToStringInvariant() + (includeReadableEnumValue ? "/*" + ObjectToCode.PlainObjectToCode(p) + "*/" : "");
-            } else if (p is IFormattable) {
-                return ((IFormattable)p).ToString(null, CultureInfo.InvariantCulture);
-            } else {
-                try {
-                    return "{!" + p + "!}";
-                } catch (Exception e) {
-                    return $"[[Exception in {nameof(SqlCommandTracer)}.{nameof(InsecureSqlDebugString)}: {e.Message}]]";
-                }
-            }
-        }
-
-        sealed class SqlCommandTracerImpl : ISqlCommandTracer
-        {
-            public int CommandCount => commandCount;
-            int commandCount;
-            int commandsCompleted;
-            readonly SqlCommandTracerOptions IncludeSensitiveInfo;
-
-            public SqlCommandTracerImpl(SqlCommandTracerOptions inlcudeSensiveInfo)
+            public AlwaysOnTracer(SqlTracerAgumentInclusion agumentInclusion)
             {
-                IncludeSensitiveInfo = inlcudeSensiveInfo;
-            }
-
-            readonly object Sync = new object();
-            readonly List<Tuple<TimeSpan, Func<string>>> allqueries = new List<Tuple<TimeSpan, Func<string>>>();
-            Tuple<TimeSpan, Func<string>> slowest = Tuple.Create(default(TimeSpan), (Func<string>)(() => "(none)"));
-            public TimeSpan SlowestCommandDuration => slowest.Item1;
-
-            [NotNull]
-            public IEnumerable<Tuple<string, TimeSpan>> AllCommands => allqueries.Select(tup => Tuple.Create(tup.Item2(), tup.Item1));
-
-            public TimeSpan TotalDuration { get; private set; }
-
-            [NotNull]
-            IDisposable StartCommandTimer([NotNull] Func<string> commandText)
-            {
-                if (commandText == null) {
-                    throw new ArgumentNullException(nameof(commandText));
-                }
-
-                return new SqlCommandTimer(this, commandText);
+                ArgumentInclusion = agumentInclusion;
             }
 
             [NotNull]
-            public IDisposable StartCommandTimer([NotNull] string commandText)
+            public SqlTraceEvent[] ListAllCommands()
             {
-                if (commandText == null) {
-                    throw new ArgumentNullException(nameof(commandText));
-                }
-
-                return StartCommandTimer(() => commandText);
-            }
-
-            [NotNull]
-            public IDisposable StartCommandTimer([NotNull] SqlCommand sqlCommand) => StartCommandTimer(DebugFriendlyCommandText(sqlCommand, IncludeSensitiveInfo));
-
-            public void FinishDisposableTimer(Func<string> commandText, TimeSpan duration)
-            {
-                lock (Sync) {
-                    var entry = Tuple.Create(duration, commandText);
-
-                    if (SlowestCommandDuration < duration) {
-                        slowest = Tuple.Create(duration, commandText);
-                    }
-                    allqueries.Add(entry);
-                    TotalDuration += duration;
+                lock (allqueries) {
+                    return allqueries.ToArray();
                 }
             }
 
-            public void StartTracing() { }
-            public void StopTracing() { }
-
-            sealed class SqlCommandTimer : IDisposable
+            public void RegisterEvent(string commandText, TimeSpan duration)
             {
-                readonly SqlCommandTracerImpl tracer;
-                readonly Func<string> lazySqlCommandText;
-                readonly Stopwatch commandStopwatch;
-
-                internal SqlCommandTimer([NotNull] SqlCommandTracerImpl tracer, Func<string> lazySqlCommandText)
-                {
-                    this.tracer = tracer;
-                    this.lazySqlCommandText = lazySqlCommandText;
-                    Interlocked.Increment(ref tracer.commandCount);
-                    commandStopwatch = Stopwatch.StartNew();
-                }
-
-                public void Dispose()
-                {
-                    commandStopwatch.Stop();
-                    Interlocked.Increment(ref tracer.commandsCompleted);
-                    tracer.FinishDisposableTimer(lazySqlCommandText, commandStopwatch.Elapsed);
+                lock (allqueries) {
+                    allqueries.Add(new SqlTraceEvent { EventContent = commandText, Duration = duration, CumulativeElapsedTime = ElapsedTime.Elapsed });
                 }
             }
+
+            public SqlTracerAgumentInclusion ArgumentInclusion { get; }
+            public bool IsTracing => true;
         }
 
-        public sealed class ResettableCommandTracer : ISqlCommandTracer
+        sealed class WrappingTracer : ISqlCommandTracer
         {
-            ISqlCommandTracer sqlCommandTracer;
-            readonly Func<ISqlCommandTracer> tracerFactory;
+            readonly ISqlCommandTracer Original;
+            readonly ISqlCommandTracer Inner;
 
-            public ResettableCommandTracer(Func<ISqlCommandTracer> tracerFactory)
+            public WrappingTracer([NotNull] ISqlCommandTracer original)
             {
-                this.tracerFactory = tracerFactory;
-                StopTracing();
+                Original = original;
+                Inner = CreateAlwaysOnTracer(original.ArgumentInclusion);
             }
 
-            public IEnumerable<Tuple<string, TimeSpan>> AllCommands => sqlCommandTracer.AllCommands;
-            public TimeSpan TotalDuration => sqlCommandTracer.TotalDuration;
-            public int CommandCount => sqlCommandTracer.CommandCount;
-            public TimeSpan SlowestCommandDuration => sqlCommandTracer.SlowestCommandDuration;
+            public SqlTraceEvent[] ListAllCommands() => Inner.ListAllCommands();
 
-            public void FinishDisposableTimer(Func<string> commandText, TimeSpan duration)
-                => sqlCommandTracer.FinishDisposableTimer(commandText, duration);
+            public void RegisterEvent(string commandText, TimeSpan duration)
+            {
+                Inner.RegisterEvent(commandText, duration);
+                Original.RegisterEvent(commandText, duration);
+            }
 
-            public IDisposable StartCommandTimer(string commandText) => sqlCommandTracer.StartCommandTimer(commandText);
-            public IDisposable StartCommandTimer(SqlCommand sqlCommand) => sqlCommandTracer.StartCommandTimer(sqlCommand);
-            public void StartTracing() => sqlCommandTracer = tracerFactory();
-            public void StopTracing() => sqlCommandTracer = CreateAlwaysOffTracer();
+            public SqlTracerAgumentInclusion ArgumentInclusion => Original.ArgumentInclusion;
+            public bool IsTracing => true;
+        }
+
+        [CanBeNull]
+        public static IDisposable StartCommandTimer(this ISqlCommandTracer tracer, string commandText)
+            => !tracer.IsTracing ? null : new SqlCommandTimer(tracer, commandText);
+
+        [CanBeNull]
+        public static IDisposable StartCommandTimer(this ISqlCommandTracer tracer, SqlCommand sqlCommand)
+            => !tracer.IsTracing ? null : new SqlCommandTimer(tracer, SqlCommandDebugStringifier.DebugFriendlyCommandText(sqlCommand, tracer.ArgumentInclusion));
+
+        sealed class SqlCommandTimer : IDisposable
+        {
+            readonly ISqlCommandTracer tracer;
+            readonly string sqlCommandText;
+            readonly Stopwatch commandStopwatch;
+
+            internal SqlCommandTimer([NotNull] ISqlCommandTracer tracer, string sqlCommandText)
+            {
+                this.tracer = tracer;
+                this.sqlCommandText = sqlCommandText;
+                commandStopwatch = Stopwatch.StartNew();
+            }
+
+            public void Dispose()
+            {
+                commandStopwatch.Stop();
+                tracer.RegisterEvent(sqlCommandText, commandStopwatch.Elapsed);
+            }
         }
     }
 }

--- a/src/ProgressOnderwijsUtils/MetaObject/MetaObjectBulkCopy.cs
+++ b/src/ProgressOnderwijsUtils/MetaObject/MetaObjectBulkCopy.cs
@@ -68,7 +68,11 @@ namespace ProgressOnderwijsUtils
         }
 
         static void TraceBulkInsertDuration([CanBeNull] ISqlCommandTracer tracerOrNull, string tableName, Stopwatch sw, int rowsInserted)
-            => tracerOrNull?.FinishDisposableTimer(() => "Bulk inserted " + rowsInserted + " rows into " + tableName, sw.Elapsed);
+        {
+            if (tracerOrNull?.IsTracing ?? false) {
+                tracerOrNull.RegisterEvent("Bulk inserted " + rowsInserted + " rows into " + tableName, sw.Elapsed);
+            }
+        }
 
         static readonly Regex colidMessageRegex = new Regex(@"Received an invalid column length from the bcp client for colid ([0-9]+).", RegexOptions.Compiled);
 

--- a/src/ProgressOnderwijsUtils/MetaObject/MetaObjectBulkCopy.cs
+++ b/src/ProgressOnderwijsUtils/MetaObject/MetaObjectBulkCopy.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlClient;
+using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -10,6 +11,7 @@ using ExpressionToCodeLib;
 using JetBrains.Annotations;
 
 // ReSharper disable once CheckNamespace
+
 namespace ProgressOnderwijsUtils
 {
     public static class MetaObjectBulkCopy
@@ -26,15 +28,16 @@ namespace ProgressOnderwijsUtils
         {
             using (var bulkCopy = new SqlBulkCopy(sqlconn.Connection, SqlBulkCopyOptions.CheckConstraints, null)) {
                 bulkCopy.BulkCopyTimeout = sqlconn.CommandTimeoutInS;
-                bulkCopy.WriteMetaObjectsToServer(metaObjects, sqlconn.Connection, tableName);
+                bulkCopy.WriteMetaObjectsToServerAsync(metaObjects, sqlconn, tableName, CancellationToken.None).Wait();
             }
         }
 
         /// <summary>
         /// Writes meta-objects to the server.  If you use this method, it must be the only "WriteToServer" method you call on this bulk-copy instance because it sets the column mapping.
         /// </summary>
-        public static async Task WriteMetaObjectsToServerAsync<T>([NotNull] this SqlBulkCopy bulkCopy, [NotNull] IEnumerable<T> metaObjects, [NotNull] SqlConnection sqlconn, [NotNull] string tableName, CancellationToken cancellationToken) where T : IMetaObject, IPropertiesAreUsedImplicitly
+        public static async Task WriteMetaObjectsToServerAsync<T>([NotNull] this SqlBulkCopy bulkCopy, [NotNull] IEnumerable<T> metaObjects, [NotNull] SqlCommandCreationContext context, [NotNull] string tableName, CancellationToken cancellationToken) where T : IMetaObject, IPropertiesAreUsedImplicitly
         {
+            var sqlconn = context.Connection;
             if (metaObjects == null) {
                 throw new ArgumentNullException(nameof(metaObjects));
             }
@@ -51,21 +54,21 @@ namespace ProgressOnderwijsUtils
 
             using (var objectReader = new MetaObjectDataReader<T>(metaObjects)) {
                 var mapping = ApplyMetaObjectColumnMapping(bulkCopy, objectReader, sqlconn, tableName);
-
+                var sw = Stopwatch.StartNew();
                 try {
                     await bulkCopy.WriteToServerAsync(objectReader, cancellationToken).ConfigureAwait(false);
                 } catch (SqlException ex) when (ParseDestinationColumnIndexFromMessage(ex.Message).HasValue) {
                     var destinationColumnIndex = ParseDestinationColumnIndexFromMessage(ex.Message).Value;
                     var metaPropName = typeof(T).ToCSharpFriendlyTypeName() + "." + mapping.Single(m => m.DstIndex == destinationColumnIndex).SourceColumnDefinition.Name;
                     throw new Exception($"Received an invalid column length from the bcp client for metaobject property ${metaPropName}.", ex);
+                } finally {
+                    TraceBulkInsertDuration(context.Tracer, tableName, sw, objectReader.RowsProcessed);
                 }
             }
         }
 
-        public static void WriteMetaObjectsToServer<T>([NotNull] this SqlBulkCopy bulkCopy, [NotNull] IEnumerable<T> metaObjects, [NotNull] SqlConnection sqlconn, [NotNull] string tableName) where T : IMetaObject, IPropertiesAreUsedImplicitly
-        {
-            bulkCopy.WriteMetaObjectsToServerAsync(metaObjects, sqlconn, tableName, CancellationToken.None).Wait();
-        }
+        static void TraceBulkInsertDuration([CanBeNull] ISqlCommandTracer tracerOrNull, string tableName, Stopwatch sw, int rowsInserted)
+            => tracerOrNull?.FinishDisposableTimer(() => "Bulk inserted " + rowsInserted + " rows into " + tableName, sw.Elapsed);
 
         static readonly Regex colidMessageRegex = new Regex(@"Received an invalid column length from the bcp client for colid ([0-9]+).", RegexOptions.Compiled);
 

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Configuration">
-    <Version>16.1.0</Version>
-    <PackageReleaseNotes>Implement ArrayOrderingComparer</PackageReleaseNotes>
+    <Version>17.0.0</Version>
+    <PackageReleaseNotes>Improve the api of SqlCommandTracer and trace bulk inserts too.</PackageReleaseNotes>
     <Authors>Progress Onderwijs</Authors>
     <Owners>Progress Onderwijs</Owners>
     <Title>ProgressOnderwijsUtils</Title>

--- a/test/ProgressOnderwijsUtils.Tests/DistinctArrayTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/DistinctArrayTest.cs
@@ -45,7 +45,7 @@ namespace ProgressOnderwijsUtils.Tests
         }
 
         [Fact]
-        public void Creating_DistinctArray_from_not_distinct_with_custom_comparer_gives_error()
+        public void Creating_DistinctArray_from_not_disBtinct_with_custom_comparer_gives_error()
         {
             Assert.ThrowsAny<ArgumentException>(() => {
                 // ReSharper disable once UnusedVariable

--- a/test/ProgressOnderwijsUtils.Tests/TransactedLocalConnection.cs
+++ b/test/ProgressOnderwijsUtils.Tests/TransactedLocalConnection.cs
@@ -12,7 +12,7 @@ namespace ProgressOnderwijsUtils.Tests
 
         public TransactedLocalConnection()
         {
-            Context = new SqlCommandCreationContext(new SqlConnection(Environment.GetEnvironmentVariable("CONNECTION_STRING") ?? @"Server = (localdb)\MSSQLLocalDB; Integrated Security = true"), 60, SqlCommandTracer.CreateAlwaysOffTracer());
+            Context = new SqlCommandCreationContext(new SqlConnection(Environment.GetEnvironmentVariable("CONNECTION_STRING") ?? @"Server = (localdb)\MSSQLLocalDB; Integrated Security = true"), 60, SqlCommandTracer.CreateAlwaysOffTracer(SqlTracerAgumentInclusion.IncludingArgumentValues));
             try {
                 Context.Connection.Open();
                 ParameterizedSql.TableValuedTypeDefinitionScripts.ExecuteNonQuery(Context);


### PR DESCRIPTION
In particular, also trace bulk copy duration+number of rows inserted.

Also reduce the api size, and include elapsed time in addition to sql time.

This will cause some breaking changes in pnet.