### PR TITLE
Herziening SLMaybeIncompleteDateConversion

### DIFF
--- a/src/ProgressOnderwijsUtils/Utils.cs
+++ b/src/ProgressOnderwijsUtils/Utils.cs
@@ -225,7 +225,7 @@ namespace ProgressOnderwijsUtils
         /// waarbij nulwaarden voor datum of maand worden omgezet naar de waarde 1
         /// Alleen voor KVA4
         /// </summary>
-        public static DateTime? SLMaybeIncompleteDateConversionLess([CanBeNull] string incompleteDate) {
+        public static DateTime? SLMaybeIncompleteDateConversion([CanBeNull] string incompleteDate) {
             var dateFrags = (incompleteDate ?? "").Split('-').Select(el => el == "00" ? "1" : el).ToArray();
             return dateFrags.Length == 3 ? (DateTime?)DateTime.Parse(string.Join("/", dateFrags)) : null;
         }

--- a/src/ProgressOnderwijsUtils/Utils.cs
+++ b/src/ProgressOnderwijsUtils/Utils.cs
@@ -225,9 +225,9 @@ namespace ProgressOnderwijsUtils
         /// waarbij nulwaarden voor datum of maand worden omgezet naar de waarde 1
         /// Alleen voor KVA4
         /// </summary>
-        public static DateTime? SLMaybeIncompleteDateConversion([CanBeNull] string incompleteDate)
+        public static DateTime? SLMaybeIncompleteDateConversion(string incompleteDate)
         {
-            if (incompleteDate != null) {
+            if (!incompleteDate.IsNullOrWhiteSpace()) {
                 var incompleteDateFragments = incompleteDate.Split('-');
                 var month = incompleteDateFragments[1] == "00" ? "1" : incompleteDateFragments[1];
                 var date = incompleteDateFragments[2] == "00" ? "1" : incompleteDateFragments[2];

--- a/src/ProgressOnderwijsUtils/Utils.cs
+++ b/src/ProgressOnderwijsUtils/Utils.cs
@@ -225,16 +225,9 @@ namespace ProgressOnderwijsUtils
         /// waarbij nulwaarden voor datum of maand worden omgezet naar de waarde 1
         /// Alleen voor KVA4
         /// </summary>
-        public static DateTime? SLMaybeIncompleteDateConversion(string incompleteDate)
-        {
-            if (!incompleteDate.IsNullOrWhiteSpace()) {
-                var incompleteDateFragments = incompleteDate.Split('-');
-                var month = incompleteDateFragments[1] == "00" ? "1" : incompleteDateFragments[1];
-                var date = incompleteDateFragments[2] == "00" ? "1" : incompleteDateFragments[2];
-                return DateTime.Parse(incompleteDateFragments[0] + "/" + month + "/" + date);
-            } else {
-                return null;
-            }
+        public static DateTime? SLMaybeIncompleteDateConversionLess([CanBeNull] string incompleteDate) {
+            var dateFrags = (incompleteDate ?? "").Split('-').Select(el => el == "00" ? "1" : el).ToArray();
+            return dateFrags.Length == 3 ? (DateTime?)DateTime.Parse(string.Join("/", dateFrags)) : null;
         }
 
         /// <summary>

--- a/src/ProgressOnderwijsUtils/Utils.cs
+++ b/src/ProgressOnderwijsUtils/Utils.cs
@@ -223,10 +223,13 @@ namespace ProgressOnderwijsUtils
         /// <summary>
         /// converteert incomplete studielinkdatums (bv 'yyyy-00-00' naar complete datum, 
         /// waarbij nulwaarden voor datum of maand worden omgezet naar de waarde 1
-        /// Alleen voor KVA4
+        /// en nullwaarde voor jaar naar 1900 (type staat nl ook "0000-00-00" toe)
         /// </summary>
         public static DateTime? SLMaybeIncompleteDateConversion([CanBeNull] string incompleteDate) {
-            var dateFrags = (incompleteDate ?? "").Split('-').Select(el => el == "00" ? "1" : el).ToArray();
+            var dateFrags = (incompleteDate ?? "")
+                .Split('-')
+                .Select(el => el == "0000" ? "1900" : el == "00" ? "1" : el)
+                .ToArray();
             return dateFrags.Length == 3 ? (DateTime?)DateTime.Parse(string.Join("/", dateFrags)) : null;
         }
 

--- a/test/ProgressOnderwijsUtils.Tests/UtilsTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/UtilsTest.cs
@@ -209,6 +209,18 @@ namespace ProgressOnderwijsUtils.Tests
         }
 
         [Fact]
+        public void SLMaybeIncompleteDateConversionTest()
+        {
+            PAssert.That(() => Utils.SLMaybeIncompleteDateConversion(null) == null);
+            PAssert.That(() => Utils.SLMaybeIncompleteDateConversion("") == null);
+            PAssert.That(() => Utils.SLMaybeIncompleteDateConversion("2018-03") == null);
+            PAssert.That(() => Utils.SLMaybeIncompleteDateConversion("2018") == null);
+            PAssert.That(() => Utils.SLMaybeIncompleteDateConversion("0000-00-00") == DateTime.Parse("1900/01/01"));
+            PAssert.That(() => Utils.SLMaybeIncompleteDateConversion("2018-00-00") == DateTime.Parse("2018/01/01"));
+            PAssert.That(() => Utils.SLMaybeIncompleteDateConversion("2018-03-00") == DateTime.Parse("2018/03/01"));
+        }
+
+        [Fact]
         public void MultiTransitiveClosureWorks()
         {
             var nodes = new[] {2, 3,};


### PR DESCRIPTION
Deze herziening zorgt ervoor dat berichten met lege datumvelden vanuit het nieuwe studielink (QDelft stuurt *alle* lege velden met xsi:nil) niet crashen