### PR TITLE
Bump dependencies

### DIFF
--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>34.4.0</Version>
+    <Version>34.5.0</Version>
     <PackageReleaseNotes>Don't consider static props metaprops (bugfix)</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Various utility methods+classes used by Progress Onderwijs.</Description>
@@ -15,7 +15,7 @@
     <EmbeddedResource Include="SingleSignOn\*.xsd.intellisensehack" />
     <PackageReference Include="System.Reactive" Version="4.1.2" />
     <PackageReference Include="JetBrains.Annotations" Version="2018.3.0" />
-    <PackageReference Include="ExpressionToCodeLib" version="3.1.0" />
+    <PackageReference Include="ExpressionToCodeLib" version="3.2.0" />
     <PackageReference Include="log4net" version="2.0.8" />
     <PackageReference Include="morelinq" version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
@@ -23,7 +23,7 @@
     <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="4.5.0" />
     <PackageReference Include="ValueUtils" version="1.4.0" />
-    <PackageReference Include="ZlibWithDictionary" version="2.2.0" />
+    <PackageReference Include="ZlibWithDictionary" version="2.3.3" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
So the DotNetZip warning is hopefullly fixed.