### PR TITLE
Workaround dot net zip semver issue

### DIFF
--- a/src/NugetPackagesCommon.props
+++ b/src/NugetPackagesCommon.props
@@ -3,7 +3,7 @@
     <Authors>Progress Onderwijs</Authors>
     <Owners>Progress Onderwijs</Owners>
 
-    <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="System.Memory" Version="4.5.1" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="4.5.0" />
     <PackageReference Include="ValueUtils" version="1.4.0" />
-    <PackageReference Include="ZlibWithDictionary" version="2.3.0" />
+    <PackageReference Include="ZlibWithDictionary" version="2.3.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
   </ItemGroup>
 </Project>

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>34.2.0</Version>
-    <PackageReleaseNotes>Fix deadlock in ProcessRunner on .net core</PackageReleaseNotes>
+    <Version>34.2.1</Version>
+    <PackageReleaseNotes>Workaround assembly loading issues</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Various utility methods+classes used by Progress Onderwijs.</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>


### PR DESCRIPTION
https://github.com/haf/DotNetZip.Semverd/issues/152

Is causing MethodMissingExceptions due to assembly loading errors (ref: https://github.com/progressonderwijs/progress/pull/20961 )

So I bumped the ZlibWithDictionary to remove multiplat builds (no longer necessary anyhow), and that seems to fix the assembly loading issues here anyhow...