### PR TITLE
Limit SqlCommandTracer to max 1000 events, in order to prevent memory…

### DIFF
--- a/src/ProgressOnderwijsUtils/Data/SqlCommandTracer.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlCommandTracer.cs
@@ -68,10 +68,16 @@ namespace ProgressOnderwijsUtils
                 }
             }
 
+            const int maxEventCount = 1000;
+
             public void RegisterEvent(string commandText, TimeSpan duration)
             {
                 lock (allqueries) {
-                    allqueries.Add(new SqlTraceEvent { EventContent = commandText, Duration = duration, CumulativeElapsedTime = ElapsedTime.Elapsed });
+                    if (allqueries.Count < maxEventCount) {
+                        allqueries.Add(new SqlTraceEvent { EventContent = commandText, Duration = duration, CumulativeElapsedTime = ElapsedTime.Elapsed });
+                    } else if (allqueries.Count == maxEventCount) {
+                        allqueries.Add(new SqlTraceEvent { EventContent = $"Max event count ({maxEventCount}) reached", CumulativeElapsedTime = ElapsedTime.Elapsed });
+                    }
                 }
             }
 

--- a/src/ProgressOnderwijsUtils/Data/SqlCommandTracer.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlCommandTracer.cs
@@ -54,6 +54,8 @@ namespace ProgressOnderwijsUtils
         {
             readonly Stopwatch ElapsedTime = Stopwatch.StartNew();
             readonly List<SqlTraceEvent> allqueries = new List<SqlTraceEvent>();
+            const int maxTotalEventContentSize = 1_000_000;
+            int totalEventContentSize;
 
             public AlwaysOnTracer(SqlTracerAgumentInclusion agumentInclusion)
             {
@@ -68,15 +70,16 @@ namespace ProgressOnderwijsUtils
                 }
             }
 
-            const int maxEventCount = 1000;
-
             public void RegisterEvent(string commandText, TimeSpan duration)
             {
                 lock (allqueries) {
-                    if (allqueries.Count < maxEventCount) {
-                        allqueries.Add(new SqlTraceEvent { EventContent = commandText, Duration = duration, CumulativeElapsedTime = ElapsedTime.Elapsed });
-                    } else if (allqueries.Count == maxEventCount) {
-                        allqueries.Add(new SqlTraceEvent { EventContent = $"Max event count ({maxEventCount}) reached", CumulativeElapsedTime = ElapsedTime.Elapsed });
+                    if (totalEventContentSize >= maxTotalEventContentSize) {
+                        return;
+                    }
+                    allqueries.Add(new SqlTraceEvent { EventContent = commandText, Duration = duration, CumulativeElapsedTime = ElapsedTime.Elapsed });
+                    totalEventContentSize += commandText.Length;
+                    if (totalEventContentSize >= maxTotalEventContentSize) {
+                        allqueries.Add(new SqlTraceEvent { EventContent = $"Max event data size ({totalEventContentSize}) reached", CumulativeElapsedTime = ElapsedTime.Elapsed });
                     }
                 }
             }

--- a/src/ProgressOnderwijsUtils/Data/SqlCommandTracer.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlCommandTracer.cs
@@ -54,7 +54,7 @@ namespace ProgressOnderwijsUtils
         {
             readonly Stopwatch ElapsedTime = Stopwatch.StartNew();
             readonly List<SqlTraceEvent> allqueries = new List<SqlTraceEvent>();
-            const int maxTotalEventContentSize = 1_000_000;
+            const int maxTotalEventContentSize = 100_000_000;
             int totalEventContentSize;
 
             public AlwaysOnTracer(SqlTracerAgumentInclusion agumentInclusion)

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Configuration">
     <Version>24.0.0</Version>
-    <PackageReleaseNotes>Limit SqlCommandTracer to max 1000000 characters worth of events, in order to prevent memory usage from exploding.</PackageReleaseNotes>
+    <PackageReleaseNotes>Limit SqlCommandTracer to max 100_000_000 characters worth of events, in order to prevent memory usage from exploding.</PackageReleaseNotes>
     <Authors>Progress Onderwijs</Authors>
     <Owners>Progress Onderwijs</Owners>
     <Title>ProgressOnderwijsUtils</Title>

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Configuration">
-    <Version>23.2.2</Version>
-    <PackageReleaseNotes>Update dependencies</PackageReleaseNotes>
+    <Version>24.0.0</Version>
+    <PackageReleaseNotes>Limit SqlCommandTracer to max 1000 events, in order to prevent memory usage from exploding.</PackageReleaseNotes>
     <Authors>Progress Onderwijs</Authors>
     <Owners>Progress Onderwijs</Owners>
     <Title>ProgressOnderwijsUtils</Title>

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Configuration">
     <Version>24.0.0</Version>
-    <PackageReleaseNotes>Limit SqlCommandTracer to max 1000 events, in order to prevent memory usage from exploding.</PackageReleaseNotes>
+    <PackageReleaseNotes>Limit SqlCommandTracer to max 1000000 characters worth of events, in order to prevent memory usage from exploding.</PackageReleaseNotes>
     <Authors>Progress Onderwijs</Authors>
     <Owners>Progress Onderwijs</Owners>
     <Title>ProgressOnderwijsUtils</Title>


### PR DESCRIPTION
… usage from exploding