### PR TITLE
Downgrade DotNetZip

### DIFF
--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="System.Memory" Version="4.5.1" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="4.5.0" />
     <PackageReference Include="ValueUtils" version="1.4.0" />
-    <PackageReference Include="ZlibWithDictionary" version="2.3.1" />
+    <PackageReference Include="ZlibWithDictionary" version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
   </ItemGroup>
 </Project>

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>34.2.1</Version>
+    <Version>34.2.2</Version>
     <PackageReleaseNotes>Workaround assembly loading issues</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Various utility methods+classes used by Progress Onderwijs.</Description>


### PR DESCRIPTION
In some cases, the current version works, but in others there are assembly loading issues.

So until haf/DotNetZip.Semverd#152 is fixed, let's downgrade.