### PR TITLE
Initial exception for singleton tvps

### DIFF
--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSql.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSql.cs
@@ -225,8 +225,9 @@ namespace ProgressOnderwijsUtils
         public void AppendTo<TCommandFactory>(ref TCommandFactory factory)
             where TCommandFactory : struct, ICommandFactory
         {
-            if (kids == null || kids.Length == 0)
+            if (kids == null || kids.Length == 0) {
                 return;
+            }
             kids[0].AppendTo(ref factory);
             for (var index = 1; index < kids.Length; index++) {
                 factory.AppendSql(" ", 0, 1);
@@ -234,7 +235,6 @@ namespace ProgressOnderwijsUtils
             }
         }
     }
-
 
     class InterpolatedSqlFragment : ISqlComponent
     {

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSql.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSql.cs
@@ -129,7 +129,9 @@ namespace ProgressOnderwijsUtils
         [Pure]
         public static ParameterizedSql TableParam<T>(string typeName, T[] objects)
             where T : IMetaObject, new()
-            => SqlParameterComponent.ToTableValuedParameter(typeName, objects, o => (T[])o).BuildableToQuery();
+            => (objects.Length == 1 ? (ISqlComponent)new SingletonQueryTableValuedParameterComponent<T>(objects[0])
+                : new QueryTableValuedParameterComponent<T, T>(typeName, objects, arr => (T[])arr)
+                ).BuildableToQuery();
 
         public static IReadOnlyDictionary<Type, string> BuiltInTabledValueTypes => SqlParameterComponent.CustomTableType.SqlTableTypeNameByDotnetType;
         public static ParameterizedSql TableValuedTypeDefinitionScripts => SqlParameterComponent.CustomTableType.DefinitionScripts;

--- a/src/ProgressOnderwijsUtils/Data/SqlParameterComponent.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlParameterComponent.cs
@@ -83,7 +83,10 @@ namespace ProgressOnderwijsUtils
         [NotNull]
         public static ISqlComponent ToTableValuedParameter<TIn, TOut>(string tableTypeName, IEnumerable<TIn> set, Func<IEnumerable<TIn>, TOut[]> projection)
             where TOut : IMetaObject, new()
-            => new QueryTableValuedParameterComponent<TIn, TOut>(tableTypeName, set, projection);
+            =>
+                set is IReadOnlyList<TIn> fixedSizeList && fixedSizeList.Count == 1
+                    ? (ISqlComponent)new SingletonQueryTableValuedParameterComponent<TOut>(projection(set)[0])
+                    : new QueryTableValuedParameterComponent<TIn, TOut>(tableTypeName, set, projection);
 
         static readonly ConcurrentDictionary<Type, ITableValuedParameterFactory> tableValuedParameterFactoryCache = new ConcurrentDictionary<Type, ITableValuedParameterFactory>();
 

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>29.0.0</Version>
-    <PackageReleaseNotes>Added 'stopCascading' delegate to the CascadeDelete parameters.
-So callers can tune the wanted casdading, for example with FK's that are set to null on delete.</PackageReleaseNotes>
+    <Version>29.1.0</Version>
+    <PackageReleaseNotes>Tweak TVP implementation details to avoid TVP for singleton sets.</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Various utility methods+classes used by Progress Onderwijs.</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>

--- a/test/ProgressOnderwijsUtils.Tests/TableValuedParameterTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/TableValuedParameterTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Data;
 using System.Data.Common;
+using System.Data.SqlClient;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -31,6 +32,19 @@ namespace ProgressOnderwijsUtils.Tests
             var q = SQL($@"select sum(x.querytablevalue) from {Enumerable.Range(1, 100)} x");
             var sum = q.ReadScalar<int>(Context);
             PAssert.That(() => sum == (100 * 100 + 100) / 2);
+        }
+
+
+        [Fact]
+        public void SingletonTvPsCanBeExecuted()
+        {
+            var q = SQL($"select sum(x.querytablevalue) from {Enumerable.Range(1, 1).ToArray()} x");
+            using (var cmd = q.CreateSqlCommand(Context)) {
+                //make sure I'm actually testing that exceptional single-value case, not the general Strucutured case.
+                PAssert.That(() => cmd.Command.Parameters.Cast<SqlParameter>().Select(p => p.SqlDbType).SequenceEqual(new[] { SqlDbType.Int }));
+            }
+            var sum = q.ReadScalar<int>(Context);
+            PAssert.That(() => sum == 1);
         }
 
         [Fact]

--- a/tools/ProgressOnderwijsUtilsBenchmarks/ProgressOnderwijsUtilsBenchmarks.csproj
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/ProgressOnderwijsUtilsBenchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net471</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net471</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>full</DebugType>
     <DebugSymbols>True</DebugSymbols>


### PR DESCRIPTION
This is not yet the "reliably fast" solution that uses a roslyn analyser to enforce array-ness and uses temp tables instead of TVPs, but it'll work in many cases and shouldn't harm.