### PR TITLE
Better retry delay chooser

### DIFF
--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>29.2.1</Version>
-    <PackageReleaseNotes>Tweak TVP implementation details to use top to express cardinality hints.</PackageReleaseNotes>
+    <Version>29.3.0</Version>
+    <PackageReleaseNotes>Tweak RetryDelayChooser to more aggressively ramp and recover around a service outage, and to make the error-rate halflife parameterizable.</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Various utility methods+classes used by Progress Onderwijs.</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>

--- a/src/ProgressOnderwijsUtils/RetryDelayChooser.cs
+++ b/src/ProgressOnderwijsUtils/RetryDelayChooser.cs
@@ -19,9 +19,9 @@ namespace ProgressOnderwijsUtils
         readonly double halflivesPerSecond;
         readonly double delayTargetInSecondsCubed;
 
-        /// <param name="constantFailureDelayTarget">The target delay to converge to during a long service outage.  The error rate half-life will be 100 times this value.</param>
+        /// <param name="constantFailureDelayTarget">The target delay to converge to during a long service outage.  The error rate half-life will be 20 times this value.</param>
         public RetryDelayChooser(TimeSpan constantFailureDelayTarget)
-            : this(constantFailureDelayTarget, 100) { }
+            : this(constantFailureDelayTarget, 20.0) { }
 
         /// <param name="constantFailureDelayTarget">The target delay to converge to during a long service outage</param>
         /// <param name="halflifeFactor">The halflife (as a factor of the constantFailureDelayTarget) of the error rate estimate.  Larger values ramp and recover more slowly; smaller values ramp and recover more quickly.</param>

--- a/src/ProgressOnderwijsUtils/RetryDelayChooser.cs
+++ b/src/ProgressOnderwijsUtils/RetryDelayChooser.cs
@@ -36,7 +36,11 @@ namespace ProgressOnderwijsUtils
         public TimeSpan RegisterErrorAndGetDelay(DateTime errorMoment) 
             => ErrorsPerDayToRetryDelay(errorRateEstimator.AddAmount(errorMoment, 1.0).EstimatedEventCountPerHalflife * halflivesPerDay);
 
+
         public TimeSpan ErrorsPerDayToRetryDelay(double approximateErrorsPerDay)
-            => TimeSpan.FromSeconds(approximateErrorsPerDay /TimeSpan.FromDays(1).TotalSeconds * approximateErrorsPerDay /TimeSpan.FromDays(1).TotalSeconds * scaleFactor);
+        {
+            var approximateErrorsPerSecond = approximateErrorsPerDay / TimeSpan.FromDays(1).TotalSeconds;
+            return TimeSpan.FromSeconds(approximateErrorsPerSecond * approximateErrorsPerSecond * scaleFactor);
+        }
     }
 }

--- a/src/ProgressOnderwijsUtils/RetryDelayChooser.cs
+++ b/src/ProgressOnderwijsUtils/RetryDelayChooser.cs
@@ -17,14 +17,14 @@ namespace ProgressOnderwijsUtils
     {
         readonly ExponentialDecayEstimator errorRateEstimator;
         readonly double halflivesPerDay;
-        readonly double scaleFactor;
+        readonly double delayTargetInSecondsCubed;
 
         public RetryDelayChooser(TimeSpan constantFailureDelayTarget)
         {
             errorRateEstimator = new ExponentialDecayEstimator(TimeSpan.FromHours(12));
             halflivesPerDay = 1.0 / errorRateEstimator.halflife.TotalDays;
 
-            scaleFactor = constantFailureDelayTarget.TotalSeconds * constantFailureDelayTarget.TotalSeconds * constantFailureDelayTarget.TotalSeconds;
+            delayTargetInSecondsCubed = constantFailureDelayTarget.TotalSeconds * constantFailureDelayTarget.TotalSeconds * constantFailureDelayTarget.TotalSeconds;
         }
 
         public void RegisterErrorAt(DateTime errorMoment)
@@ -36,10 +36,10 @@ namespace ProgressOnderwijsUtils
         public TimeSpan RegisterErrorAndGetDelay(DateTime errorMoment)
             => ErrorsPerDayToRetryDelay(errorRateEstimator.AddAmount(errorMoment, 1.0).EstimatedEventCountPerHalflife * halflivesPerDay);
 
-        public TimeSpan ErrorsPerDayToRetryDelay(double approximateErrorsPerDay) 
+        public TimeSpan ErrorsPerDayToRetryDelay(double approximateErrorsPerDay)
             => ErrorsPerSecondToRetryDelay(approximateErrorsPerDay / TimeSpan.FromDays(1).TotalSeconds);
 
-        public TimeSpan ErrorsPerSecondToRetryDelay(double approximateErrorsPerSecond) 
-            => TimeSpan.FromSeconds(approximateErrorsPerSecond * approximateErrorsPerSecond * scaleFactor);
+        public TimeSpan ErrorsPerSecondToRetryDelay(double approximateErrorsPerSecond)
+            => TimeSpan.FromSeconds(approximateErrorsPerSecond * approximateErrorsPerSecond * delayTargetInSecondsCubed);
     }
 }

