### PR TITLE
Bump version

### DIFF
--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>36.0.0</Version>
+    <Version>37.0.0</Version>
     <PackageReleaseNotes>Bump dependecies</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>


### PR DESCRIPTION
So https://github.com/progressonderwijs/progress/pull/23867 becomes mergable

Previously #247 

Probably best not to wait too long for this one because https://github.com/progressonderwijs/progress/pull/23867 has the promise of attracting a bunch of boring but time-consuming mergeconflicts