### PR TITLE
Support casting from null to IMetaObjectPropertyConverter types even with DynamicCast

### DIFF
--- a/src/ProgressOnderwijsUtils/Data/FromDbValueConverter.cs
+++ b/src/ProgressOnderwijsUtils/Data/FromDbValueConverter.cs
@@ -114,6 +114,11 @@ namespace ProgressOnderwijsUtils
         {
             if (type.IsInstanceOfType(val)) {
                 return val;
+            } else if (val == null || val == DBNull.Value) {
+                if (type.IsValueType && !type.IsNullableValueType()) {
+                    throw new InvalidCastException("Cannot cast (db)null to " + type.ToCSharpFriendlyTypeName());
+                }
+                return null;
             } else if (MetaObjectPropertyConverter.GetOrNull(type) is MetaObjectPropertyConverter targetConvertible) {
                 return targetConvertible.ConvertFromDb(val);
             } else if (MetaObjectPropertyConverter.GetOrNull(val.GetType()) is MetaObjectPropertyConverter sourceConvertible && sourceConvertible.DbType == type.GetNonNullableType()) {

--- a/test/ProgressOnderwijsUtils.Tests/FromDbValueConverterTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/FromDbValueConverterTest.cs
@@ -184,9 +184,12 @@ namespace ProgressOnderwijsUtils.Tests
             PAssert.That(() => 42 == ((TrivialConvertibleValue<int>)DbValueConverter.DynamicCast(42, typeof(TrivialConvertibleValue<int>?))).Value);
             PAssert.That(() => null == DbValueConverter.DynamicCast(null, typeof(TrivialConvertibleValue<string>?)));
             PAssert.That(() => null == DbValueConverter.DynamicCast(null, typeof(TrivialConvertibleValue<int>?)));
-            PAssert.That(() => null == DbValueConverter.DynamicCast(null, typeof(TrivialConvertibleValue<int?>)));
             PAssert.That(() => null == DbValueConverter.DynamicCast(null, typeof(TrivialConvertibleValue<int?>?)));
         }
+
+        [Fact]
+        public void CanNotCastNullToNonNullableConvertibleContainingNullable()
+            => Assert.ThrowsAny<Exception>(() => null == DbValueConverter.DynamicCast(null, typeof(TrivialConvertibleValue<int?>)));
 
         [Fact]
         public void CanDynamicCastBetweenEnumsAndInts()
@@ -196,6 +199,10 @@ namespace ProgressOnderwijsUtils.Tests
             PAssert.That(() => DayOfWeek.Wednesday == (DayOfWeek)DbValueConverter.DynamicCast(3, typeof(DayOfWeek)));
             PAssert.That(() => DayOfWeek.Wednesday == (DayOfWeek)DbValueConverter.DynamicCast(3, typeof(DayOfWeek?)));
         }
+
+        [Fact]
+        public void CanDynamicCastFromNull()
+            => PAssert.That(() => null == (int?)DbValueConverter.DynamicCast(null, typeof(int?)));
 
         [Fact]
         public void CanDynamicCastFromBetweenConvertiblesRegarlessOfNullability()


### PR DESCRIPTION
This locally solves all failing test cases we have here: http://pcjenkins2015:8080/job/BuildTest-PullRequest/59814