--- a/src/ProgressOnderwijsUtils/RetryDelayChooser.cs
+++ b/src/ProgressOnderwijsUtils/RetryDelayChooser.cs
@@ -24,9 +24,9 @@ namespace ProgressOnderwijsUtils
             errorRateEstimator = new ExponentialDecayEstimator(TimeSpan.FromHours(12));
             halflivesPerDay = 1.0 / errorRateEstimator.halflife.TotalDays;
 
-            var targetConvergedDelaysPerDay = TimeSpan.FromDays(1).TotalSeconds / constantFailureDelayTarget.TotalSeconds;
+            var days_per_targetConvergedDelays = constantFailureDelayTarget.TotalSeconds / TimeSpan.FromDays(1).TotalSeconds;
             //choose scaleFactor such that: delayConvergenceTarget.TotalSeconds == targetConvergedDelaysPerDay * targetConvergedDelaysPerDay * scaleFactor
-            scaleFactor = constantFailureDelayTarget.TotalSeconds / (targetConvergedDelaysPerDay * targetConvergedDelaysPerDay);
+            scaleFactor = constantFailureDelayTarget.TotalSeconds * (days_per_targetConvergedDelays * days_per_targetConvergedDelays);
         }
 
         public void RegisterErrorAt(DateTime errorMoment)

--- a/src/ProgressOnderwijsUtils/RetryDelayChooser.cs
+++ b/src/ProgressOnderwijsUtils/RetryDelayChooser.cs
@@ -24,9 +24,7 @@ namespace ProgressOnderwijsUtils
             errorRateEstimator = new ExponentialDecayEstimator(TimeSpan.FromHours(12));
             halflivesPerDay = 1.0 / errorRateEstimator.halflife.TotalDays;
 
-            var seconds_per_targetConvergedDelays = constantFailureDelayTarget.TotalSeconds;
-            
-            scaleFactor = constantFailureDelayTarget.TotalSeconds * (seconds_per_targetConvergedDelays * seconds_per_targetConvergedDelays);
+            scaleFactor = constantFailureDelayTarget.TotalSeconds * constantFailureDelayTarget.TotalSeconds * constantFailureDelayTarget.TotalSeconds;
         }
 
         public void RegisterErrorAt(DateTime errorMoment)

--- a/src/ProgressOnderwijsUtils/RetryDelayChooser.cs
+++ b/src/ProgressOnderwijsUtils/RetryDelayChooser.cs
@@ -25,7 +25,7 @@ namespace ProgressOnderwijsUtils
             halflivesPerDay = 1.0 / errorRateEstimator.halflife.TotalDays;
 
             var days_per_targetConvergedDelays = constantFailureDelayTarget.TotalSeconds / TimeSpan.FromDays(1).TotalSeconds;
-            //choose scaleFactor such that: delayConvergenceTarget.TotalSeconds == targetConvergedDelaysPerDay * targetConvergedDelaysPerDay * scaleFactor
+            
             scaleFactor = constantFailureDelayTarget.TotalSeconds * (days_per_targetConvergedDelays * days_per_targetConvergedDelays);
         }
 

--- a/src/ProgressOnderwijsUtils/RetryDelayChooser.cs
+++ b/src/ProgressOnderwijsUtils/RetryDelayChooser.cs
@@ -33,14 +33,13 @@ namespace ProgressOnderwijsUtils
         public TimeSpan RetryDelayAt(DateTime moment)
             => ErrorsPerDayToRetryDelay(errorRateEstimator.EstimatedRateOfChangePerHalflife(moment) * halflivesPerDay);
 
-        public TimeSpan RegisterErrorAndGetDelay(DateTime errorMoment) 
+        public TimeSpan RegisterErrorAndGetDelay(DateTime errorMoment)
             => ErrorsPerDayToRetryDelay(errorRateEstimator.AddAmount(errorMoment, 1.0).EstimatedEventCountPerHalflife * halflivesPerDay);
 
+        public TimeSpan ErrorsPerDayToRetryDelay(double approximateErrorsPerDay) 
+            => ErrorsPerSecondToRetryDelay(approximateErrorsPerDay / TimeSpan.FromDays(1).TotalSeconds);
 
