### PR TITLE
Replace AuthnInstant in SsoAttributes with IssueInstant

### DIFF
--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>27.0.0</Version>
-    <PackageReleaseNotes>Remove Async support of SqlBulkCopy wrappers to workaround SqlBulkCopy bugs.</PackageReleaseNotes>
+    <Version>28.0.0</Version>
+    <PackageReleaseNotes>Replace AuthnInstant in SsoAttributes with IssueInstant.</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Various utility methods+classes used by Progress Onderwijs.</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>

--- a/src/ProgressOnderwijsUtils/SingleSignOn/SsoAttributes.cs
+++ b/src/ProgressOnderwijsUtils/SingleSignOn/SsoAttributes.cs
@@ -10,7 +10,7 @@ namespace ProgressOnderwijsUtils.SingleSignOn
         public string[] email;
         public string[] roles;
         public string InResponseTo;
-        public DateTime AuthnInstant;
+        public DateTime IssueInstant;
         public string AuthnContextClassRef;
 
         public override string ToString()

--- a/src/ProgressOnderwijsUtils/SingleSignOn/SsoProcessor.cs
+++ b/src/ProgressOnderwijsUtils/SingleSignOn/SsoProcessor.cs
@@ -80,7 +80,7 @@ namespace ProgressOnderwijsUtils.SingleSignOn
                 email = GetAttributes(assertion, MAIL),
                 roles = GetAttributes(assertion, ROLE),
                 InResponseTo = GetInResponseTo(assertion),
-                AuthnInstant = (DateTime)authnStatement.Attribute("AuthnInstant"),
+                IssueInstant = (DateTime)assertion.Attribute("IssueInstant"),
                 AuthnContextClassRef = (string)authnStatement.Element(SamlNamespaces.SAML_NS + "AuthnContext").Element(SamlNamespaces.SAML_NS + "AuthnContextClassRef"),
             };
         }


### PR DESCRIPTION
We weigeren requests die te oud zijn, echter kan AuthnInstant ver in het verleden liggen omdat je niet altijd je wachtwoord opnieuw hoeft in te vullen, dus IssueInstant is beter, denk ik.