### PR TITLE
Allow FromDbValueConverter to accept values that were already in code format.

### DIFF
--- a/src/ProgressOnderwijsUtils/Data/FromDbValueConverter.cs
+++ b/src/ProgressOnderwijsUtils/Data/FromDbValueConverter.cs
@@ -62,7 +62,7 @@ namespace ProgressOnderwijsUtils
             static Func<object, T> ExtractorFromConverter(Type type, MetaObjectPropertyConverter converter)
             {
                 if (type.IsNullableValueType() || !type.IsValueType) {
-                    return obj => obj == DBNull.Value || obj == null ? default(T) : (T)converter.ConvertFromDb(obj);
+                    return obj => obj == DBNull.Value || obj == null ? default(T) : obj is T alreadyCast ? alreadyCast : (T)converter.ConvertFromDb(obj);
                 } else {
                     return obj => obj == DBNull.Value || obj == null ? throw new InvalidCastException("Cannot convert null to " + type.ToCSharpFriendlyTypeName()) : (T)converter.ConvertFromDb(obj);
                 }

--- a/src/ProgressOnderwijsUtils/Data/FromDbValueConverter.cs
+++ b/src/ProgressOnderwijsUtils/Data/FromDbValueConverter.cs
@@ -14,18 +14,13 @@ namespace ProgressOnderwijsUtils
         ///  - it supports casting from boxed int to nullable enum.
         /// </summary>
         [Pure]
-        public static T FromDb<T>(object fromdatabase)
+        public static T FromDb<T>(object valueFromDb)
         {
             try {
-                return FromDbHelper<T>.Convert(fromdatabase);
+                return FromDbHelper<T>.Convert(valueFromDb == DBNull.Value ? null : valueFromDb);
             } catch (Exception e) {
-                var valStr =
-                    fromdatabase == null
-                        ? "<null>"
-                        : fromdatabase == DBNull.Value
-                            ? "<dbnull>"
-                            : fromdatabase.GetType().FullName + " value";
-                throw new InvalidCastException("Cannot cast " + valStr + " to type " + typeof(T).FullName, e);
+                var valTypeString = valueFromDb?.GetType().ToCSharpFriendlyTypeName() ?? "<null>";
+                throw new InvalidCastException("Cannot cast " + valTypeString + " to type " + typeof(T).ToCSharpFriendlyTypeName(), e);
             }
         }
 
@@ -36,18 +31,13 @@ namespace ProgressOnderwijsUtils
         ///  - it supports casting from boxed int to nullable enum.
         /// </summary>
         [Pure]
-        public static T ToDb<T>(object fromCode)
+        public static T ToDb<T>(object valueFromCode)
         {
             try {
-                return ToDbHelper<T>.Convert(fromCode);
+                return ToDbHelper<T>.Convert(valueFromCode);
             } catch (Exception e) {
-                var valStr =
-                    fromCode == null
-                        ? "<null>"
-                        : fromCode == DBNull.Value
-                            ? "<dbnull>"
-                            : fromCode.GetType().FullName + " value";
-                throw new InvalidCastException("Cannot cast " + valStr + " to type " + typeof(T).FullName, e);
+                var valTypeString = valueFromCode?.GetType().ToCSharpFriendlyTypeName() ?? "<null>";
+                throw new InvalidCastException("Cannot cast " + valTypeString + " to type " + typeof(T).ToCSharpFriendlyTypeName(), e);
             }
         }
 

--- a/src/ProgressOnderwijsUtils/Data/FromDbValueConverter.cs
+++ b/src/ProgressOnderwijsUtils/Data/FromDbValueConverter.cs
@@ -27,7 +27,6 @@ namespace ProgressOnderwijsUtils
 
         /// <summary>
         /// This method works just like a normal C# cast, with the following changed:
-        /// - it treats DBNull.Value as if it were null
         /// - it ignores explicit and implicit cast operators
         /// - it supports casting from boxed int to nullable enum.
         /// - it supports casting ToDb when the passed value is IMetaPropertyConvertible.

--- a/src/ProgressOnderwijsUtils/Data/FromDbValueConverter.cs
+++ b/src/ProgressOnderwijsUtils/Data/FromDbValueConverter.cs
@@ -119,10 +119,17 @@ namespace ProgressOnderwijsUtils
 
         [Pure]
         public static object DynamicCast(object val, Type type)
-            => type.IsInstanceOfType(val) ? val
-                : MetaObjectPropertyConverter.GetOrNull(type) is MetaObjectPropertyConverter targetConvertible ? targetConvertible.ConvertFromDb(val)
-                : MetaObjectPropertyConverter.GetOrNull(val.GetType()) is MetaObjectPropertyConverter sourceConvertible && sourceConvertible.DbType == type.GetNonNullableType() ? sourceConvertible.ConvertToDb(val)
-                : genericCastMethod.MakeGenericMethod(type).Invoke(null, new[] { val });
+        {
+            if (type.IsInstanceOfType(val)) {
+                return val;
+            } else if (MetaObjectPropertyConverter.GetOrNull(type) is MetaObjectPropertyConverter targetConvertible) {
+                return targetConvertible.ConvertFromDb(val);
+            } else if (MetaObjectPropertyConverter.GetOrNull(val.GetType()) is MetaObjectPropertyConverter sourceConvertible && sourceConvertible.DbType == type.GetNonNullableType()) {
+                return sourceConvertible.ConvertToDb(val);
+            } else {
+                return genericCastMethod.MakeGenericMethod(type).Invoke(null, new[] { val });
+            }
+        }
 
         [Pure]
         public static bool EqualsConvertingIntToEnum([CanBeNull] object val1, [CanBeNull] object val2)

--- a/src/ProgressOnderwijsUtils/Data/FromDbValueConverter.cs
+++ b/src/ProgressOnderwijsUtils/Data/FromDbValueConverter.cs
@@ -9,9 +9,10 @@ namespace ProgressOnderwijsUtils
     {
         /// <summary>
         /// This method works just like a normal C# cast, with the following changed:
-        ///  - it treats DBNull.Value as if it were null
-        ///  - it doesn't support custom casts, just built-in casts
-        ///  - it supports casting from boxed int to nullable enum.
+        /// - it treats DBNull.Value as if it were null
+        /// - it ignores explicit and implicit cast operators
+        /// - it supports casting from boxed int to nullable enum.
+        /// - it supports casting fromDb when the target type is IMetaPropertyConvertible
         /// </summary>
         [Pure]
         public static T FromDb<T>(object valueFromDb)
@@ -26,9 +27,10 @@ namespace ProgressOnderwijsUtils
 
         /// <summary>
         /// This method works just like a normal C# cast, with the following changed:
-        ///  - it treats DBNull.Value as if it were null
-        ///  - it doesn't support custom casts, just built-in casts
-        ///  - it supports casting from boxed int to nullable enum.
+        /// - it treats DBNull.Value as if it were null
+        /// - it ignores explicit and implicit cast operators
+        /// - it supports casting from boxed int to nullable enum.
+        /// - it supports casting ToDb when the passed value is IMetaPropertyConvertible.
         /// </summary>
         [Pure]
         public static T ToDb<T>(object valueFromCode)

--- a/src/ProgressOnderwijsUtils/Data/FromDbValueConverter.cs
+++ b/src/ProgressOnderwijsUtils/Data/FromDbValueConverter.cs
@@ -62,7 +62,7 @@ namespace ProgressOnderwijsUtils
                     return ForConvertible(type, converter);
                 }
                 if (!type.IsValueType) {
-                    return obj => obj == DBNull.Value ? default(T) : (T)obj;
+                    return obj => (T)obj;
                 }
                 var nonnullableUnderlyingType = type.IfNullableGetNonNullableType();
                 if (nonnullableUnderlyingType == null) {
@@ -75,9 +75,9 @@ namespace ProgressOnderwijsUtils
             static Func<object, T> ForConvertible(Type type, MetaObjectPropertyConverter converter)
             {
                 if (type.IsNullableValueType() || !type.IsValueType) {
-                    return obj => obj == DBNull.Value || obj == null ? default(T) : obj is T alreadyCast ? alreadyCast : (T)converter.ConvertFromDb(obj);
+                    return obj => obj == null ? default(T) : obj is T alreadyCast ? alreadyCast : (T)converter.ConvertFromDb(obj);
                 } else {
-                    return obj => obj == DBNull.Value || obj == null ? throw new InvalidCastException("Cannot convert null to " + type.ToCSharpFriendlyTypeName()) : (T)converter.ConvertFromDb(obj);
+                    return obj => obj == null ? throw new InvalidCastException("Cannot convert null to " + type.ToCSharpFriendlyTypeName()) : (T)converter.ConvertFromDb(obj);
                 }
             }
         }
@@ -104,7 +104,8 @@ namespace ProgressOnderwijsUtils
 
         static TStruct? ExtractNullableValueType<TStruct>([CanBeNull] object obj)
             where TStruct : struct
-            => obj == DBNull.Value || obj == null ? default(TStruct?) : (TStruct)obj;
+        // ReSharper disable once MergeConditionalExpression //does not work for enums!
+            => obj == null ? default(TStruct?) : (TStruct)obj;
 
         static readonly MethodInfo genericCastMethod = ((Func<object, int>)FromDb<int>).Method.GetGenericMethodDefinition();
 

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -29,7 +29,7 @@ namespace ProgressOnderwijsUtils
                 try {
                     var value = cmd.Command.ExecuteScalar();
 
-                    return FromDbValueConverter.Cast<T>(value);
+                    return DbValueConverter.FromDb<T>(value);
                 } catch (Exception e) {
                     throw cmd.CreateExceptionWithTextAndArguments(CurrentMethodName<T>() + " failed.", e);
                 }

--- a/src/ProgressOnderwijsUtils/Extensions/DictionaryExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/DictionaryExtensions.cs
@@ -14,7 +14,7 @@ namespace ProgressOnderwijsUtils
         /// </summary>
         public static T Field<T>([NotNull] this IDictionary<string, object> dict, [NotNull] string key)
         {
-            return FromDbValueConverter.Cast<T>(dict[key]);
+            return DbValueConverter.FromDb<T>(dict[key]);
         }
 
         /// <summary>
@@ -23,7 +23,7 @@ namespace ProgressOnderwijsUtils
         [UsefulToKeep("library method; interface is used, since method above is used")]
         public static T Field<T>([NotNull] this IReadOnlyDictionary<string, object> dict, string key)
         {
-            return FromDbValueConverter.Cast<T>(dict[key]);
+            return DbValueConverter.FromDb<T>(dict[key]);
         }
 
         /// <summary>

--- a/src/ProgressOnderwijsUtils/MetaObject/IMetaObjectPropertyConvertible.cs
+++ b/src/ProgressOnderwijsUtils/MetaObject/IMetaObjectPropertyConvertible.cs
@@ -2,7 +2,19 @@
 
 namespace ProgressOnderwijsUtils
 {
-    public interface IMetaObjectPropertyConvertible<TModel, TProvider, [UsedImplicitly] TConverterSource>
+    /// <summary>
+    /// Marker interface to easily allow the detection of convertible types.  Never implement this type specifically; use the fully-specified IMetaObjectPropertyConvertible with TModel, TProvider, and TConverterSource
+    /// </summary>
+    public interface IMetaObjectPropertyConvertible { }
+
+    /// <summary>
+    /// Marker interface to easily allow the detection of convertible types.  Never implement this type specifically; use the fully-specified IMetaObjectPropertyConvertible with TModel, TProvider, and TConverterSource
+    /// </summary>
+    /// <typeparam name="TProvider"></typeparam>
+    // ReSharper disable once UnusedTypeParameter
+    public interface IMetaObjectPropertyConvertible<TProvider> : IMetaObjectPropertyConvertible { }
+
+    public interface IMetaObjectPropertyConvertible<TModel, TProvider, [UsedImplicitly] TConverterSource> : IMetaObjectPropertyConvertible<TProvider>
         where TConverterSource : struct, IConverterSource<TModel, TProvider>
         where TModel : struct, IMetaObjectPropertyConvertible<TModel, TProvider, TConverterSource> { }
 }

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>41.0.0</Version>
-    <PackageReleaseNotes>Drop MetaObjectPropertyLoader (use IMetaObjectPropertyConvertible); Rename DBNullRemover => FromDbValueConverter and add support for IMetaObjectPropertyConvertible</PackageReleaseNotes>
+    <Version>42.0.0</Version>
+    <PackageReleaseNotes>Support both from- and to- DbValueConversion</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>

--- a/test/ProgressOnderwijsUtils.Tests/Data/TrivialConvertibleValue.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/TrivialConvertibleValue.cs
@@ -21,8 +21,5 @@ namespace ProgressOnderwijsUtils.Tests.Data
             => Value = value;
 
         public T Value { get; }
-
-        public static TrivialConvertibleValue<T> MethodWithIrrelevantName(T value)
-            => new TrivialConvertibleValue<T>(value);
     }
 }