-        public TimeSpan ErrorsPerDayToRetryDelay(double approximateErrorsPerDay)
-        {
-            var approximateErrorsPerSecond = approximateErrorsPerDay / TimeSpan.FromDays(1).TotalSeconds;
-            return TimeSpan.FromSeconds(approximateErrorsPerSecond * approximateErrorsPerSecond * scaleFactor);
-        }
+        public TimeSpan ErrorsPerSecondToRetryDelay(double approximateErrorsPerSecond) 
+            => TimeSpan.FromSeconds(approximateErrorsPerSecond * approximateErrorsPerSecond * scaleFactor);
     }
 }

--- a/src/ProgressOnderwijsUtils/RetryDelayChooser.cs
+++ b/src/ProgressOnderwijsUtils/RetryDelayChooser.cs
@@ -24,9 +24,9 @@ namespace ProgressOnderwijsUtils
             errorRateEstimator = new ExponentialDecayEstimator(TimeSpan.FromHours(12));
             halflivesPerDay = 1.0 / errorRateEstimator.halflife.TotalDays;
 
-            var days_per_targetConvergedDelays = constantFailureDelayTarget.TotalSeconds / TimeSpan.FromDays(1).TotalSeconds;
+            var seconds_per_targetConvergedDelays = constantFailureDelayTarget.TotalSeconds;
             
-            scaleFactor = constantFailureDelayTarget.TotalSeconds * (days_per_targetConvergedDelays * days_per_targetConvergedDelays);
+            scaleFactor = constantFailureDelayTarget.TotalSeconds * (seconds_per_targetConvergedDelays * seconds_per_targetConvergedDelays);
         }
 
         public void RegisterErrorAt(DateTime errorMoment)
@@ -39,6 +39,6 @@ namespace ProgressOnderwijsUtils
             => ErrorsPerDayToRetryDelay(errorRateEstimator.AddAmount(errorMoment, 1.0).EstimatedEventCountPerHalflife * halflivesPerDay);
 
         public TimeSpan ErrorsPerDayToRetryDelay(double approximateErrorsPerDay)
-            => TimeSpan.FromSeconds(approximateErrorsPerDay * approximateErrorsPerDay * scaleFactor);
+            => TimeSpan.FromSeconds(approximateErrorsPerDay /TimeSpan.FromDays(1).TotalSeconds * approximateErrorsPerDay /TimeSpan.FromDays(1).TotalSeconds * scaleFactor);
     }
 }

--- a/src/ProgressOnderwijsUtils/RetryDelayChooser.cs
+++ b/src/ProgressOnderwijsUtils/RetryDelayChooser.cs
@@ -29,14 +29,16 @@ namespace ProgressOnderwijsUtils
         {
             if (halflifeFactor < 1.0)
                 throw new Exception("For reasonably convergence, the error-rate half-life must exceed the delay target; i.e. halflifeFactor must exceed 1.0.  A reasonable value might be 10.");
-            var delaysPerHalflife = 1.0 / halflifeFactor;
-            var convergenceOverestimateRatio = 1 + 0.230 * delaysPerHalflife + 0.09761662037037 * delaysPerHalflife * delaysPerHalflife;
+            var delaysPerHalflife = 1.0 / halflifeFactor; //so this is at *most* 1, and typically much smaller, therefore...
+            var empiracalConvergenceOverestimateRatio = 1 + 0.230 * delaysPerHalflife + 0.09761662037037 * delaysPerHalflife * delaysPerHalflife; //...this is at *most* 1.33
+
+            //The convergenceOverestimateRatio is irrelevant for long halflives, but it's a "nice" to compensate for unusually small halflives, and a compensation of 1.33 isn't too bad.
 
             var halfLife = TimeSpan.FromSeconds(constantFailureDelayTarget.TotalSeconds * halflifeFactor);
             errorRateEstimator = new ExponentialDecayEstimator(halfLife);
             halflivesPerSecond = 1.0 / errorRateEstimator.halflife.TotalSeconds;
 
-            var compensatedTargetConvergedDelay = constantFailureDelayTarget.TotalSeconds / convergenceOverestimateRatio;
+            var compensatedTargetConvergedDelay = constantFailureDelayTarget.TotalSeconds / empiracalConvergenceOverestimateRatio;
 
             delayTargetInSecondsCubed = compensatedTargetConvergedDelay * compensatedTargetConvergedDelay * compensatedTargetConvergedDelay;
         }

