### PR TITLE
Simplify (and while at it, optimize) some parts of ParameterizedSqlObjectMapper

### DIFF
--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -670,6 +670,7 @@ namespace ProgressOnderwijsUtils
                         ? backingField
                         : null;
 
+            [UsefulToKeep("for symmetry with BackingFieldOfPropertyOrNull")]
             public static PropertyInfo AutoPropertyOfFieldOrNull(FieldInfo fieldInfo)
                 => IsCompilerGenerated(fieldInfo)
                     && AutoPropNameFromBackingField(fieldInfo.Name) is string autoPropertyName

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -11,6 +11,7 @@ using ExpressionToCodeLib;
 using JetBrains.Annotations;
 using ProgressOnderwijsUtils.Collections;
 
+// ReSharper disable ConvertToUsingDeclaration
 namespace ProgressOnderwijsUtils
 {
     public enum FieldMappingMode

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -79,19 +79,38 @@ namespace ProgressOnderwijsUtils
                 SqlDataReader reader = null;
                 try {
                     reader = cmd.Command.ExecuteReader(CommandBehavior.SequentialAccess);
-                    var unpacker = DataReaderSpecialization<SqlDataReader>.ByMetaObjectImpl<T>.DataReaderToSingleRowUnpacker(reader, fieldMapping);
-                    var builder = new ArrayBuilder<T>();
-                    while (reader.Read()) {
-                        var nextRow = unpacker(reader, out lastColumnRead);
-                        builder.Add(nextRow);
-                    }
-                    return builder.ToArray();
+                    return typeof(T).IsValueType ? ReaderToArrayViaRefs<T>(fieldMapping, reader, ref lastColumnRead) : ReaderToArray<T>(fieldMapping, reader, ref lastColumnRead);
                 } catch (Exception ex) {
                     throw cmd.CreateExceptionWithTextAndArguments(CurrentMethodName<T>() + " failed. " + UnpackingErrorMessage<T>(reader, lastColumnRead), ex);
                 } finally {
                     reader?.Dispose();
                 }
             }
+        }
+
+        static T[] ReaderToArray<T>(FieldMappingMode fieldMapping, SqlDataReader reader, ref int lastColumnRead)
+            where T : IMetaObject, new()
+        {
+            var unpacker = DataReaderSpecialization<SqlDataReader>.ByMetaObjectImpl<T>.DataReaderToSingleRowUnpacker(reader, fieldMapping);
+            var builder = new ArrayBuilder<T>();
+            while (reader.Read()) {
+                var nextRow = unpacker(reader, out lastColumnRead);
+                builder.Add(nextRow);
+            }
+            return builder.ToArray();
+        }
+
+        static T[] ReaderToArrayViaRefs<T>(FieldMappingMode fieldMapping, SqlDataReader reader, ref int lastColumnRead)
+            where T : IMetaObject, new()
+        {
+            var unpacker = DataReaderSpecialization<SqlDataReader>.ByMetaObjectImpl<T>.DataReaderToSingleRowRefUnpacker(reader, fieldMapping);
+            var builder = new ArrayBuilder<T>();
+            T nextRow;
+            while (reader.Read()) {
+                unpacker(reader, out lastColumnRead, out nextRow);
+                builder.Add(nextRow);
+            }
+            return builder.ToArray();
         }
 
         [NotNull]
@@ -457,7 +476,9 @@ namespace ProgressOnderwijsUtils
                 }
 
                 static readonly object constructionSync = new object();
-                static readonly ConcurrentDictionary<ColumnOrdering, TRowReader<T>> loadRow_by_ordering;
+                static readonly ConcurrentDictionary<ColumnOrdering, TRowReader<T>> loadRow_by_ordering = new ConcurrentDictionary<ColumnOrdering, TRowReader<T>>();
+                static readonly object refConstructionSync = new object();
+                static readonly ConcurrentDictionary<ColumnOrdering, TRowRefReader<T>> loadRowRef_by_ordering = new ConcurrentDictionary<ColumnOrdering, TRowRefReader<T>>();
 
                 [NotNull]
                 static Type type