--- a/test/ProgressOnderwijsUtils.Tests/FromDbValueConverterTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/FromDbValueConverterTest.cs
@@ -132,5 +132,29 @@ namespace ProgressOnderwijsUtils.Tests
             PAssert.That(() => FromDbValueConverter.Cast<TrivialConvertibleValue<string>?>(null) == null);
             PAssert.That(() => !Equals(FromDbValueConverter.Cast<TrivialConvertibleValue<string>?>(null), new TrivialConvertibleValue<string>(null)));
         }
+
+        [Fact]
+        public void CanCastToNullableNonConvertible()
+        {
+            PAssert.That(() => FromDbValueConverter.Cast<int?>(3) == 3);
+        }
+
+        [Fact]
+        public void CanCastToNullableConvertibleOfReferenceType()
+        {
+            PAssert.That(() => FromDbValueConverter.Cast<TrivialConvertibleValue<string>?>(new TrivialConvertibleValue<string>("asdf")).Value.Value == "asdf");
+        }
+
+        [Fact]
+        public void CanDynamicCastToNullableConvertibleOfReferenceType()
+        {
+            PAssert.That(() => new TrivialConvertibleValue<string>("asdf").Equals(FromDbValueConverter.DynamicCast(new TrivialConvertibleValue<string>("asdf"), typeof(TrivialConvertibleValue<string>?))));
+        }
+
+        [Fact]
+        public void CanCastToNullableConvertibleOfValueType()
+        {
+            PAssert.That(() => FromDbValueConverter.Cast<TrivialConvertibleValue<int>?>(new TrivialConvertibleValue<int>(-123)).Value.Value == -123);
+        }
     }
 }

