### PR TITLE
Set the default field-mapping to exact-match for the bulk-copies.

### DIFF
--- a/src/ProgressOnderwijsUtils/Data/CascadedDelete.cs
+++ b/src/ProgressOnderwijsUtils/Data/CascadedDelete.cs
@@ -45,13 +45,12 @@ namespace ProgressOnderwijsUtils
             )
             where TId : IPropertiesAreUsedImplicitly, IMetaObject
         {
-            var tableName = "#pksTable";
-            var pksTable = ParameterizedSql.CreateDynamic($"{tableName}");
+            var pksTable = SQL($"#pksTable");
             var pkColumns = MetaObject.GetMetaProperties<TId>().Select(mp => mp.Name).ToArray();
             var pkColumnsSql = pkColumns.ArraySelect(ParameterizedSql.CreateDynamic);
 
             CloneTableSchemaWithoutIdentityProperties(conn, initialTableAsEntered.QualifiedNameSql, pkColumnsSql, pksTable);
-            pksToDelete.BulkCopyToSqlServer(conn, tableName, initialTableAsEntered.Columns.ArraySelect(column => column.ColumnMetaData));
+            pksToDelete.BulkCopyToSqlServer(conn, pksTable.CommandText(), DbColumnMetaData.ColumnMetaDatas(conn, pksTable));
             var report = RecursivelyDelete(conn, initialTableAsEntered, outputAllDeletedRows, logger, stopCascading, pkColumns, SQL($@"
                 select {pkColumnsSql.ConcatenateSql(SQL($", "))}
                 from {pksTable}

--- a/src/ProgressOnderwijsUtils/Data/FieldMapping.cs
+++ b/src/ProgressOnderwijsUtils/Data/FieldMapping.cs
@@ -1,82 +1,89 @@
-﻿using JetBrains.Annotations;
-using System;
+﻿using System;
+using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Linq;
+using ExpressionToCodeLib;
+using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
-    public enum FieldMappingMode
+    public readonly struct FieldMapping
     {
-        RequireExactColumnMatches,
-        IgnoreExtraDestinationFields,
-    }
+        public readonly IColumnDefinition Src;
+        public readonly IColumnDefinition Dst;
 
-    public struct FieldMapping
-    {
-        public readonly IColumnDefinition SourceColumnDefinition;
-        public readonly int SrcIndex, DstIndex;
-
-        FieldMapping(IColumnDefinition sourceColumnDefinition, int srcIndex, int dstIndex)
+        FieldMapping(IColumnDefinition src, IColumnDefinition dst)
         {
-            SourceColumnDefinition = sourceColumnDefinition;
-            SrcIndex = srcIndex;
-            DstIndex = dstIndex;
+            Src = src;
+            Dst = dst;
         }
 
         [NotNull]
-        public static FieldMapping[] VerifyAndCreate(
-            IColumnDefinition[] srcFields,
-            string srcSetDebugName,
-            IColumnDefinition[] dstFields,
-            string dstSetDebugName,
-            FieldMappingMode mode)
+        public static FieldMapping[] Create([NotNull] IColumnDefinition[] srcColumns, [NotNull] IColumnDefinition[] dstColumns)
         {
-            var mkFieldDict = Utils.F(
-                (IColumnDefinition[] fields) => fields
-                    .Select(colDef => new { Def = colDef, UnderlyingType = colDef.DataType.GetNonNullableUnderlyingType() })
-                    .ToDictionary(col => col.Def.Name ?? "!!UNNAMED COLUMN!!", StringComparer.OrdinalIgnoreCase)
-                );
+            var dstColumnsByName = dstColumns.ToDictionary(o => o.Name ?? "!!UNNAMED COLUMN!!", StringComparer.OrdinalIgnoreCase);
 
-            var srcFieldsByName = mkFieldDict(srcFields);
-            var dstFieldsByName = mkFieldDict(dstFields);
-            var colCountMismatch = srcFieldsByName.Count > dstFieldsByName.Count
-                || mode == FieldMappingMode.RequireExactColumnMatches && srcFieldsByName.Count < dstFieldsByName.Count;
-
-            if (colCountMismatch || srcFieldsByName.Any(
-                srcField =>
-                    !dstFieldsByName.ContainsKey(srcField.Key) || dstFieldsByName[srcField.Key].UnderlyingType != srcField.Value.UnderlyingType
-                )) {
-                var extraSrcCols = srcFieldsByName.Keys.Where(dbcol => !dstFieldsByName.ContainsKey(dbcol)).ToArray();
-                var extraDstCols = dstFieldsByName.Keys.Where(prop => !srcFieldsByName.ContainsKey(prop)).ToArray();
-                var nameMatchedCols = srcFieldsByName.Keys.Where(dstFieldsByName.ContainsKey);
-                var typeMismatchCols = nameMatchedCols.Where(name => srcFieldsByName[name].UnderlyingType != dstFieldsByName[name].UnderlyingType);
-
-                var typeMismatchMessage = !typeMismatchCols.Any()
-                    ? ""
-                    : "\n\nType mismatches (src <> dst):\n"
-                        + typeMismatchCols.Select(
-                            name => "  " +
-                                srcFieldsByName[name].Def.ToString() + "  <>  " + dstFieldsByName[name].Def.ToString() + "\n"
-                            ).JoinStrings();
-
-                throw new InvalidOperationException(
-                    "Source " + srcSetDebugName + " has different shape than destination " + dstSetDebugName + " with mode " + mode + ":\n"
-                        + (!extraSrcCols.Any() ? "" : "\n" + "Fields only on source " + srcSetDebugName + ": " + string.Join(", ", extraSrcCols))
-                        + (!extraDstCols.Any() ? "" : "\n" + "Fields only on destination " + dstSetDebugName + ": " + string.Join(", ", extraDstCols))
-                        + typeMismatchMessage
-                        + "\n" + "All source " + srcSetDebugName + " fields: " + srcFieldsByName.Select(col => col.Value.Def.ToString()).JoinStrings(", ")
-                        + "\n" + "All destination " + dstSetDebugName + " fields: " + dstFieldsByName.Select(col => col.Value.Def.ToString()).JoinStrings(", ")
-                    );
+            var list = new List<FieldMapping>(srcColumns.Length + dstColumns.Length);
+            foreach (var srcColumn in srcColumns) {
+                if (dstColumnsByName.TryGetValue(srcColumn.Name, out var dstColumn)) {
+                    dstColumnsByName.Remove(dstColumn.Name);
+                    list.Add(new FieldMapping(srcColumn, dstColumn));
+                } else {
+                    list.Add(new FieldMapping(srcColumn, null));
+                }
             }
+            list.AddRange(dstColumnsByName.Values.Select(dstColumn => new FieldMapping(null, dstColumn)));
 
-            return srcFieldsByName.Values.Select(srcCol => new FieldMapping(srcCol.Def, srcCol.Def.Index, dstFieldsByName[srcCol.Def.Name].Def.Index)).ToArray();
+            return list.ToArray();
         }
 
         public static void ApplyFieldMappingsToBulkCopy([NotNull] FieldMapping[] mapping, [NotNull] SqlBulkCopy bulkCopy)
         {
             bulkCopy.ColumnMappings.Clear();
             foreach (var mapEntry in mapping) {
-                bulkCopy.ColumnMappings.Add(mapEntry.SrcIndex, mapEntry.DstIndex);
+                bulkCopy.ColumnMappings.Add(mapEntry.Src.Index, mapEntry.Dst.Index);
+            }
+        }
+
+        [NotNull]
+        public static FieldMapping[] VerifyAndCreate(
+            [NotNull] IColumnDefinition[] srcColumns,
+            string srcName,
+            bool allowExtraSrcColumns,
+            [NotNull] IColumnDefinition[] dstColumns,
+            string dstName,
+            bool allowExtraDstColumns)
+        {
+            var mapping = Create(srcColumns, dstColumns);
+            var errors = new List<string>(mapping.Length);
+            var mapped = new List<FieldMapping>(mapping.Length);
+
+            foreach (var entry in mapping) {
+                if (entry.Src == null && entry.Dst == null) {
+                    throw new ArgumentException();
+                } else {
+                    if (entry.Src == null && !allowExtraDstColumns) {
+                        errors.Add($"Entity '{srcName}' is missing property '{entry.Dst.Name}' to insert into table '{dstName}'.");
+                    }
+
+                    if (entry.Dst == null && !allowExtraSrcColumns) {
+                        errors.Add($"Table '{dstName}' has no column '{entry.Src.Name}' to insert from entity '{srcName}'.");
+                    }
+
+                    if (entry.Src != null && entry.Dst != null) {
+                        if (entry.Src.DataType.GetNonNullableUnderlyingType() != entry.Dst.DataType.GetNonNullableUnderlyingType()) {
+                            errors.Add($"Type '{entry.Src.DataType.ToCSharpFriendlyTypeName()}' of property '{srcName}.{entry.Src.Name}' differs from type '{entry.Dst.DataType.ToCSharpFriendlyTypeName()}' of column '{dstName}.{entry.Dst.Name}'.");
+                        } else {
+                            mapped.Add(entry);
+                        }
+                    }
+                }
+            }
+
+            if (errors.Any()) {
+                throw new InvalidOperationException(errors.JoinStrings("\n"));
+            } else {
+                return mapped.ToArray();
             }
         }
     }

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -1,3 +1,6 @@
+using ExpressionToCodeLib;
+using JetBrains.Annotations;
+using ProgressOnderwijsUtils.Collections;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -7,10 +10,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using ExpressionToCodeLib;
-using FastExpressionCompiler;
-using JetBrains.Annotations;
-using ProgressOnderwijsUtils.Collections;
 
 namespace ProgressOnderwijsUtils
 {

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -13,6 +13,12 @@ using System.Runtime.CompilerServices;
 
 namespace ProgressOnderwijsUtils
 {
+    public enum FieldMappingMode
+    {
+        RequireExactColumnMatches,
+        IgnoreExtraDestinationFields,
+    }
+
     public static class ParameterizedSqlObjectMapper
     {
         [MustUseReturnValue]

--- a/src/ProgressOnderwijsUtils/MetaObject/MetaObjectBulkCopy.cs
+++ b/src/ProgressOnderwijsUtils/MetaObject/MetaObjectBulkCopy.cs
@@ -43,8 +43,8 @@ namespace ProgressOnderwijsUtils
         /// <param name="tableName">The name of the table to insert into.</param>
         /// <param name="columns">The schema of the table as it currently exists in the database.</param>
         public static void BulkCopyToSqlServer<T>([NotNull] this IEnumerable<T> metaObjects, [NotNull] SqlCommandCreationContext sqlconn, [NotNull] string tableName, [NotNull] DbColumnMetaData[] columns)
-                where T : IMetaObject, IPropertiesAreUsedImplicitly
-            {
+            where T : IMetaObject, IPropertiesAreUsedImplicitly
+        {
             using (var bulkCopy = new SqlBulkCopy(sqlconn.Connection, SqlBulkCopyOptions.CheckConstraints, null)) {
                 bulkCopy.BulkCopyTimeout = sqlconn.CommandTimeoutInS;
                 var token = sqlconn.CommandTimeoutInS == 0
@@ -93,7 +93,7 @@ namespace ProgressOnderwijsUtils
             bulkCopy.DestinationTableName = tableName;
 
             using (var objectReader = new MetaObjectDataReader<T>(metaObjects, cancellationToken)) {
-                var mapping = ApplyMetaObjectColumnMapping(bulkCopy, objectReader, tableName, columns);
+                var mapping = ApplyMetaObjectColumnMapping(bulkCopy, objectReader, tableName, columns.Where(column => !column.Is_Computed && !column.Is_RowVersion).ToArray());
                 var sw = Stopwatch.StartNew();
                 try {
                     bulkCopy.WriteToServer(objectReader);
@@ -158,7 +158,7 @@ namespace ProgressOnderwijsUtils
                 typeof(T).ToCSharpFriendlyTypeName(),
                 dataColumns,
                 "table " + tableName,
-                FieldMappingMode.IgnoreExtraDestinationFields);
+                FieldMappingMode.RequireExactColumnMatches);
 
             FieldMapping.ApplyFieldMappingsToBulkCopy(mapping, bulkCopy);
             return mapping;

--- a/src/ProgressOnderwijsUtils/MetaObject/MetaObjectBulkCopy.cs
+++ b/src/ProgressOnderwijsUtils/MetaObject/MetaObjectBulkCopy.cs
@@ -111,7 +111,7 @@ namespace ProgressOnderwijsUtils
         [NotNull]
         static Exception MetaObjectBasedException<T>([NotNull] FieldMapping[] mapping, int destinationColumnIndex, SqlException ex) where T : IMetaObject, IPropertiesAreUsedImplicitly
         {
-            var sourceColumnName = mapping.Where(m => m.DstIndex == destinationColumnIndex).Select(m => m.SourceColumnDefinition.Name).FirstOrDefault();
+            var sourceColumnName = mapping.Where(m => m.Dst.Index == destinationColumnIndex).Select(m => m.Src.Name).FirstOrDefault();
             var metaPropName = typeof(T).ToCSharpFriendlyTypeName() + "." + (sourceColumnName ?? "??unknown??");
             return new Exception($"Received an invalid column length from the bcp client for metaobject property ${metaPropName}.", ex);
         }
@@ -156,9 +156,10 @@ namespace ProgressOnderwijsUtils
             var mapping = FieldMapping.VerifyAndCreate(
                 clrColumns,
                 typeof(T).ToCSharpFriendlyTypeName(),
+                false,
                 dataColumns,
                 "table " + tableName,
-                FieldMappingMode.RequireExactColumnMatches);
+                false);
 
             FieldMapping.ApplyFieldMappingsToBulkCopy(mapping, bulkCopy);
             return mapping;

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>31.0.1</Version>
-    <PackageReleaseNotes>Use the column-index from the db itself, instead of assuming the order of the columns-array.</PackageReleaseNotes>
+    <Version>31.0.2</Version>
+    <PackageReleaseNotes>Set the default field-mapping to exact-match for the bulk-copies.
+
+This is now possible because we can filter out the read-only db-columns.</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Various utility methods+classes used by Progress Onderwijs.</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>

--- a/test/ProgressOnderwijsUtils.Tests/MetaObjectBulkCopyTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/MetaObjectBulkCopyTest.cs
@@ -97,13 +97,6 @@ namespace ProgressOnderwijsUtils.Tests
         }
 
         [Fact]
-        public void BulkCopyAllowsExtraDestinationColumns()
-        {
-            var (table, columns) = CreateTempTable();
-            new BlaWithMissingClrFields[0].BulkCopyToSqlServer(Context.Connection, table, columns);
-        }
-
-        [Fact]
         public void BulkCopyChecksNames()
         {
             var (table, columns) = CreateTempTable();


### PR DESCRIPTION
  This is now possible because we can filter out the read-only db-columns.