--- a/src/ProgressOnderwijsUtils/RetryDelayChooser.cs
+++ b/src/ProgressOnderwijsUtils/RetryDelayChooser.cs
@@ -16,13 +16,13 @@ namespace ProgressOnderwijsUtils
     public sealed class RetryDelayChooser
     {
         readonly ExponentialDecayEstimator errorRateEstimator;
-        readonly double halflivesPerDay;
+        readonly double halflivesPerSecond;
         readonly double delayTargetInSecondsCubed;
 
         public RetryDelayChooser(TimeSpan constantFailureDelayTarget)
         {
             errorRateEstimator = new ExponentialDecayEstimator(TimeSpan.FromHours(12));
-            halflivesPerDay = 1.0 / errorRateEstimator.halflife.TotalDays;
+            halflivesPerSecond = 1.0 / errorRateEstimator.halflife.TotalSeconds;
 
             delayTargetInSecondsCubed = constantFailureDelayTarget.TotalSeconds * constantFailureDelayTarget.TotalSeconds * constantFailureDelayTarget.TotalSeconds;
         }
@@ -31,10 +31,10 @@ namespace ProgressOnderwijsUtils
             => errorRateEstimator.AddAmount(errorMoment, 1.0);
 
         public TimeSpan RetryDelayAt(DateTime moment)
-            => ErrorsPerDayToRetryDelay(errorRateEstimator.EstimatedRateOfChangePerHalflife(moment) * halflivesPerDay);
+            => ErrorsPerSecondToRetryDelay(errorRateEstimator.EstimatedRateOfChangePerHalflife(moment) * halflivesPerSecond);
 
         public TimeSpan RegisterErrorAndGetDelay(DateTime errorMoment)
-            => ErrorsPerDayToRetryDelay(errorRateEstimator.AddAmount(errorMoment, 1.0).EstimatedEventCountPerHalflife * halflivesPerDay);
+            => ErrorsPerSecondToRetryDelay(errorRateEstimator.AddAmount(errorMoment, 1.0).EstimatedEventCountPerHalflife * halflivesPerSecond);
 
         public TimeSpan ErrorsPerDayToRetryDelay(double approximateErrorsPerDay)
             => ErrorsPerSecondToRetryDelay(approximateErrorsPerDay / TimeSpan.FromDays(1).TotalSeconds);

--- a/test/ProgressOnderwijsUtils.Tests/RetryDelayChooserTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/RetryDelayChooserTest.cs
@@ -45,11 +45,11 @@ namespace ProgressOnderwijsUtils.Tests
         [Fact]
         public void OneErrorIsBla()
         {
-            var constantFailureDelayTarget = TimeSpan.FromHours(1);
+            var constantFailureDelayTarget = TimeSpan.FromMinutes(1);
             var delayChooser = new RetryDelayChooser(constantFailureDelayTarget);
             var startMoment = new DateTime(2040, 4, 4).ToUniversalTime(); //arbitrary
             delayChooser.RegisterErrorAt(startMoment);
-            PAssert.That(() => Utils.FuzzyEquals(delayChooser.RetryDelayAt(startMoment).TotalSeconds * 299.7252518, constantFailureDelayTarget.TotalSeconds));
+            PAssert.That(() => Utils.FuzzyEquals(delayChooser.RetryDelayAt(startMoment).TotalMinutes * 20_000, constantFailureDelayTarget.TotalMinutes));
         }
 
         [Fact]

--- a/test/ProgressOnderwijsUtils.Tests/RetryDelayChooserTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/RetryDelayChooserTest.cs
@@ -31,7 +31,7 @@ namespace ProgressOnderwijsUtils.Tests
             }
             var delay = delayChooser.RetryDelayAt(endMoment);
             //so now we've had 30 errors a day for a few days
-            PAssert.That(() => Utils.FuzzyEquals(delay.TotalSeconds, 1.951));
+            PAssert.That(() => Utils.FuzzyEquals(delay.TotalSeconds, 1.901));
         }
 
         [Fact]

--- a/test/ProgressOnderwijsUtils.Tests/RetryDelayChooserTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/RetryDelayChooserTest.cs
@@ -70,7 +70,7 @@ namespace ProgressOnderwijsUtils.Tests
         public void OneContinuouslyFailingProcessRetriesAsPredicted()
         {
             var convergedDelay = ConvergedDelay(1, TimeSpan.FromMinutes(5));
-            PAssert.That(() => convergedDelay > TimeSpan.FromMinutes(4.99) && convergedDelay < TimeSpan.FromMinutes(5.01));
+            PAssert.That(() => 4.99 < convergedDelay.TotalMinutes && convergedDelay.TotalMinutes < 5.01);
         }
 
         static TimeSpan ConvergedDelay(int parallelFailingProcesses, TimeSpan constantFailureDelayTarget)


### PR DESCRIPTION
Essentially: ramp more aggressively by default, and recover more quickly too; but have the half-life configurable.