--- a/test/ProgressOnderwijsUtils.Tests/FromDbValueConverterTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/FromDbValueConverterTest.cs
@@ -171,6 +171,37 @@ namespace ProgressOnderwijsUtils.Tests
             => PAssert.That(() => "asdf" == (string)DbValueConverter.DynamicCast(new TrivialConvertibleValue<string>("asdf"), typeof(string)));
 
         [Fact]
+        public void CanDynamicCastFromPlainValueToConvertibleType()
+        {
+            PAssert.That(() => "asdf" == ((TrivialConvertibleValue<string>)DbValueConverter.DynamicCast("asdf", typeof(TrivialConvertibleValue<string>))).Value);
+            PAssert.That(() => 42 == ((TrivialConvertibleValue<int>)DbValueConverter.DynamicCast(42, typeof(TrivialConvertibleValue<int>))).Value);
+        }
+
+        [Fact]
+        public void CanDynamicCastFromPlainValueToNullableConvertibleType()
+        {
+            PAssert.That(() => "asdf" == ((TrivialConvertibleValue<string>)DbValueConverter.DynamicCast("asdf", typeof(TrivialConvertibleValue<string>?))).Value);
+            PAssert.That(() => 42 == ((TrivialConvertibleValue<int>)DbValueConverter.DynamicCast(42, typeof(TrivialConvertibleValue<int>?))).Value);
+            PAssert.That(() => null == DbValueConverter.DynamicCast(null, typeof(TrivialConvertibleValue<string>?)));
+            PAssert.That(() => null == DbValueConverter.DynamicCast(null, typeof(TrivialConvertibleValue<int>?)));
+            PAssert.That(() => null == DbValueConverter.DynamicCast(null, typeof(TrivialConvertibleValue<int?>)));
+            PAssert.That(() => null == DbValueConverter.DynamicCast(null, typeof(TrivialConvertibleValue<int?>?)));
+        }
+
+        [Fact]
+        public void CanDynamicCastBetweenEnumsAndInts()
+        {
+            PAssert.That(() => 3 == (int)DbValueConverter.DynamicCast(DayOfWeek.Wednesday, typeof(int)));
+            PAssert.That(() => 3 == (int)DbValueConverter.DynamicCast(DayOfWeek.Wednesday, typeof(int?)));
+            PAssert.That(() => DayOfWeek.Wednesday == (DayOfWeek)DbValueConverter.DynamicCast(3, typeof(DayOfWeek)));
+            PAssert.That(() => DayOfWeek.Wednesday == (DayOfWeek)DbValueConverter.DynamicCast(3, typeof(DayOfWeek?)));
+        }
+
+        [Fact]
+        public void CanDynamicCastFromBetweenConvertiblesRegarlessOfNullability()
+            => PAssert.That(() => "asdf" == ((TrivialConvertibleValue<string>)DbValueConverter.DynamicCast(new TrivialConvertibleValue<string>("asdf"), typeof(TrivialConvertibleValue<string>?))).Value);
+
+        [Fact]
         public void CanCastFromConvertibleOfReferenceType()
             => PAssert.That(() => DbValueConverter.ToDb<string>(new TrivialConvertibleValue<string>("asdf")) == "asdf");
 

