### PR TITLE
Convenient try with cleanup wrapper

### DIFF
--- a/src/ProgressOnderwijsUtils/Collections/Maybe.cs
+++ b/src/ProgressOnderwijsUtils/Collections/Maybe.cs
@@ -198,6 +198,11 @@ namespace ProgressOnderwijsUtils.Collections
             }
         }
 
+        /// <summary>
+        /// Executions a computation with reliable cleanup (like try...finally or using(...) {}).
+        /// When both computation and cleanup throw exceptions, wraps both exceptions in an AggregateException.
+        /// Instead of throwing, this method returns exceptions in a Maybe.Error().
+        /// </summary>
         public Maybe<Unit, Exception> Finally(Action cleanup)
         {
             try {
@@ -226,6 +231,11 @@ namespace ProgressOnderwijsUtils.Collections
             }
         }
 
+        /// <summary>
+        /// Executions a computation with reliable cleanup (like try...finally or using(...) {}).
+        /// When both computation and cleanup throw exceptions, wraps both exceptions in an AggregateException.
+        /// Instead of throwing, this method returns exceptions in a Maybe.Error().
+        /// </summary>
         public Maybe<TOk, Exception> Finally(Action cleanup)
         {
             try {

--- a/src/ProgressOnderwijsUtils/Collections/Maybe.cs
+++ b/src/ProgressOnderwijsUtils/Collections/Maybe.cs
@@ -197,6 +197,16 @@ namespace ProgressOnderwijsUtils.Collections
                 return Maybe.Error(e);
             }
         }
+
+        public Maybe<Unit, Exception> Finally(Action cleanup)
+        {
+            try {
+                Utils.TryWithCleanup(tryBody, cleanup);
+                return Maybe.Ok();
+            } catch (Exception e) {
+                return Maybe.Error(e);
+            }
+        }
     }
 
     public struct MaybeTryBody<TOk>
@@ -212,6 +222,15 @@ namespace ProgressOnderwijsUtils.Collections
             try {
                 return Maybe.Ok(tryBody());
             } catch (TError e) {
+                return Maybe.Error(e);
+            }
+        }
+
+        public Maybe<TOk, Exception> Finally(Action cleanup)
+        {
+            try {
+                return Maybe.Ok(Utils.TryWithCleanup(tryBody, cleanup));
+            } catch (Exception e) {
                 return Maybe.Error(e);
             }
         }

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>45.0.0</Version>
-    <PackageReleaseNotes>Trigger triggers on bulkinsert by default</PackageReleaseNotes>
+    <Version>45.1.0</Version>
+    <PackageReleaseNotes>Add Utility methods Utils.TryWithCleanup and Maybe.Try().Finally() to simplify dealing with possibly failing cleanup code.</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>

--- a/src/ProgressOnderwijsUtils/Utils.cs
+++ b/src/ProgressOnderwijsUtils/Utils.cs
@@ -166,6 +166,10 @@ namespace ProgressOnderwijsUtils
         public static int MaandSpan(DateTime d1, DateTime d2)
             => Math.Abs(d1 > d2 ? 12 * (d1.Year - d2.Year) + d1.Month - d2.Month : 12 * (d2.Year - d1.Year) + d2.Month - d1.Month);
 
+        /// <summary>
+        /// Executions a computation with reliable cleanup (like try...finally or using(...) {}).
+        /// When both computation and cleanup throw exceptions, wraps both exceptions in an AggregateException.
+        /// </summary>
         public static T TryWithCleanup<T>(Func<T> computation, Action cleanup)
         {
             var completedOk = false;
@@ -181,6 +185,10 @@ namespace ProgressOnderwijsUtils
             }
         }
 
+        /// <summary>
+        /// Executions a computation with reliable cleanup (like try...finally or using(...) {}).
+        /// When both computation and cleanup throw exceptions, wraps both exceptions in an AggregateException.
+        /// </summary>
         public static void TryWithCleanup(Action computation, Action cleanup)
         {
             var completedOk = false;

--- a/src/ProgressOnderwijsUtils/Utils.cs
+++ b/src/ProgressOnderwijsUtils/Utils.cs
@@ -166,6 +166,45 @@ namespace ProgressOnderwijsUtils
         public static int MaandSpan(DateTime d1, DateTime d2)
             => Math.Abs(d1 > d2 ? 12 * (d1.Year - d2.Year) + d1.Month - d2.Month : 12 * (d2.Year - d1.Year) + d2.Month - d1.Month);
 
+        public static T TryWithCleanup<T>(Func<T> computation, Action cleanup)
+        {
+            var completedOk = false;
+            try {
+                var retval = computation();
+                completedOk = true;
+                cleanup();
+                return retval;
+            } catch (Exception computationEx) when (!completedOk && Catch(cleanup) is Exception cleanupEx) {
+                //for debugger-friendliness: try to avoid catching exceptions and rethrowing, even with "throw;"
+                //That means a catch-rethrow should only occur when we know both fail.
+                throw new AggregateException("Both the computation and the cleanup code crashed", computationEx, cleanupEx);
+            }
+        }
+
+        public static void TryWithCleanup(Action computation, Action cleanup)
+        {
+            var completedOk = false;
+            try {
+                computation();
+                completedOk = true;
+                cleanup();
+            } catch (Exception computationEx) when (!completedOk && Catch(cleanup) is Exception cleanupEx) {
+                //for debugger-friendliness: try to avoid catching exceptions and rethrowing, even with "throw;"
+                //That means a catch-rethrow should only occur when we know both fail.
+                throw new AggregateException("Both the computation and the cleanup code crashed", computationEx, cleanupEx);
+            }
+        }
+
+        static Exception Catch(Action cleanup)
+        {
+            try {
+                cleanup();
+            } catch (Exception e) {
+                return e;
+            }
+            return null;
+        }
+
         /// <summary>
         /// Volgordebehoudende transformatie van getal naar string, dus:
         /// 


### PR DESCRIPTION
Aim: to make debugging failure cases easier, particularly when the cleanup code can fail too.