### PR TITLE
Minor cleanups

### DIFF
--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -1,5 +1,3 @@
-// ReSharper disable PossiblyMistakenUseOfParamsMethod
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -8,16 +6,12 @@ using System.Data.SqlClient;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using ExpressionToCodeLib;
 using FastExpressionCompiler;
 using JetBrains.Annotations;
 using ProgressOnderwijsUtils.Collections;
-// ReSharper disable RedundantUsingDirective
-using System.Reflection.Emit;
-using System.Threading;
-
-// ReSharper restore RedundantUsingDirective
 
 namespace ProgressOnderwijsUtils
 {
@@ -252,18 +246,6 @@ namespace ProgressOnderwijsUtils
                 map => map.InterfaceMethods.Zip(map.TargetMethods, Tuple.Create))
                 .ToDictionary(methodPair => methodPair.Item1, methodPair => methodPair.Item2);
         }
-
-        static readonly ModuleBuilder moduleBuilder;
-#pragma warning disable 169
-        static int counter;
-#pragma warning restore 169
-
-        static ParameterizedSqlObjectMapper()
-        {
-            var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("AutoLoadFromDb_Helper"), AssemblyBuilderAccess.Run);
-            moduleBuilder = assemblyBuilder.DefineDynamicModule("AutoLoadFromDb_HelperModule");
-        }
-
         static readonly MethodInfo getTimeSpan_SqlDataReader = typeof(SqlDataReader).GetMethod("GetTimeSpan", binding);
         static readonly MethodInfo getDateTimeOffset_SqlDataReader = typeof(SqlDataReader).GetMethod("GetDateTimeOffset", binding);
         const int AsciiUpperToLowerDiff = 'a' - 'A';

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -331,21 +331,16 @@ namespace ProgressOnderwijsUtils
             static MethodInfo CreateMethodOfTypeWithCreateMethod([NotNull] Type type)
             {
                 var underlyingType = type.GetNonNullableUnderlyingType();
-                var method = underlyingType.GetMethods(BindingFlags.Static | BindingFlags.Public).SingleOrDefault(m => m.GetCustomAttributes<MetaObjectPropertyLoaderAttribute>().Any());
-                if (method == null) {
-                    return null;
-                }
-                if (method.ReturnType != underlyingType) {
-                    return null;
-                }
-                var parameters = method.GetParameters();
-                if (parameters.Length != 1) {
-                    return null;
-                }
-                if (SupportsType(parameters[0].ParameterType)) {
-                    return method;
-                }
-                return null;
+                var methods = underlyingType.GetMethods(BindingFlags.Static | BindingFlags.Public);
+                var method = methods.SingleOrDefault(m => m.GetCustomAttributes<MetaObjectPropertyLoaderAttribute>().Any());
+                return
+                    method != null
+                        && method.ReturnType == underlyingType
+                        && method.GetParameters() is var parameters
+                        && parameters.Length == 1
+                        && SupportsType(parameters[0].ParameterType)
+                        ? method
+                        : null;
             }
 
             static MethodInfo GetterForType([NotNull] Type underlyingType)

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -6,7 +6,6 @@ using System.Data.SqlClient;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using ExpressionToCodeLib;
 using FastExpressionCompiler;
@@ -246,6 +245,7 @@ namespace ProgressOnderwijsUtils
                 map => map.InterfaceMethods.Zip(map.TargetMethods, Tuple.Create))
                 .ToDictionary(methodPair => methodPair.Item1, methodPair => methodPair.Item2);
         }
+
         static readonly MethodInfo getTimeSpan_SqlDataReader = typeof(SqlDataReader).GetMethod("GetTimeSpan", binding);
         static readonly MethodInfo getDateTimeOffset_SqlDataReader = typeof(SqlDataReader).GetMethod("GetDateTimeOffset", binding);
         const int AsciiUpperToLowerDiff = 'a' - 'A';
@@ -332,31 +332,28 @@ namespace ProgressOnderwijsUtils
                 return SupportsType(mp.DataType);
             }
 
-            static bool IsCreatableType([NotNull] IMetaProperty mp)
-            {
-                return CreateMethodOfTypeWithCreateMethod(mp.DataType, out var _);
-            }
+            static bool IsCreatableType([NotNull] IMetaProperty mp) 
+                => CreateMethodOfTypeWithCreateMethod(mp.DataType) != null;
 
