### PR TITLE
Partially restore length token for query-plan specialization

### DIFF
--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>29.1.0</Version>
-    <PackageReleaseNotes>Tweak TVP implementation details to avoid TVP for singleton sets.</PackageReleaseNotes>
+    <Version>29.2.0</Version>
+    <PackageReleaseNotes>Tweak TVP implementation details to use top to express cardinality hints.</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Various utility methods+classes used by Progress Onderwijs.</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>


### PR DESCRIPTION
… except now use `top` to really hint at the cardinality.

This is likely causing test timeouts in progress, so I'm going to merge this quickly.