@@ -492,8 +513,6 @@ namespace ProgressOnderwijsUtils
                             break;
                         }
                     }
-
-                    loadRow_by_ordering = new ConcurrentDictionary<ColumnOrdering, TRowReader<T>>();
                 }
 
                 public static TRowReader<T> DataReaderToSingleRowUnpacker([NotNull] TReader reader, FieldMappingMode fieldMappingMode)
@@ -506,6 +525,20 @@ namespace ProgressOnderwijsUtils
                     } else {
                         lock (constructionSync) {
                             return loadRow_by_ordering.GetOrAdd(ordering, constructTRowReaderWithCols);
+                        }
+                    }
+                }
+
+                public static TRowRefReader<T> DataReaderToSingleRowRefUnpacker([NotNull] TReader reader, FieldMappingMode fieldMappingMode)
+                {
+                    AssertColumnsCanBeMappedToObject(reader, fieldMappingMode);
+                    var ordering = ColumnOrdering.FromReader(reader);
+                    if (loadRowRef_by_ordering.TryGetValue(ordering, out var cachedRowReaderWithCols)) {
+                        PooledSmallBufferAllocator<string>.ReturnToPool(ordering.Cols);
+                        return cachedRowReaderWithCols;
+                    } else {
+                        lock (refConstructionSync) {
+                            return loadRowRef_by_ordering.GetOrAdd(ordering, constructTRowRefReaderWithCols);
                         }
                     }
                 }
@@ -542,6 +575,20 @@ namespace ProgressOnderwijsUtils
                     var constructRowExpr = Expression.Block(typeof(T), new[] { rowVar }, statements);
                     var loadRowsParamExprs = new[] { dataReaderParamExpr, lastColumnReadParamExpr };
                     var loadRowsLambda = Expression.Lambda<TRowReader<T>>(constructRowExpr, "LoadRows", loadRowsParamExprs);
+                    return loadRowsLambda.Compile();
+                };
+
+                static readonly Func<ColumnOrdering, TRowRefReader<T>> constructTRowRefReaderWithCols = columnOrdering => {
+                    var cols = columnOrdering.Cols;
+                    var dataReaderParamExpr = Expression.Parameter(typeof(TReader), "dataReader");
+                    var lastColumnReadParamExpr = Expression.Parameter(typeof(int).MakeByRefType(), "lastColumnRead");
+                    var rowVar = Expression.Parameter(typeof(T).MakeByRefType(), "row");
+                    var statements = new List<Expression>(1 + cols.Length * 2);
+                    statements.Add(Expression.Assign(rowVar, Expression.New(typeof(T))));
+                    ReadAllFields(dataReaderParamExpr, rowVar, cols, lastColumnReadParamExpr, statements);
+                    var constructRowExpr = Expression.Block(statements);
+                    var loadRowsParamExprs = new[] { dataReaderParamExpr, lastColumnReadParamExpr, rowVar };
+                    var loadRowsLambda = Expression.Lambda<TRowRefReader<T>>(constructRowExpr, "LoadRows", loadRowsParamExprs);
                     return loadRowsLambda.Compile();
                 };
 