--- a/test/ProgressOnderwijsUtils.Tests/FromDbValueConverterTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/FromDbValueConverterTest.cs
@@ -9,152 +9,173 @@ namespace ProgressOnderwijsUtils.Tests
     {
         [Fact]
         public void Monday_is_equal_to_int_1()
-            => PAssert.That(() => FromDbValueConverter.EqualsConvertingIntToEnum(DayOfWeek.Monday, 1));
+            => PAssert.That(() => DbValueConverter.EqualsConvertingIntToEnum(DayOfWeek.Monday, 1));
 
         [Fact]
         public void Int_1_is_equal_to_Monday()
-            => PAssert.That(() => FromDbValueConverter.EqualsConvertingIntToEnum(1, DayOfWeek.Monday));
+            => PAssert.That(() => DbValueConverter.EqualsConvertingIntToEnum(1, DayOfWeek.Monday));
 
         [Fact]
         public void Monday_is_not_equal_to_int_2()
-            => PAssert.That(() => !FromDbValueConverter.EqualsConvertingIntToEnum(DayOfWeek.Monday, 2));
+            => PAssert.That(() => !DbValueConverter.EqualsConvertingIntToEnum(DayOfWeek.Monday, 2));
 
         [Fact]
         public void Int_2_is_not_equal_to_Monday()
-            => PAssert.That(() => !FromDbValueConverter.EqualsConvertingIntToEnum(2, DayOfWeek.Monday));
+            => PAssert.That(() => !DbValueConverter.EqualsConvertingIntToEnum(2, DayOfWeek.Monday));
 
         [Fact]
         public void Monday_is_not_equal_to_null()
-            => PAssert.That(() => !FromDbValueConverter.EqualsConvertingIntToEnum(DayOfWeek.Monday, null));
+            => PAssert.That(() => !DbValueConverter.EqualsConvertingIntToEnum(DayOfWeek.Monday, null));
 
         [Fact]
         public void Null_is_not_equal_to_Monday()
-            => PAssert.That(() => !FromDbValueConverter.EqualsConvertingIntToEnum(null, DayOfWeek.Monday));
+            => PAssert.That(() => !DbValueConverter.EqualsConvertingIntToEnum(null, DayOfWeek.Monday));
 
         [Fact]
         public void Int_1_is_equal_to_int_1()
-            => PAssert.That(() => FromDbValueConverter.EqualsConvertingIntToEnum(1, 1));
+            => PAssert.That(() => DbValueConverter.EqualsConvertingIntToEnum(1, 1));
 
         [Fact]
         public void Int_1_is_not_equal_to_int_2()
-            => PAssert.That(() => !FromDbValueConverter.EqualsConvertingIntToEnum(1, 2));
+            => PAssert.That(() => !DbValueConverter.EqualsConvertingIntToEnum(1, 2));
 
         [Fact]
         public void Monday_is_equal_to_Monday()
-            => PAssert.That(() => FromDbValueConverter.EqualsConvertingIntToEnum(DayOfWeek.Monday, DayOfWeek.Monday));
+            => PAssert.That(() => DbValueConverter.EqualsConvertingIntToEnum(DayOfWeek.Monday, DayOfWeek.Monday));
 
         [Fact]
         public void Monday_is_not_equal_to_Sunday()
-            => PAssert.That(() => !FromDbValueConverter.EqualsConvertingIntToEnum(DayOfWeek.Monday, DayOfWeek.Sunday));
+            => PAssert.That(() => !DbValueConverter.EqualsConvertingIntToEnum(DayOfWeek.Monday, DayOfWeek.Sunday));
 
         [Fact]
         public void DbNullConvertsToNullableInt()
-            => PAssert.That(() => FromDbValueConverter.Cast<int?>(DBNull.Value).HasValue == false);
+            => PAssert.That(() => DbValueConverter.FromDb<int?>(DBNull.Value).HasValue == false);
 
         [Fact]
         public void NullConvertsToNullableInt()
-            => PAssert.That(() => FromDbValueConverter.Cast<int?>(default(string)).HasValue == false);
+            => PAssert.That(() => DbValueConverter.FromDb<int?>(default(string)).HasValue == false);
 
         [Fact]
         public void NullConvertsToString()
-            => PAssert.That(() => FromDbValueConverter.Cast<string>(default(string)) == null);
+            => PAssert.That(() => DbValueConverter.FromDb<string>(default(string)) == null);
 
         [Fact]
         public void DbNullConvertsToString()
-            => PAssert.That(() => FromDbValueConverter.Cast<string>(DBNull.Value) == null);
+            => PAssert.That(() => DbValueConverter.FromDb<string>(DBNull.Value) == null);
 
         [Fact]
         public void StringsGetPassedThrough()
-            => PAssert.That(() => FromDbValueConverter.Cast<string>("hello") == "hello");
+            => PAssert.That(() => DbValueConverter.FromDb<string>("hello") == "hello");
 
         [Fact]
         public void BytesGetPassedThrough()
-            => PAssert.That(() => FromDbValueConverter.Cast<byte>((byte)128) == 128);
+            => PAssert.That(() => DbValueConverter.FromDb<byte>((byte)128) == 128);
 
         [Fact]
         public void IntsGetPassedThrough()
-            => PAssert.That(() => FromDbValueConverter.Cast<int>(42) == 42);
+            => PAssert.That(() => DbValueConverter.FromDb<int>(42) == 42);
 
         [Fact]
         public void IntsConvertToShorts_crashes()
-            => Assert.Throws<InvalidCastException>(() => FromDbValueConverter.Cast<short>(42) == 42);
+            => Assert.Throws<InvalidCastException>(() => DbValueConverter.FromDb<short>(42) == 42);
 
         [Fact]
         public void EnumsConvertToInt()
-            => PAssert.That(() => FromDbValueConverter.Cast<int>(DayOfWeek.Tuesday) == 2);
+            => PAssert.That(() => DbValueConverter.FromDb<int>(DayOfWeek.Tuesday) == 2);
 
         [Fact]
         public void EnumsConvertToNonUnderlyingType_crashes()
-            => Assert.Throws<InvalidCastException>(() => FromDbValueConverter.Cast<short>(DayOfWeek.Tuesday) == 2);
+            => Assert.Throws<InvalidCastException>(() => DbValueConverter.FromDb<short>(DayOfWeek.Tuesday) == 2);
 
         [Fact]
         public void IntsConvertToEnum()
-            => PAssert.That(() => FromDbValueConverter.Cast<DayOfWeek>(2) == DayOfWeek.Tuesday);
+            => PAssert.That(() => DbValueConverter.FromDb<DayOfWeek>(2) == DayOfWeek.Tuesday);
 
         [Fact]
         public void NonUnderlyingIntsConvertToEnum_crashes()
-            => Assert.Throws<InvalidCastException>(() => FromDbValueConverter.Cast<DayOfWeek>((short)2) == DayOfWeek.Tuesday);
+            => Assert.Throws<InvalidCastException>(() => DbValueConverter.FromDb<DayOfWeek>((short)2) == DayOfWeek.Tuesday);
 
         [Fact]
         public void DoublesConvertToInt_crashes()
-            => Assert.Throws<InvalidCastException>(() => FromDbValueConverter.Cast<int>(3.0) == 3);
+            => Assert.Throws<InvalidCastException>(() => DbValueConverter.FromDb<int>(3.0) == 3);
 
         [Fact]
-        public void TrivialConverterPassesValueTypesThrough()
-            => PAssert.That(() => FromDbValueConverter.Cast<TrivialConvertibleValue<int>>(3).Value == 3);
+        public void TrivialConverterPassesValueTypesThrough_FromDb()
+            => PAssert.That(() => DbValueConverter.FromDb<TrivialConvertibleValue<int>>(3).Value == 3);
+
+        [Fact]
+        public void TrivialConverterPassesValueTypesThrough_ToDb()
+            => PAssert.That(() => DbValueConverter.ToDb<int>(new TrivialConvertibleValue<int>(3)) == 3);
+
+        [Fact]
+        public void NastyDoubleNullabilityToDbIsReasonable()
+        {
+            PAssert.That(() => DbValueConverter.ToDb<int>(new TrivialConvertibleValue<int?>(3)) == 3);
+            PAssert.That(() => DbValueConverter.ToDb<int?>(new TrivialConvertibleValue<int>(3)) == 3);
+            PAssert.That(() => DbValueConverter.ToDb<int?>(new TrivialConvertibleValue<int?>(3)) == 3);
+            PAssert.That(() => DbValueConverter.ToDb<int?>(default(TrivialConvertibleValue<int?>?)) == null);
+        }
+
+        [Fact]
+        public void NullableTrivialConverterConvertsNullableValueIntoUnwrappedNull_ToDb()
+            => PAssert.That(() => DbValueConverter.ToDb<int?>(default(TrivialConvertibleValue<int>?)) == null);
 
         [Fact]
         public void EnumConvertibleTypesCanNotConvertFomInt()
-            => Assert.Throws<InvalidCastException>(() => FromDbValueConverter.Cast<TrivialConvertibleValue<DayOfWeek>>(3).Value);
+            => Assert.Throws<InvalidCastException>(() => DbValueConverter.FromDb<TrivialConvertibleValue<DayOfWeek>>(3).Value);
 
         [Fact]
         public void IntConvertibleTypesCanConvertFomEnum()
-            => PAssert.That(() => FromDbValueConverter.Cast<TrivialConvertibleValue<int>>(DayOfWeek.Thursday).Value == 4, "weird, probably not a good idea, but current behavior nontheless");
+            => PAssert.That(() => DbValueConverter.FromDb<TrivialConvertibleValue<int>>(DayOfWeek.Thursday).Value == 4, "weird, probably not a good idea, but current behavior nontheless");
 
         [Fact]
         public void IntConvertibleTypesCanConvertFomShort()
-            => PAssert.That(() => FromDbValueConverter.Cast<TrivialConvertibleValue<int>>((short)37).Value == 37, "weird, probably not a good idea, but current behavior nontheless");
+            => PAssert.That(() => DbValueConverter.FromDb<TrivialConvertibleValue<int>>((short)37).Value == 37, "weird, probably not a good idea, but current behavior nontheless");
 
         [Fact]
         public void TrivialConverterPassesRefTypesThrough()
-            => PAssert.That(() => FromDbValueConverter.Cast<TrivialConvertibleValue<string>>("asdf").Value == "asdf");
+            => PAssert.That(() => DbValueConverter.FromDb<TrivialConvertibleValue<string>>("asdf").Value == "asdf");
 
         [Fact]
         public void NullableTrivialConverterConvertsNullableValueIntoUnwrappedNull()
         {
-            PAssert.That(() => FromDbValueConverter.Cast<TrivialConvertibleValue<int?>?>(null) == null);
-            PAssert.That(() => !Equals(FromDbValueConverter.Cast<TrivialConvertibleValue<int?>?>(null), new TrivialConvertibleValue<int?>(null)));
+            PAssert.That(() => DbValueConverter.FromDb<TrivialConvertibleValue<int?>?>(null) == null);
+            PAssert.That(() => !Equals(DbValueConverter.FromDb<TrivialConvertibleValue<int?>?>(null), new TrivialConvertibleValue<int?>(null)));
         }
 
         [Fact]
         public void NullableTrivialConverterConvertsNullableRefIntoUnwrappedNull()
         {
-            PAssert.That(() => FromDbValueConverter.Cast<TrivialConvertibleValue<string>?>(null) == null);
-            PAssert.That(() => !Equals(FromDbValueConverter.Cast<TrivialConvertibleValue<string>?>(null), new TrivialConvertibleValue<string>(null)));
+            PAssert.That(() => DbValueConverter.FromDb<TrivialConvertibleValue<string>?>(null) == null);
+            PAssert.That(() => !Equals(DbValueConverter.FromDb<TrivialConvertibleValue<string>?>(null), new TrivialConvertibleValue<string>(null)));
         }
 
         [Fact]
         public void CanCastToNullableNonConvertible()
-        {
-            PAssert.That(() => FromDbValueConverter.Cast<int?>(3) == 3);
-        }
+            => PAssert.That(() => DbValueConverter.FromDb<int?>(3) == 3);
+
+        [Fact]
+        public void CanCastToNullableFromConvertible()
+            => PAssert.That(() => DbValueConverter.ToDb<int?>(new TrivialConvertibleValue<int?>(3)) == 3);
 
         [Fact]
         public void CanCastToNullableConvertibleOfReferenceType()
-        {
-            PAssert.That(() => FromDbValueConverter.Cast<TrivialConvertibleValue<string>?>(new TrivialConvertibleValue<string>("asdf")).Value.Value == "asdf");
-        }
+            => PAssert.That(() => DbValueConverter.FromDb<TrivialConvertibleValue<string>?>(new TrivialConvertibleValue<string>("asdf")).Value.Value == "asdf");
 
         [Fact]
         public void CanDynamicCastToNullableConvertibleOfReferenceType()
-        {
-            PAssert.That(() => new TrivialConvertibleValue<string>("asdf").Equals(FromDbValueConverter.DynamicCast(new TrivialConvertibleValue<string>("asdf"), typeof(TrivialConvertibleValue<string>?))));
-        }
+            => PAssert.That(() => new TrivialConvertibleValue<string>("asdf").Equals(DbValueConverter.DynamicCast(new TrivialConvertibleValue<string>("asdf"), typeof(TrivialConvertibleValue<string>?))));
+
+        [Fact]
+        public void CanDynamicCastToPlainStringFromConvertibleReferenceType()
+            => PAssert.That(() => "asdf" == (string)DbValueConverter.DynamicCast(new TrivialConvertibleValue<string>("asdf"), typeof(string)));
+
+        [Fact]
+        public void CanCastFromConvertibleOfReferenceType()
+            => PAssert.That(() => DbValueConverter.ToDb<string>(new TrivialConvertibleValue<string>("asdf")) == "asdf");
 
         [Fact]
         public void CanCastToNullableConvertibleOfValueType()
-        {
-            PAssert.That(() => FromDbValueConverter.Cast<TrivialConvertibleValue<int>?>(new TrivialConvertibleValue<int>(-123)).Value.Value == -123);
-        }
+            => PAssert.That(() => DbValueConverter.FromDb<TrivialConvertibleValue<int>?>(new TrivialConvertibleValue<int>(-123)).Value.Value == -123);
     }
 }

