### PR TITLE
Fix crash SsoProcessor.GetAssertion when multiple StatusCodes are present

### DIFF
--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Configuration">
-    <Version>18.0.0</Version>
-    <PackageReleaseNotes>Improve the api of CascadedDelete.</PackageReleaseNotes>
+    <Version>18.0.1</Version>
+    <PackageReleaseNotes>Fix crash SsoProcessor.GetAssertion when multiple StatusCodes are present.</PackageReleaseNotes>
     <Authors>Progress Onderwijs</Authors>
     <Owners>Progress Onderwijs</Owners>
     <Title>ProgressOnderwijsUtils</Title>

--- a/src/ProgressOnderwijsUtils/SingleSignOn/SsoProcessor.cs
+++ b/src/ProgressOnderwijsUtils/SingleSignOn/SsoProcessor.cs
@@ -49,7 +49,7 @@ namespace ProgressOnderwijsUtils.SingleSignOn
         {
             LOG.Debug(() => $"GetAssertion(response='{response}')");
 
-            var statusCodeAttribute = response.Descendants(SamlNamespaces.SAMLP_NS + "StatusCode").Single().Attribute("Value")
+            var statusCodeAttribute = response.Descendants(SamlNamespaces.SAMLP_NS + "StatusCode").First().Attribute("Value")
                 ?? throw new InvalidOperationException("Missing status code attribute");
 
             if (statusCodeAttribute.Value == "urn:oasis:names:tc:SAML:2.0:status:Success") {

--- a/src/ProgressOnderwijsUtils/SingleSignOn/SsoProcessor.cs
+++ b/src/ProgressOnderwijsUtils/SingleSignOn/SsoProcessor.cs
@@ -49,7 +49,12 @@ namespace ProgressOnderwijsUtils.SingleSignOn
         {
             LOG.Debug(() => $"GetAssertion(response='{response}')");
 
-            var statusCodeAttribute = response.Descendants(SamlNamespaces.SAMLP_NS + "StatusCode").First().Attribute("Value")
+            var statusCodes = response.Descendants(SamlNamespaces.SAMLP_NS + "StatusCode").ToArray();
+            if (statusCodes.Length > 1) {
+                return null;
+            }
+
+            var statusCodeAttribute = statusCodes[0].Attribute("Value")
                 ?? throw new InvalidOperationException("Missing status code attribute");
 
             if (statusCodeAttribute.Value == "urn:oasis:names:tc:SAML:2.0:status:Success") {


### PR DESCRIPTION
Example:

```xml
<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_280dea7f76d83385651ab0aef8a12c6eb26532302cd580ce955ff0b2dcd3" Version="2.0" IssueInstant="2018-03-06T13:32:27Z" Destination="https://progresswww.nl/surff/sso/post/" InResponseTo="bla">
  <saml:Issuer>https://sa-gw.surfconext.nl/authentication/metadata</saml:Issuer>
  <samlp:Status>
    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Responder">
      <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:NoAuthnContext" />
    </samlp:StatusCode>
  </samlp:Status>
</samlp:Response>
```