--- a/src/ProgressOnderwijsUtils/MetaObject/MetaInfo.cs
+++ b/src/ProgressOnderwijsUtils/MetaObject/MetaInfo.cs
@@ -64,13 +64,16 @@ namespace ProgressOnderwijsUtils
         public IMetaProperty<T> GetByExpression<TProp>([NotNull] Expression<Func<T, TProp>> propertyExpression)
         {
             var memberInfo = MetaObject.GetMemberInfo(propertyExpression);
-            var retval = MetaProperties.SingleOrNull(mp => mp.PropertyInfo == memberInfo); //TODO:get by name.
-            if (retval == null) {
-                throw new ArgumentException(
-                    "To configure a metaproperty, must pass a lambda such as o=>o.MyPropertyName\n" +
-                    "The argument lambda refers to a property " + memberInfo.Name + " that is not a MetaProperty");
+            if (indexByName.TryGetValue(memberInfo.Name, out var metapropIdx)) {
+                var metaprop = MetaProperties[metapropIdx];
+                if (metaprop.PropertyInfo == memberInfo) {
+                    return metaprop;
+                }
             }
-            return retval;
+
+            throw new ArgumentException(
+                "To configure a metaproperty, must pass a lambda such as o=>o.MyPropertyName\n" +
+                "The argument lambda refers to a property " + memberInfo.Name + " that is not a MetaProperty");
         }
 
         public IEnumerator<IMetaProperty<T>> GetEnumerator()

--- a/src/ProgressOnderwijsUtils/MetaObject/MetaObject.cs
+++ b/src/ProgressOnderwijsUtils/MetaObject/MetaObject.cs
@@ -123,9 +123,5 @@ namespace ProgressOnderwijsUtils
         [Pure]
         static IMetaPropCache<IMetaProperty> GetCache(Type t)
             => (IMetaPropCache<IMetaProperty>)genGetCache.MakeGenericMethod(t).Invoke(null, null);
-
-        [Pure]
-        public static ParameterizedSql SqlColumnName([NotNull] this IMetaProperty mp)
-            => SQL($@"[{ParameterizedSql.CreateDynamic(mp.Name)}]");
     }
 }

--- a/src/ProgressOnderwijsUtils/MetaObject/MetaProperty.cs
+++ b/src/ProgressOnderwijsUtils/MetaObject/MetaProperty.cs
@@ -22,6 +22,7 @@ namespace ProgressOnderwijsUtils
         IReadOnlyList<object> CustomAttributes { get; }
         Type DataType { get; }
         string Name { get; }
+        ParameterizedSql SqlColumnName { get; }
         int Index { get; }
     }
 
@@ -41,6 +42,11 @@ namespace ProgressOnderwijsUtils
         {
             public bool IsKey { get; }
             public string Name { get; }
+            ParameterizedSql sqlColumnName;
+
+            public ParameterizedSql SqlColumnName
+                => sqlColumnName ? sqlColumnName : sqlColumnName = ParameterizedSql.CreateDynamic(Name);
+
             public IReadOnlyList<object> CustomAttributes { get; }
             public int Index { get; }
 

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>39.6.0</Version>
-    <PackageReleaseNotes>Expose propertyconvertercache</PackageReleaseNotes>
+    <Version>40.0.0</Version>
+    <PackageReleaseNotes>Cache MetaProperty name-as-sql</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>

--- a/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/Program.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/Program.cs
@@ -17,11 +17,11 @@ namespace ProgressOnderwijsUtilsBenchmarks.MicroOrmBench
             ParameterizedSqlExecutor.ConstructWithoutExecuting(benchmarker);
             ParameterizedSqlExecutor.RunQuery(benchmarker);
             ParameterizedSqlExecutor.RunWideQuery(benchmarker);
-            //ParameterizedSqlExecutor.RunTvpQuery(benchmarker);
-            //DapperExecutor.RunQuery(benchmarker);
+            ParameterizedSqlExecutor.RunTvpQuery(benchmarker);
+            DapperExecutor.RunQuery(benchmarker);
             HandrolledAdoNetExecutor.RunQuery(benchmarker);
             HandrolledAdoNetExecutor.RunWideQuery(benchmarker);
-            //DapperExecutor.RunWideQuery(benchmarker);
+            DapperExecutor.RunWideQuery(benchmarker);
         }
     }
 }


### PR DESCRIPTION
This is motivated by the hope to make it a little easier to implement something like the value conversion, and as it happens it's no longer useful to inline the array construction during reader extraction, so removing the special case isn't hurting perf notably either.