--- a/test/ProgressOnderwijsUtils.Tests/MetaObjectPropertyLoaderTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/MetaObjectPropertyLoaderTest.cs
@@ -128,7 +128,7 @@ namespace ProgressOnderwijsUtils.Tests
         [Fact]
         public void MetaObjectSupportsCustomObject_struct()
         {
-            PAssert.That(() => TrivialConvertibleValue<string>.MethodWithIrrelevantName("aap").Value == "aap");
+            PAssert.That(() => new TrivialConvertibleValue<string>("aap").Value == "aap");
 
             var target = CreateTempTable();
             SampleObjects.BulkCopyToSqlServer(Context, target);
@@ -140,7 +140,7 @@ namespace ProgressOnderwijsUtils.Tests
         [Fact]
         public void MetaObjectSupportsCustomObject_nullable_struct()
         {
-            PAssert.That(() => TrivialConvertibleValue<string>.MethodWithIrrelevantName("aap").Value == "aap");
+            PAssert.That(() => new TrivialConvertibleValue<string>("aap").Value == "aap");
 
             var target = CreateTempTable();
             SampleObjects.BulkCopyToSqlServer(Context, target);
@@ -152,7 +152,7 @@ namespace ProgressOnderwijsUtils.Tests
         [Fact]
         public void MetaObjectSupportsCustomObject_nonnullable_struct_with_null_values_throws_exception_with_helpful_message()
         {
-            PAssert.That(() => TrivialConvertibleValue<string>.MethodWithIrrelevantName("aap").Value == "aap");
+            PAssert.That(() => new TrivialConvertibleValue<string>("aap").Value == "aap");
 
             var target = CreateTempTable();
             SampleObjects.BulkCopyToSqlServer(Context, target);
@@ -164,7 +164,7 @@ namespace ProgressOnderwijsUtils.Tests
         [Fact]
         public void Query_errors_unrelated_to_column_mapping_are_not_misleading()
         {
-            PAssert.That(() => TrivialConvertibleValue<string>.MethodWithIrrelevantName("aap").Value == "aap");
+            PAssert.That(() => new TrivialConvertibleValue<string>("aap").Value == "aap");
 
             var target = CreateTempTable();
             SampleObjects.BulkCopyToSqlServer(Context, target);


### PR DESCRIPTION
This is a little dubious, since it means there are places in the code that are converting multiple times, but it's existing behavior in pnet.