-            static bool CreateMethodOfTypeWithCreateMethod([NotNull] Type type, [CanBeNull] out MethodInfo methodInfo)
+            [CanBeNull]
+            static MethodInfo CreateMethodOfTypeWithCreateMethod([NotNull] Type type)
             {
-                methodInfo = null;
                 var underlyingType = type.GetNonNullableUnderlyingType();
                 var method = underlyingType.GetMethods(BindingFlags.Static | BindingFlags.Public).SingleOrDefault(m => m.GetCustomAttributes<MetaObjectPropertyLoaderAttribute>().Any());
                 if (method == null) {
-                    return false;
+                    return null;
                 }
                 if (method.ReturnType != underlyingType) {
-                    return false;
+                    return null;
                 }
                 var parameters = method.GetParameters();
                 if (parameters.Length != 1) {
-                    return false;
+                    return null;
                 }
                 if (SupportsType(parameters[0].ParameterType)) {
-                    methodInfo = method;
-                    return true;
+                    return method;
                 }
-                return false;
+                return null;
             }
 
             static MethodInfo GetterForType([NotNull] Type underlyingType)
@@ -365,7 +362,7 @@ namespace ProgressOnderwijsUtils
                     return getTimeSpan_SqlDataReader;
                 } else if (isSqlDataReader && underlyingType == typeof(DateTimeOffset)) {
                     return getDateTimeOffset_SqlDataReader;
-                } else if (CreateMethodOfTypeWithCreateMethod(underlyingType, out var methodInfo)) {
+                } else if (CreateMethodOfTypeWithCreateMethod(underlyingType) is var methodInfo && methodInfo != null) {
                     return InterfaceMap[getterMethodsByType[methodInfo.GetParameters()[0].ParameterType]];
                 } else {
                     return InterfaceMap[getterMethodsByType[underlyingType]];
@@ -375,7 +372,9 @@ namespace ProgressOnderwijsUtils
             static Expression GetCastExpression(Expression callExpression, [NotNull] Type type)
             {
                 var underlyingType = type.GetNonNullableUnderlyingType();
-                var isTypeWithCreateMethod = CreateMethodOfTypeWithCreateMethod(underlyingType, out var methodInfo);
+                var methodInfo = CreateMethodOfTypeWithCreateMethod(underlyingType);
+                var isTypeWithCreateMethod = methodInfo != null;
+
                 var needsCast = underlyingType != type.GetNonNullableType();
 
                 if (isTypeWithCreateMethod) {

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -319,10 +319,10 @@ namespace ProgressOnderwijsUtils
             }
 
             static bool IsSupportedType([NotNull] Type type)
-                => IsSupportedBasicType(type) || IsTypeWithCustomLoader(type) != null;
+                => IsSupportedBasicType(type) || CustomLoaderForType(type) != null;
 
             [CanBeNull]
-            static MethodInfo IsTypeWithCustomLoader([NotNull] Type type)
+            static MethodInfo CustomLoaderForType([NotNull] Type type)
             {
                 var underlyingType = type.GetNonNullableUnderlyingType();
                 var methods = underlyingType.GetMethods(BindingFlags.Static | BindingFlags.Public);
@@ -343,7 +343,7 @@ namespace ProgressOnderwijsUtils
                     return getTimeSpan_SqlDataReader;
                 } else if (isSqlDataReader && underlyingType == typeof(DateTimeOffset)) {
                     return getDateTimeOffset_SqlDataReader;
-                } else if (IsTypeWithCustomLoader(underlyingType) is var methodInfo && methodInfo != null) {
+                } else if (CustomLoaderForType(underlyingType) is var methodInfo && methodInfo != null) {
                     return InterfaceMap[getterMethodsByType[methodInfo.GetParameters()[0].ParameterType]];
                 } else {
                     return InterfaceMap[getterMethodsByType[underlyingType]];
@@ -353,7 +353,7 @@ namespace ProgressOnderwijsUtils
             static Expression GetCastExpression(Expression callExpression, [NotNull] Type type)
             {
                 var underlyingType = type.GetNonNullableUnderlyingType();
-                var methodInfo = IsTypeWithCustomLoader(underlyingType);
+                var methodInfo = CustomLoaderForType(underlyingType);
                 var isTypeWithCreateMethod = methodInfo != null;
 
                 var needsCast = underlyingType != type.GetNonNullableType();

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -10,6 +10,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using ExpressionToCodeLib;
+using FastExpressionCompiler;
 using JetBrains.Annotations;
 using ProgressOnderwijsUtils.Collections;
 // ReSharper disable RedundantUsingDirective
@@ -473,10 +474,10 @@ namespace ProgressOnderwijsUtils
             }
 
             [NotNull]
-            static TDelegate ConvertLambdaExpressionIntoDelegate<T, TDelegate>([NotNull] Expression<TDelegate> loadRowsLambda)
+            static TDelegate ConvertLambdaExpressionIntoDelegate<T, TDelegate>([NotNull] Expression<TDelegate> loadRowsLambda) where TDelegate : class
             {
                 try {
-                    return loadRowsLambda.Compile(); //TODO: use FastExpressionCompiler
+                    return loadRowsLambda.CompileFast<TDelegate>();
                 } catch (Exception e) {
                     throw new InvalidOperationException("Cannot dynamically compile unpacker method for type " + typeof(T) + ", where type.IsPublic: " + typeof(T).IsPublic, e);
                 }

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -242,8 +242,8 @@ namespace ProgressOnderwijsUtils
         static Dictionary<MethodInfo, MethodInfo> MakeMap([NotNull] params InterfaceMapping[] mappings)
         {
             return mappings.SelectMany(
-                map => map.InterfaceMethods.Zip(map.TargetMethods, Tuple.Create))
-                .ToDictionary(methodPair => methodPair.Item1, methodPair => methodPair.Item2);
+                map => map.InterfaceMethods.Zip(map.TargetMethods, (interfaceMethod, targetMethod) => (interfaceMethod, targetMethod)))
+                .ToDictionary(methodPair => methodPair.interfaceMethod, methodPair => methodPair.targetMethod);
         }
 
         static readonly MethodInfo getTimeSpan_SqlDataReader = typeof(SqlDataReader).GetMethod("GetTimeSpan", binding);

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -233,11 +233,7 @@ namespace ProgressOnderwijsUtils
                 { typeof(string), typeof(IDataRecord).GetMethod("GetString", binding) },
             };
 
-        //static bool SupportsType(Type type) => GetterMethodsByType.ContainsKey(type);
-        //static MethodInfo GetterForType(Type type) => GetterMethodsByType[type];
 
-        //static readonly MethodInfo IsDBNullMethod = typeof(IDataRecord).GetMethod("IsDBNull", binding);
-        //static readonly MethodInfo ReadMethod = typeof(IDataReader).GetMethod("Read", binding);
         [NotNull]
         static Dictionary<MethodInfo, MethodInfo> MakeMap([NotNull] params InterfaceMapping[] mappings)
             => mappings

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -327,10 +327,8 @@ namespace ProgressOnderwijsUtils
             static bool SupportsMetaProperty([NotNull] IMetaProperty mp)
                 => IsSimpletype(mp) || IsCreatableType(mp);
 
-            static bool IsSimpletype([NotNull] IMetaProperty mp)
-            {
-                return SupportsType(mp.DataType);
-            }
+            static bool IsSimpletype([NotNull] IMetaProperty mp) 
+                => SupportsType(mp.DataType);
 
             static bool IsCreatableType([NotNull] IMetaProperty mp) 
                 => CreateMethodOfTypeWithCreateMethod(mp.DataType) != null;

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -240,11 +240,9 @@ namespace ProgressOnderwijsUtils
         //static readonly MethodInfo ReadMethod = typeof(IDataReader).GetMethod("Read", binding);
         [NotNull]
         static Dictionary<MethodInfo, MethodInfo> MakeMap([NotNull] params InterfaceMapping[] mappings)
-        {
-            return mappings.SelectMany(
+            => mappings.SelectMany(
                 map => map.InterfaceMethods.Zip(map.TargetMethods, (interfaceMethod, targetMethod) => (interfaceMethod, targetMethod)))
                 .ToDictionary(methodPair => methodPair.interfaceMethod, methodPair => methodPair.targetMethod);
-        }
 
         static readonly MethodInfo getTimeSpan_SqlDataReader = typeof(SqlDataReader).GetMethod("GetTimeSpan", binding);
         static readonly MethodInfo getDateTimeOffset_SqlDataReader = typeof(SqlDataReader).GetMethod("GetDateTimeOffset", binding);

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -315,7 +315,7 @@ namespace ProgressOnderwijsUtils
             static readonly MethodInfo ReadMethod = InterfaceMap[typeof(IDataReader).GetMethod("Read", binding)];
             static readonly bool isSqlDataReader = typeof(TReader) == typeof(SqlDataReader);
 
-            static bool SupportsType([NotNull] Type type)
+            static bool IsSupportedBasicType([NotNull] Type type)
             {
                 var underlyingType = type.GetNonNullableUnderlyingType();
 
@@ -325,7 +325,7 @@ namespace ProgressOnderwijsUtils
             }
 
             static bool SupportsMetaProperty([NotNull] IMetaProperty mp)
-                => SupportsType(mp.DataType) || CreateMethodOfTypeWithCreateMethod(mp.DataType) != null;
+                => IsSupportedBasicType(mp.DataType) || CreateMethodOfTypeWithCreateMethod(mp.DataType) != null;
 
             [CanBeNull]
             static MethodInfo CreateMethodOfTypeWithCreateMethod([NotNull] Type type)
@@ -338,7 +338,7 @@ namespace ProgressOnderwijsUtils
                         && method.ReturnType == underlyingType
                         && method.GetParameters() is var parameters
                         && parameters.Length == 1
-                        && SupportsType(parameters[0].ParameterType)
+                        && IsSupportedBasicType(parameters[0].ParameterType)
                         ? method
                         : null;
             }
@@ -682,11 +682,11 @@ namespace ProgressOnderwijsUtils
                     }
                     var retval = constructors.Single();
 
-                    if (!retval.GetParameters().All(pi => SupportsType(pi.ParameterType))) {
+                    if (!retval.GetParameters().All(pi => IsSupportedBasicType(pi.ParameterType))) {
                         throw new ArgumentException(
                             FriendlyName + " : ILoadFromDbByConstructor's constructor must have only simple types: cannot support "
                                 + retval.GetParameters()
-                                    .Where(pi => !SupportsType(pi.ParameterType))
+                                    .Where(pi => !IsSupportedBasicType(pi.ParameterType))
                                     .Select(pi => pi.ParameterType.ToCSharpFriendlyTypeName() + " " + pi.Name)
                                     .JoinStrings(", "));
                     }
@@ -731,7 +731,7 @@ namespace ProgressOnderwijsUtils
 
                 static void VerifyTypeValidity()
                 {
-                    if (!SupportsType(type)) {
+                    if (!IsSupportedBasicType(type)) {
                         throw new ArgumentException(
                             FriendlyName + " cannot be auto loaded as plain data since it isn't a basic type ("
                                 + getterMethodsByType.Keys.Select(ObjectToCode.ToCSharpFriendlyTypeName).JoinStrings(", ") + ")!");

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -325,13 +325,7 @@ namespace ProgressOnderwijsUtils
             }
 
             static bool SupportsMetaProperty([NotNull] IMetaProperty mp)
-                => IsSimpletype(mp) || IsCreatableType(mp);
-
-            static bool IsSimpletype([NotNull] IMetaProperty mp) 
-                => SupportsType(mp.DataType);
-
-            static bool IsCreatableType([NotNull] IMetaProperty mp) 
-                => CreateMethodOfTypeWithCreateMethod(mp.DataType) != null;
+                => SupportsType(mp.DataType) || CreateMethodOfTypeWithCreateMethod(mp.DataType) != null;
 
             [CanBeNull]
             static MethodInfo CreateMethodOfTypeWithCreateMethod([NotNull] Type type)

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -324,8 +324,8 @@ namespace ProgressOnderwijsUtils
                     ;
             }
 
-            static bool SupportsMetaProperty([NotNull] IMetaProperty mp)
-                => IsSupportedBasicType(mp.DataType) || CreateMethodOfTypeWithCreateMethod(mp.DataType) != null;
+            static bool SupportsMetaProperty([NotNull] IMetaProperty mp, [NotNull] Type type)
+                => IsSupportedBasicType(type) || CreateMethodOfTypeWithCreateMethod(type) != null;
 
             [CanBeNull]
             static MethodInfo CreateMethodOfTypeWithCreateMethod([NotNull] Type type)
@@ -504,7 +504,7 @@ namespace ProgressOnderwijsUtils
                 {
                     var writablePropCount = 0;
                     foreach (var mp in metadata) { //perf:no LINQ
-                        if (mp.CanWrite && SupportsMetaProperty(mp)) {
+                        if (mp.CanWrite && SupportsMetaProperty(mp, mp.DataType)) {
                             writablePropCount++;
                         }
                     }
@@ -516,7 +516,7 @@ namespace ProgressOnderwijsUtils
                         }
                     hasUnsupportedColumns = false;
                     foreach (var mp in metadata) { //perf:no LINQ
-                        if (mp.CanWrite && !SupportsMetaProperty(mp)) {
+                        if (mp.CanWrite && !SupportsMetaProperty(mp, mp.DataType)) {
                             hasUnsupportedColumns = true;
                             break;
                         }
@@ -557,7 +557,7 @@ namespace ProgressOnderwijsUtils
                     if (reader.FieldCount > ColHashPrimes.Length
                         || (reader.FieldCount < ColHashPrimes.Length || hasUnsupportedColumns) && fieldMappingMode == FieldMappingMode.RequireExactColumnMatches) {
                         var columnNames = Enumerable.Range(0, reader.FieldCount).Select(reader.GetName).ToArray();
-                        var publicWritableProperties = metadata.Where(SupportsMetaProperty).Select(mp => mp.Name).ToArray();
+                        var publicWritableProperties = metadata.Where(mp => SupportsMetaProperty(mp, mp.DataType)).Select(mp => mp.Name).ToArray();
                         var columnsThatCannotBeMapped = columnNames.Except(publicWritableProperties, StringComparer.OrdinalIgnoreCase);
                         var propertiesWithoutColumns = publicWritableProperties.Except(columnNames, StringComparer.OrdinalIgnoreCase);
                         throw new InvalidOperationException(

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -324,7 +324,7 @@ namespace ProgressOnderwijsUtils
                     ;
             }
 
-            static bool SupportsMetaProperty([NotNull] IMetaProperty mp, [NotNull] Type type)
+            static bool SupportsMetaProperty([NotNull] Type type)
                 => IsSupportedBasicType(type) || CreateMethodOfTypeWithCreateMethod(type) != null;
 
             [CanBeNull]
@@ -504,7 +504,7 @@ namespace ProgressOnderwijsUtils
                 {
                     var writablePropCount = 0;
                     foreach (var mp in metadata) { //perf:no LINQ
-                        if (mp.CanWrite && SupportsMetaProperty(mp, mp.DataType)) {
+                        if (mp.CanWrite && SupportsMetaProperty(mp.DataType)) {
                             writablePropCount++;
                         }
                     }
@@ -516,7 +516,7 @@ namespace ProgressOnderwijsUtils
                         }
                     hasUnsupportedColumns = false;
                     foreach (var mp in metadata) { //perf:no LINQ
-                        if (mp.CanWrite && !SupportsMetaProperty(mp, mp.DataType)) {
+                        if (mp.CanWrite && !SupportsMetaProperty(mp.DataType)) {
                             hasUnsupportedColumns = true;
                             break;
                         }
@@ -557,7 +557,7 @@ namespace ProgressOnderwijsUtils
                     if (reader.FieldCount > ColHashPrimes.Length
                         || (reader.FieldCount < ColHashPrimes.Length || hasUnsupportedColumns) && fieldMappingMode == FieldMappingMode.RequireExactColumnMatches) {
                         var columnNames = Enumerable.Range(0, reader.FieldCount).Select(reader.GetName).ToArray();
-                        var publicWritableProperties = metadata.Where(mp => SupportsMetaProperty(mp, mp.DataType)).Select(mp => mp.Name).ToArray();
+                        var publicWritableProperties = metadata.Where(mp => SupportsMetaProperty(mp.DataType)).Select(mp => mp.Name).ToArray();
                         var columnsThatCannotBeMapped = columnNames.Except(publicWritableProperties, StringComparer.OrdinalIgnoreCase);
                         var propertiesWithoutColumns = publicWritableProperties.Except(columnNames, StringComparer.OrdinalIgnoreCase);
                         throw new InvalidOperationException(

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -240,8 +240,8 @@ namespace ProgressOnderwijsUtils
         //static readonly MethodInfo ReadMethod = typeof(IDataReader).GetMethod("Read", binding);
         [NotNull]
         static Dictionary<MethodInfo, MethodInfo> MakeMap([NotNull] params InterfaceMapping[] mappings)
-            => mappings.SelectMany(
-                map => map.InterfaceMethods.Zip(map.TargetMethods, (interfaceMethod, targetMethod) => (interfaceMethod, targetMethod)))
+            => mappings
+                .SelectMany(map => map.InterfaceMethods.Zip(map.TargetMethods, (interfaceMethod, targetMethod) => (interfaceMethod, targetMethod)))
                 .ToDictionary(methodPair => methodPair.interfaceMethod, methodPair => methodPair.targetMethod);
 
         static readonly MethodInfo getTimeSpan_SqlDataReader = typeof(SqlDataReader).GetMethod("GetTimeSpan", binding);


### PR DESCRIPTION
except for the (hopefully trivial) first commit, these are local refactorings, and replacing Expression.Compile with CompileFast *should* be safe.