### PR TITLE
Various utils cleanups

### DIFF
--- a/src/ProgressOnderwijsUtils/Collections/Tree.cs
+++ b/src/ProgressOnderwijsUtils/Collections/Tree.cs
@@ -34,11 +34,6 @@ namespace ProgressOnderwijsUtils.Collections
             => new Tree<T>(value, null);
 
         [Pure]
-        public static Tree<T?> Nullable<T>(T? value)
-            where T : class
-            => new Tree<T?>(value, null);
-
-        [Pure]
         public static Tree<T> BuildRecursively<T>(T root, Func<T, IEnumerable<T>?> kidLookup)
             => CachedTreeBuilder<T>.Resolve(root, kidLookup);
 

--- a/src/ProgressOnderwijsUtils/Collections/Tree.cs
+++ b/src/ProgressOnderwijsUtils/Collections/Tree.cs
@@ -32,7 +32,6 @@ namespace ProgressOnderwijsUtils.Collections
 
         [NotNull]
         [Pure]
-        [CodeThatsOnlyUsedForTests]
         public static Tree<T> Node<T>(T value, Tree<T> a, Tree<T> b, Tree<T> c)
             => new Tree<T>(value, new[] { a, b, c });
 
@@ -65,7 +64,6 @@ namespace ProgressOnderwijsUtils.Collections
 
         [NotNull]
         [Pure]
-        [CodeThatsOnlyUsedForTests]
         public static IEqualityComparer<Tree<T>> EqualityComparer<T>(IEqualityComparer<T> valueComparer)
             => new Tree<T>.Comparer(valueComparer);
 

--- a/src/ProgressOnderwijsUtils/Collections/Tree.cs
+++ b/src/ProgressOnderwijsUtils/Collections/Tree.cs
@@ -20,21 +20,6 @@ namespace ProgressOnderwijsUtils.Collections
         public static Tree<T> Node<T>(T value, IEnumerable<Tree<T>> children)
             => new Tree<T>(value, children);
 
-        [NotNull]
-        [Pure]
-        public static Tree<T> Node<T>(T value, Tree<T> a)
-            => new Tree<T>(value, new[] { a, });
-
-        [NotNull]
-        [Pure]
-        public static Tree<T> Node<T>(T value, Tree<T> a, Tree<T> b)
-            => new Tree<T>(value, new[] { a, b });
-
-        [NotNull]
-        [Pure]
-        public static Tree<T> Node<T>(T value, Tree<T> a, Tree<T> b, Tree<T> c)
-            => new Tree<T>(value, new[] { a, b, c });
-
         // ReSharper disable MethodOverloadWithOptionalParameter
         [NotNull]
         [Pure]

--- a/src/ProgressOnderwijsUtils/Data/ColumnSort.cs
+++ b/src/ProgressOnderwijsUtils/Data/ColumnSort.cs
@@ -30,15 +30,11 @@ namespace ProgressOnderwijsUtils
 
         [Pure]
         public ColumnSort WithReverseDirection()
-            => new ColumnSort(ColumnName, FlipDirection(SortDirection));
+            => new ColumnSort(ColumnName, SortDirection == SortDirection.Asc ? SortDirection.Desc : SortDirection.Asc);
 
         [Pure]
         public ColumnSort WithDifferentName(string newColumn)
             => new ColumnSort(newColumn, SortDirection);
-
-        [Pure]
-        static SortDirection FlipDirection(SortDirection dir)
-            => dir == SortDirection.Asc ? SortDirection.Desc : SortDirection.Asc;
 
         [Pure]
         public bool Equals(ColumnSort other)

--- a/src/ProgressOnderwijsUtils/Data/ColumnSort.cs
+++ b/src/ProgressOnderwijsUtils/Data/ColumnSort.cs
@@ -13,7 +13,6 @@ namespace ProgressOnderwijsUtils
     public readonly struct ColumnSort : IEquatable<ColumnSort>
     {
         public string ColumnName { get; }
-
         public SortDirection SortDirection { get; }
 
         [NotNull]
@@ -25,8 +24,8 @@ namespace ProgressOnderwijsUtils
 
         public ColumnSort(string column, SortDirection direction)
         {
-            this.ColumnName = column;
-            this.SortDirection = direction;
+            ColumnName = column;
+            SortDirection = direction;
         }
 
         [Pure]

--- a/src/ProgressOnderwijsUtils/Data/ColumnSort.cs
+++ b/src/ProgressOnderwijsUtils/Data/ColumnSort.cs
@@ -10,7 +10,7 @@ namespace ProgressOnderwijsUtils
     }
 
     [Serializable]
-    public struct ColumnSort : IEquatable<ColumnSort>
+    public readonly struct ColumnSort : IEquatable<ColumnSort>
     {
         readonly string column;
         readonly SortDirection direction;

--- a/src/ProgressOnderwijsUtils/Data/ColumnSort.cs
+++ b/src/ProgressOnderwijsUtils/Data/ColumnSort.cs
@@ -48,16 +48,5 @@ namespace ProgressOnderwijsUtils
         [Pure]
         public override int GetHashCode()
             => StringComparer.OrdinalIgnoreCase.GetHashCode(ColumnName) + 51 * (int)SortDirection;
-
-        [Pure]
-        public static bool operator ==(ColumnSort a, ColumnSort b)
-            => a.Equals(b);
-        //ReferenceEquals(a, b) || null != (object)a &&
-
-        [Pure]
-        public static bool operator !=(ColumnSort a, ColumnSort b)
-            => !a.Equals(b);
-
-        //!ReferenceEquals(a, b) && (null == (object)a ||
     }
 }

--- a/src/ProgressOnderwijsUtils/Data/ColumnSort.cs
+++ b/src/ProgressOnderwijsUtils/Data/ColumnSort.cs
@@ -12,35 +12,30 @@ namespace ProgressOnderwijsUtils
     [Serializable]
     public readonly struct ColumnSort : IEquatable<ColumnSort>
     {
-        readonly string column;
-        readonly SortDirection direction;
+        public string ColumnName { get; }
 
-        public string ColumnName
-            => column;
-
-        public SortDirection SortDirection
-            => direction;
+        public SortDirection SortDirection { get; }
 
         [NotNull]
         public string SqlSortString()
-            => column + " " + direction;
+            => ColumnName + " " + SortDirection;
 
         public override string ToString()
-            => "[" + column + " " + direction + "]";
+            => "[" + ColumnName + " " + SortDirection + "]";
 
         public ColumnSort(string column, SortDirection direction)
         {
-            this.column = column;
-            this.direction = direction;
+            this.ColumnName = column;
+            this.SortDirection = direction;
         }
 
         [Pure]
         public ColumnSort WithReverseDirection()
-            => new ColumnSort(column, FlipDirection(direction));
+            => new ColumnSort(ColumnName, FlipDirection(SortDirection));
 
         [Pure]
         public ColumnSort WithDifferentName(string newColumn)
-            => new ColumnSort(newColumn, direction);
+            => new ColumnSort(newColumn, SortDirection);
 
         [Pure]
         static SortDirection FlipDirection(SortDirection dir)
@@ -57,7 +52,7 @@ namespace ProgressOnderwijsUtils
 
         [Pure]
         public override int GetHashCode()
-            => StringComparer.OrdinalIgnoreCase.GetHashCode(column) + 51 * (int)direction;
+            => StringComparer.OrdinalIgnoreCase.GetHashCode(ColumnName) + 51 * (int)SortDirection;
 
         [Pure]
         public static bool operator ==(ColumnSort a, ColumnSort b)

--- a/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
+++ b/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
@@ -153,7 +153,7 @@ namespace ProgressOnderwijsUtils
 
         [Pure]
         public override int GetHashCode()
-            => (int)DirectAcessColumns.Select((sc, i) => (2 * i + 1) * (long)sc.GetHashCode()).Aggregate(12345L, (a, b) => a + b);
+            => 12345 + (int)DirectAcessColumns.Select((sc, i) => (2 * i + 1) * (long)sc.GetHashCode()).Sum();
 
         public override string ToString()
             => "{" + DirectAcessColumns.Select(col => col.ToString()).JoinStrings(", ") + "}";

--- a/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
+++ b/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
@@ -161,16 +161,14 @@ namespace ProgressOnderwijsUtils
         [Pure]
         public OrderByColumns AssumeThenBy(OrderByColumns BaseSortOrder)
         {
-            if (!BaseSortOrder.DirectAcessColumns.Any()) {
-                return this;
+            var myCols = DirectAcessColumns;
+            var assumedCols = BaseSortOrder.DirectAcessColumns;
+            for (var matchLen = Math.Min(assumedCols.Length, myCols.Length); 0 < matchLen; matchLen--) {
+                if (myCols.AsSpan(myCols.Length - matchLen, matchLen).SequenceEqual(assumedCols.AsSpan(0, matchLen))) {
+                    return new OrderByColumns(myCols.AsSpan(0, myCols.Length - matchLen).ToArray());
+                }
             }
-            var possibleMatchingTail = DirectAcessColumns.SkipWhile(colsort => !colsort.Equals(BaseSortOrder.DirectAcessColumns.First()));
-            var baseTailOfSameLength = BaseSortOrder.DirectAcessColumns.Take(possibleMatchingTail.Count());
-            if (possibleMatchingTail.SequenceEqual(baseTailOfSameLength)) { //equal!
-                return new OrderByColumns(DirectAcessColumns.TakeWhile(colsort => !colsort.Equals(BaseSortOrder.DirectAcessColumns.First())));
-            } else {
-                return this;
-            }
+            return this;
         }
     }
 }

--- a/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
+++ b/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
@@ -16,9 +16,6 @@ namespace ProgressOnderwijsUtils
     [Serializable]
     public struct OrderByColumns : IEquatable<OrderByColumns>
     {
-        static bool streq(string a, string b)
-            => string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
-
         readonly ColumnSort[]? sortColumns;
 
         [Pure]

--- a/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
+++ b/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
@@ -50,7 +50,7 @@ namespace ProgressOnderwijsUtils
         public SortDirection? GetColumnSortDirection(string column)
         {
             foreach (var sc in Columns) {
-                if (streq(sc.ColumnName, column)) {
+                if (string.Equals(sc.ColumnName, column, StringComparison.OrdinalIgnoreCase)) {
                     return sc.SortDirection;
                 }
             }

--- a/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
+++ b/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 using System.Linq;
-using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -23,7 +23,7 @@ namespace ProgressOnderwijsUtils
 
         readonly ColumnSort[] sortColumns;
 
-        [System.Diagnostics.Contracts.Pure]
+        [Pure]
         public IEnumerable<ColumnSort> Columns
         {
             get {
@@ -89,7 +89,7 @@ namespace ProgressOnderwijsUtils
             return index == -1 ? default(int?) : index + 1;
         }
 
-        [System.Diagnostics.Contracts.Pure]
+        [Pure]
         public int ColumnCount
             => sortColumns == null ? 0 : sortColumns.Length;
 

--- a/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
+++ b/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
@@ -76,10 +76,6 @@ namespace ProgressOnderwijsUtils
         }
 
         [Pure]
-        public int ColumnCount
-            => sortColumns == null ? 0 : sortColumns.Length;
-
-        [Pure]
         public OrderByColumns ToggleSortDirection(string kolomnaam)
         {
             var oldSortCol = GetSortColumn(kolomnaam);

--- a/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
+++ b/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
@@ -25,9 +25,6 @@ namespace ProgressOnderwijsUtils
         public ColumnSort[] Columns
             => sortColumns.EmptyIfNull();
 
-        ColumnSort[] DirectAcessColumns
-            => sortColumns.EmptyIfNull();
-
         public static OrderByColumns Empty
             => default(OrderByColumns);
 
@@ -52,7 +49,7 @@ namespace ProgressOnderwijsUtils
         [Pure]
         public SortDirection? GetColumnSortDirection(string column)
         {
-            foreach (var sc in DirectAcessColumns) {
+            foreach (var sc in Columns) {
                 if (streq(sc.ColumnName, column)) {
                     return sc.SortDirection;
                 }
@@ -66,11 +63,11 @@ namespace ProgressOnderwijsUtils
 
         [Pure]
         public OrderByColumns FirstSortBy(ColumnSort firstby)
-            => new OrderByColumns(DeduplicateByName(new[] { firstby }.ConcatArray(DirectAcessColumns)));
+            => new OrderByColumns(DeduplicateByName(new[] { firstby }.ConcatArray(Columns)));
 
         [Pure]
         public OrderByColumns ThenSortBy(ColumnSort thenby)
-            => new OrderByColumns(DeduplicateByName(DirectAcessColumns.Append(thenby)));
+            => new OrderByColumns(Columns.Append(thenby));
 
         [Pure]
         public OrderByColumns ThenAsc(string column)
@@ -90,11 +87,11 @@ namespace ProgressOnderwijsUtils
 
         [Pure]
         public OrderByColumns ThenSortBy(OrderByColumns thenby)
-            => new OrderByColumns(DeduplicateByName(DirectAcessColumns.ConcatArray(thenby.DirectAcessColumns)));
+            => new OrderByColumns(DeduplicateByName(Columns.ConcatArray(thenby.Columns)));
 
         [Pure]
         public bool Equals(OrderByColumns other)
-            => DirectAcessColumns.SequenceEqual(other.DirectAcessColumns);
+            => Columns.SequenceEqual(other.Columns);
 
         public static bool operator ==(OrderByColumns a, OrderByColumns b)
             => a.Equals(b);
@@ -108,16 +105,16 @@ namespace ProgressOnderwijsUtils
 
         [Pure]
         public override int GetHashCode()
-            => 12345 + (int)DirectAcessColumns.Select((sc, i) => (2 * i + 1) * (long)sc.GetHashCode()).Sum();
+            => 12345 + (int)Columns.Select((sc, i) => (2 * i + 1) * (long)sc.GetHashCode()).Sum();
 
         public override string ToString()
-            => "{" + DirectAcessColumns.Select(col => col.ToString()).JoinStrings(", ") + "}";
+            => "{" + Columns.Select(col => col.ToString()).JoinStrings(", ") + "}";
 
         [Pure]
         public OrderByColumns AssumeThenBy(OrderByColumns BaseSortOrder)
         {
-            var myCols = DirectAcessColumns;
-            var assumedCols = BaseSortOrder.DirectAcessColumns;
+            var myCols = Columns;
+            var assumedCols = BaseSortOrder.Columns;
             for (var matchLen = Math.Min(assumedCols.Length, myCols.Length); 0 < matchLen; matchLen--) {
                 if (myCols.AsSpan(myCols.Length - matchLen, matchLen).SequenceEqual(assumedCols.AsSpan(0, matchLen))) {
                     return new OrderByColumns(myCols.AsSpan(0, myCols.Length - matchLen).ToArray());

--- a/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
+++ b/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
@@ -16,19 +16,17 @@ namespace ProgressOnderwijsUtils
     [Serializable]
     public struct OrderByColumns : IEquatable<OrderByColumns>
     {
-        static readonly ColumnSort[] EmptyOrder = { };
-
         static bool streq(string a, string b)
             => string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
 
-        readonly ColumnSort[] sortColumns;
+        readonly ColumnSort[]? sortColumns;
 
         [Pure]
         public ColumnSort[] Columns
-            => sortColumns ?? EmptyOrder;
+            => sortColumns.EmptyIfNull();
 
         ColumnSort[] DirectAcessColumns
-            => sortColumns ?? EmptyOrder;
+            => sortColumns.EmptyIfNull();
 
         public static OrderByColumns Empty
             => default(OrderByColumns);

--- a/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
+++ b/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
@@ -41,7 +41,7 @@ namespace ProgressOnderwijsUtils
         public static OrderByColumns Empty
             => default(OrderByColumns);
 
-        public OrderByColumns([NotNull] IEnumerable<ColumnSort> order)
+        public OrderByColumns(IEnumerable<ColumnSort> order)
         {
             var columns = new ColumnSort[4];
             var idx = 0;
@@ -102,8 +102,7 @@ namespace ProgressOnderwijsUtils
                 : new OrderByColumns(DirectAcessColumns.Prepend(new ColumnSort(kolomnaam, SortDirection.Desc)).ToArray());
         }
 
-        [NotNull]
-        static IEnumerable<ColumnSort> PrependFiltered(ColumnSort head, [NotNull] IEnumerable<ColumnSort> tail)
+        static IEnumerable<ColumnSort> PrependFiltered(ColumnSort head, IEnumerable<ColumnSort> tail)
             => new[] { head }.Concat(tail.Where(sc => sc.ColumnName != head.ColumnName));
 
         [Pure]

--- a/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
+++ b/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
@@ -164,10 +164,10 @@ namespace ProgressOnderwijsUtils
             if (!BaseSortOrder.DirectAcessColumns.Any()) {
                 return this;
             }
-            var possibleMatchingTail = DirectAcessColumns.SkipWhile(colsort => colsort != BaseSortOrder.DirectAcessColumns.First());
+            var possibleMatchingTail = DirectAcessColumns.SkipWhile(colsort => !colsort.Equals(BaseSortOrder.DirectAcessColumns.First()));
             var baseTailOfSameLength = BaseSortOrder.DirectAcessColumns.Take(possibleMatchingTail.Count());
             if (possibleMatchingTail.SequenceEqual(baseTailOfSameLength)) { //equal!
-                return new OrderByColumns(DirectAcessColumns.TakeWhile(colsort => colsort != BaseSortOrder.DirectAcessColumns.First()));
+                return new OrderByColumns(DirectAcessColumns.TakeWhile(colsort => !colsort.Equals(BaseSortOrder.DirectAcessColumns.First())));
             } else {
                 return this;
             }

--- a/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
+++ b/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
@@ -66,10 +66,7 @@ namespace ProgressOnderwijsUtils
 
         [Pure]
         public SortDirection? GetColumnSortDirection(string column)
-        {
-            var sc = GetSortColumn(column);
-            return sc == null ? default(SortDirection?) : sc.Value.SortDirection;
-        }
+            => GetSortColumn(column)?.SortDirection;
 
         [Pure]
         public int? GetColumnSortRank(string col)

--- a/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
+++ b/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
@@ -27,11 +27,7 @@ namespace ProgressOnderwijsUtils
         public IEnumerable<ColumnSort> Columns
         {
             get {
-                if (sortColumns != null) {
-                    foreach (var sc in sortColumns) {
-                        yield return sc;
-                    }
-                }
+                return DirectAcessColumns;
             }
         }
 
@@ -82,7 +78,6 @@ namespace ProgressOnderwijsUtils
         }
 
         [Pure]
-        [CodeThatsOnlyUsedForTests]
         public int? GetColumnSortRank(string col)
         {
             var index = DirectAcessColumns.IndexOf(sc => sc.ColumnName.Equals(col, StringComparison.OrdinalIgnoreCase));

--- a/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
+++ b/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
@@ -77,12 +77,9 @@ namespace ProgressOnderwijsUtils
                 : new OrderByColumns(DirectAcessColumns.Prepend(new ColumnSort(kolomnaam, SortDirection.Desc)).ToArray());
         }
 
-        static IEnumerable<ColumnSort> PrependFiltered(ColumnSort head, IEnumerable<ColumnSort> tail)
-            => new[] { head }.Concat(tail.Where(sc => sc.ColumnName != head.ColumnName));
-
         [Pure]
         public OrderByColumns FirstSortBy(ColumnSort firstby)
-            => new OrderByColumns(PrependFiltered(firstby, DirectAcessColumns).ToArray());
+            => new OrderByColumns(new[] { firstby }.Concat(DirectAcessColumns.Where(sc => sc.ColumnName != firstby.ColumnName)).ToArray());
 
         [Pure]
         public OrderByColumns ThenSortBy(ColumnSort thenby)

--- a/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
+++ b/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
@@ -69,13 +69,6 @@ namespace ProgressOnderwijsUtils
             => GetSortColumn(column)?.SortDirection;
 
         [Pure]
-        public int? GetColumnSortRank(string col)
-        {
-            var index = DirectAcessColumns.IndexOf(sc => sc.ColumnName.Equals(col, StringComparison.OrdinalIgnoreCase));
-            return index == -1 ? default(int?) : index + 1;
-        }
-
-        [Pure]
         public OrderByColumns ToggleSortDirection(string kolomnaam)
         {
             var oldSortCol = GetSortColumn(kolomnaam);

--- a/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
+++ b/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
@@ -25,11 +25,7 @@ namespace ProgressOnderwijsUtils
 
         [Pure]
         public IEnumerable<ColumnSort> Columns
-        {
-            get {
-                return DirectAcessColumns;
-            }
-        }
+            => sortColumns ?? EmptyOrder;
 
         ColumnSort[] DirectAcessColumns
             => sortColumns ?? EmptyOrder;

--- a/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
+++ b/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
@@ -24,7 +24,7 @@ namespace ProgressOnderwijsUtils
         readonly ColumnSort[] sortColumns;
 
         [Pure]
-        public IEnumerable<ColumnSort> Columns
+        public ColumnSort[] Columns
             => sortColumns ?? EmptyOrder;
 
         ColumnSort[] DirectAcessColumns

--- a/src/ProgressOnderwijsUtils/Extensions/StringUtils.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/StringUtils.cs
@@ -152,45 +152,6 @@ namespace ProgressOnderwijsUtils
                     .JoinStrings(", ")
                 + "]";
 
-        /// <summary>
-        /// Vervang in een [naam]string beginletters door hoofdletters,
-        /// rekening houdend met tussenvoegsels en interpunctie
-        /// </summary>
-        /// <remarks>
-        /// tussenvoegsels zouden ook uit database kunnen worden gehaald:
-        /// [SELECT voorvoegsels FROM student group by voorvoegsels]
-        /// </remarks>
-        [Pure]
-        [CodeThatsOnlyUsedForTests]
-        public static string Name2UpperCasedName(string inp)
-        {
-            //string wat opschonen
-            inp = Regex.Replace(inp, @"\s+", " ");
-            inp = Regex.Replace(inp, @"\-+", "-");
-            inp = Regex.Replace(inp, @"('s)([a-zA-Z]+)", "$1 $2"); //'sgravenhage bv
-            inp = Regex.Replace(inp, @"^\-+|\-+$", "").Trim();
-            const string expression = @"d'|o'
-                                        | 's | 's-|'s| op 't | op ten | op de
-                                        | van het | van der | van de | van den | van ter
-                                        | auf dem | auf der | von der | von den
-                                        | in het | in 't | in de
-                                        | uit de | uit den | uit het 
-                                        | voor de | voor 't 
-                                        | aan het | aan 't | aan de | aan den | bij de | de la 
-                                        | del | van | von | het | de 
-                                        | der | den | des | di | dos | do | du | el | le | la
-                                        | lo | los | op | te | ten | ter | uit 
-                                        | vd | v.d. | v\/d
-                                        | au | aux | a | à | à la | a la 
-                                        | \- |\s|\s+|\-+";
-            var newstr = Regex.Split(inp, Regex.Replace(expression, @"\s+", " "));
-            return newstr.Aggregate(
-                inp,
-                (current, t) =>
-                    Regex.Replace(current, t, t.Length > 0 ? Capitalize(t.ToLowerInvariant()) : t)
-            );
-        }
-
         [Pure]
         static bool isVowel(char c)
             => c == 'a' || c == 'e' || c == 'i' || c == 'o' || c == 'u' || c == 'A' || c == 'E' || c == 'I' || c == 'O' || c == 'U';

--- a/src/ProgressOnderwijsUtils/Extensions/StringUtils.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/StringUtils.cs
@@ -50,18 +50,6 @@ namespace ProgressOnderwijsUtils
         }
 
         [Pure]
-        [CodeThatsOnlyUsedForTests]
-        public static string PrettyPrintCamelCased(string rawString)
-        {
-            var withSpace =
-                PrettyPrintValues.capLetter.Replace(
-                    rawString,
-                    m => (m.Index == 0 ? "" : " ") + (IsUpperAscii(m.Value) ? m.Value : DecapitalizeAscii(m.Value))
-                );
-            return PrettyPrintValues.whiteSpaceSequence.Replace(withSpace, " ");
-        }
-
-        [Pure]
         static bool IsUpperAscii(string str)
         {
             foreach (var c in str) {

--- a/src/ProgressOnderwijsUtils/Extensions/StringUtils.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/StringUtils.cs
@@ -140,7 +140,6 @@ namespace ProgressOnderwijsUtils
         }
 
         [Pure]
-        [CodeThatsOnlyUsedForTests]
         public static double LevenshteinDistanceScaled(string s, string t)
             => LevenshteinDistance(s, t) / (double)Math.Max(1, Math.Max(s.Length, t.Length));
 

--- a/src/ProgressOnderwijsUtils/Extensions/StringUtils.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/StringUtils.cs
@@ -71,7 +71,7 @@ namespace ProgressOnderwijsUtils
         }
 
         [Pure]
-        public static string PrettyCapitalizedPrintCamelCased(string rawString)
+        public static string PrettyPrintCamelCased(string rawString)
         {
             var withSpace =
                 PrettyPrintValues.capLetter.Replace(

--- a/src/ProgressOnderwijsUtils/PnetNullableExtensions.cs
+++ b/src/ProgressOnderwijsUtils/PnetNullableExtensions.cs
@@ -69,7 +69,6 @@ namespace ProgressOnderwijsUtils
             where TVal : struct
             => values.DefaultIfEmpty();
 
-        [CodeThatsOnlyUsedForTests]
         public static IEnumerable<TVal?> NullableIfEmpty<TVal>(this IEnumerable<TVal> values)
             where TVal : struct
             => values.Select(o => (TVal?)o).NullIfEmpty();

--- a/src/ProgressOnderwijsUtils/Pocos/PocoUtils.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/PocoUtils.cs
@@ -24,7 +24,6 @@ namespace ProgressOnderwijsUtils
 
         [NotNull]
         [Pure]
-        [CodeThatsOnlyUsedForTests]
         public static IPocoProperty<TPoco> GetByExpression<TPoco, T>([NotNull] Expression<Func<TPoco, T>> propertyExpression)
             where TPoco : IPoco
             => PocoProperties<TPoco>.Instance.GetByExpression(propertyExpression);

--- a/src/ProgressOnderwijsUtils/Utils.cs
+++ b/src/ProgressOnderwijsUtils/Utils.cs
@@ -49,7 +49,6 @@ namespace ProgressOnderwijsUtils
         /// <summary>
         /// Compares two floating point number for approximate equality (up to a 1 part per 2^32 deviation)
         /// </summary>
-        [CodeThatsOnlyUsedForTests]
         public static bool FuzzyEquals(double x, double y)
         {
             const double relativeEpsilon = 1.0 / (1ul << 32);

--- a/src/ProgressOnderwijsUtils/Utils.cs
+++ b/src/ProgressOnderwijsUtils/Utils.cs
@@ -321,14 +321,6 @@ namespace ProgressOnderwijsUtils
             return new string(str, 0, idx);
         }
 
-
-        [CodeThatsOnlyUsedForTests]
-        public static decimal RoundUp(decimal input, int places)
-        {
-            var multiplier = Convert.ToDecimal(Math.Pow(10, Convert.ToDouble(places)));
-            return Math.Ceiling(input * multiplier) / multiplier;
-        }
-
         /// <summary>
         /// returns 0 if input is zero; otherwise returns the only int for which the postcondition holds
         /// Postcondition: (1ul &lt;&lt; result) &lt;= x &lt; (1ul &lt;&lt; result+1)

--- a/src/ProgressOnderwijsUtils/Utils.cs
+++ b/src/ProgressOnderwijsUtils/Utils.cs
@@ -321,19 +321,6 @@ namespace ProgressOnderwijsUtils
             return new string(str, 0, idx);
         }
 
-        [CodeThatsOnlyUsedForTests]
-        public static DateTime? DateMax(DateTime? d1, DateTime? d2)
-        {
-            if (d1 == null) {
-                return d2;
-            }
-
-            if (d2 == null) {
-                return d1;
-            }
-
-            return d2 > d1 ? d2 : d1;
-        }
 
         [CodeThatsOnlyUsedForTests]
         public static decimal RoundUp(decimal input, int places)

--- a/src/ProgressOnderwijsUtils/XmlSerializableBase.cs
+++ b/src/ProgressOnderwijsUtils/XmlSerializableBase.cs
@@ -78,7 +78,6 @@ namespace ProgressOnderwijsUtils
         }
 
         [NotNull]
-        [CodeThatsOnlyUsedForTests]
         public static string Serialize([NotNull] T val)
         {
             using (var writer = new StringWriter()) {

--- a/test/ProgressOnderwijsUtils.Tests/OrderByColumnsTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/OrderByColumnsTest.cs
@@ -39,7 +39,7 @@ namespace ProgressOnderwijsUtils.Tests
 
         [Fact]
         public void ColumnCountOk()
-            => PAssert.That(() => colSort.ColumnCount == 3);
+            => PAssert.That(() => colSort.Columns.Length == 3);
 
         [Fact]
         public void ToStringOk()

--- a/test/ProgressOnderwijsUtils.Tests/OrderByColumnsTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/OrderByColumnsTest.cs
@@ -23,13 +23,6 @@ namespace ProgressOnderwijsUtils.Tests
             => PAssert.That(() => colSort.Columns.SequenceEqual(someOrder));
 
         [Fact]
-        public void SortRankOk()
-        {
-            PAssert.That(() => colSort.GetColumnSortRank("monster") == null);
-            PAssert.That(() => colSort.GetColumnSortRank("abc") == 2); //"rank" is 1-based
-        }
-
-        [Fact]
         public void SortDirectionOk()
         {
             PAssert.That(() => colSort.GetColumnSortDirection("abc") == SortDirection.Asc);

--- a/test/ProgressOnderwijsUtils.Tests/OrderByColumnsTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/OrderByColumnsTest.cs
@@ -14,7 +14,7 @@ namespace ProgressOnderwijsUtils.Tests
         static readonly ColumnSort monsterD = new ColumnSort("monster", SortDirection.Desc);
         static readonly ColumnSort acolA = new ColumnSort("acol", SortDirection.Asc);
         static readonly ColumnSort acolD = new ColumnSort("acol", SortDirection.Desc);
-        static readonly ColumnSort[] someOrder = new[] { ziggyA, abcA, acolD };
+        static readonly ColumnSort[] someOrder = { ziggyA, abcA, acolD };
         static readonly OrderByColumns colSort = new OrderByColumns(someOrder);
 
         [Fact]

--- a/test/ProgressOnderwijsUtils.Tests/SortColumnTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/SortColumnTest.cs
@@ -21,16 +21,6 @@ namespace ProgressOnderwijsUtils.Tests
         }
 
         [Fact]
-        public void OperatorsOk()
-        {
-            PAssert.That(() => new ColumnSort("test", SortDirection.Asc) == new ColumnSort("ziggy", SortDirection.Asc).WithDifferentName("test"));
-            PAssert.That(() => !(new ColumnSort("test", SortDirection.Asc) != new ColumnSort("ziggy", SortDirection.Asc).WithDifferentName("test")));
-
-            PAssert.That(() => new ColumnSort("test", SortDirection.Asc) == new ColumnSort("Test", SortDirection.Asc));
-            PAssert.That(() => !(new ColumnSort("test", SortDirection.Asc) != new ColumnSort("Test", SortDirection.Asc)));
-        }
-
-        [Fact]
         public void CheckSqlSortString()
         {
             Assert.Equal("ziggy Asc", new ColumnSort("ziggy", SortDirection.Asc).SqlSortString());

--- a/test/ProgressOnderwijsUtils.Tests/StringExtensionsTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/StringExtensionsTest.cs
@@ -188,9 +188,7 @@ namespace ProgressOnderwijsUtils.Tests
             };
             for (var row = 0; row < translations.GetLength(0); row++) {
                 var initial = translations[row, 0];
-                var ideal = translations[row, 1];
                 var idealCap = translations[row, 2];
-                PAssert.That(() => StringUtils.PrettyPrintCamelCased(initial) == ideal);
                 PAssert.That(() => StringUtils.PrettyCapitalizedPrintCamelCased(initial) == idealCap);
             }
         }

--- a/test/ProgressOnderwijsUtils.Tests/StringExtensionsTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/StringExtensionsTest.cs
@@ -189,7 +189,7 @@ namespace ProgressOnderwijsUtils.Tests
             for (var row = 0; row < translations.GetLength(0); row++) {
                 var initial = translations[row, 0];
                 var idealCap = translations[row, 2];
-                PAssert.That(() => StringUtils.PrettyCapitalizedPrintCamelCased(initial) == idealCap);
+                PAssert.That(() => StringUtils.PrettyPrintCamelCased(initial) == idealCap);
             }
         }
 

--- a/test/ProgressOnderwijsUtils.Tests/StringExtensionsTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/StringExtensionsTest.cs
@@ -101,31 +101,7 @@ namespace ProgressOnderwijsUtils.Tests
             PAssert.That(() => StringUtils.LevenshteinDistance("simple", "Simpler") == 2);
             PAssert.That(() => StringUtils.LevenshteinDistance("hmmm", "yummy") == 3);
             PAssert.That(() => StringUtils.LevenshteinDistance("World-wide", "wordy") == 7);
-            //"W"=>"w",drop "l", replace "-wide"
         }
-
-        [Fact]
-        public void testNaam2Upper()
-        {
-            PAssert.That(() => StringUtils.Name2UpperCasedName("joepje jofel") == "Joepje Jofel");
-            PAssert.That(() => StringUtils.Name2UpperCasedName("carolien Kaasteen") == "Carolien Kaasteen");
-            PAssert.That(
-                () => StringUtils.Name2UpperCasedName("maarten middelmaat--meloen") == "Maarten Middelmaat-Meloen");
-            PAssert.That(() => StringUtils.Name2UpperCasedName("carolien    Kaasteen") == "Carolien Kaasteen");
-            PAssert.That(() => StringUtils.Name2UpperCasedName("'s-gravenhage") == "'s-Gravenhage");
-            PAssert.That(() => StringUtils.Name2UpperCasedName("'s gravenhage") == "'s Gravenhage");
-            PAssert.That(() => StringUtils.Name2UpperCasedName("'sgravenhage") == "'s Gravenhage");
-            PAssert.That(() => StringUtils.Name2UpperCasedName("sieb op de kast") == "Sieb op de Kast");
-        }
-
-        [Fact]
-        public void testLangeNaam2Upper()
-            => PAssert.That(
-                () =>
-                    StringUtils.Name2UpperCasedName(
-                        "miep boezeroen-jansen van der sloot op 't gootje v.d. geest de la terrine du soupe au beurre à demi v/d zo-is-het-wel-genoeg ja")
-                    ==
-                    "Miep Boezeroen-Jansen van der Sloot op 't Gootje v.d. Geest de la Terrine du Soupe au Beurre à Demi v/d Zo-Is-Het-Wel-Genoeg Ja");
 
         [Fact]
         public void testDepluralize()

--- a/test/ProgressOnderwijsUtils.Tests/TreeTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/TreeTest.cs
@@ -50,10 +50,10 @@ namespace ProgressOnderwijsUtils.Tests
         [Fact]
         public void CustomizableComparerWorks()
         {
-            var tree1 = Tree.Node("a", Tree.Nullable("x"), Tree.Nullable("b"), Tree.Node(default(string)), Tree.Nullable(""));
-            var tree2 = Tree.Node("a", Tree.Nullable("x"), Tree.Nullable("B"), Tree.Node(default(string)), Tree.Nullable(""));
-            var tree3 = Tree.Node("a", Tree.Nullable("x"), Tree.Nullable("b"), Tree.Node(default(string)), Tree.Nullable(""));
-            var tree4 = Tree.Node("a", Tree.Nullable("y"), Tree.Nullable("b"), Tree.Node(default(string)), Tree.Nullable(""));
+            var tree1 = Tree.Node("a".PretendNullable(), Tree.Node("x".PretendNullable()), Tree.Node("b".PretendNullable()), Tree.Node(default(string)), Tree.Node("".PretendNullable()));
+            var tree2 = Tree.Node("a".PretendNullable(), Tree.Node("x".PretendNullable()), Tree.Node("B".PretendNullable()), Tree.Node(default(string)), Tree.Node("".PretendNullable()));
+            var tree3 = Tree.Node("a".PretendNullable(), Tree.Node("x".PretendNullable()), Tree.Node("b".PretendNullable()), Tree.Node(default(string)), Tree.Node("".PretendNullable()));
+            var tree4 = Tree.Node("a".PretendNullable(), Tree.Node("y".PretendNullable()), Tree.Node("b".PretendNullable()), Tree.Node(default(string)), Tree.Node("".PretendNullable()));
 
             PAssert.That(() => !tree1.Equals(tree2));
             PAssert.That(() => tree1.Equals(tree3));

--- a/test/ProgressOnderwijsUtils.Tests/UtilsTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/UtilsTest.cs
@@ -151,42 +151,6 @@ namespace ProgressOnderwijsUtils.Tests
         }
 
         [Fact]
-        public void DateMaxTest()
-        {
-            DateTime? d1 = null;
-            DateTime? d2 = null;
-
-            PAssert.That(() => Utils.DateMax(d1, d2) == null);
-
-            d1 = DateTime.Today;
-            PAssert.That(() => Utils.DateMax(d1, d2) == d1);
-
-            d1 = null;
-            d2 = DateTime.Today;
-            PAssert.That(() => Utils.DateMax(d1, d2) == d2);
-
-            d1 = DateTime.Today;
-            d2 = DateTime.Today;
-            PAssert.That(() => Utils.DateMax(d1, d2) == d1);
-
-            d1 = DateTime.Today.AddDays(-1);
-            d2 = DateTime.Today;
-            PAssert.That(() => Utils.DateMax(d1, d2) == d2);
-
-            d1 = DateTime.Today.AddDays(1);
-            d2 = DateTime.Today;
-            PAssert.That(() => Utils.DateMax(d1, d2) == d1);
-
-            d1 = DateTime.Today;
-            d2 = DateTime.Today.AddDays(-1);
-            PAssert.That(() => Utils.DateMax(d1, d2) == d1);
-
-            d1 = DateTime.Today;
-            d2 = DateTime.Today.AddDays(1);
-            PAssert.That(() => Utils.DateMax(d1, d2) == d2);
-        }
-
-        [Fact]
         public void RoundUp()
         {
             PAssert.That(() => Utils.RoundUp(1.12m, 2) == 1.12m);

--- a/test/ProgressOnderwijsUtils.Tests/UtilsTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/UtilsTest.cs
@@ -151,17 +151,6 @@ namespace ProgressOnderwijsUtils.Tests
         }
 
         [Fact]
-        public void RoundUp()
-        {
-            PAssert.That(() => Utils.RoundUp(1.12m, 2) == 1.12m);
-            PAssert.That(() => Utils.RoundUp(1.0m, 2) == 1.0m);
-            PAssert.That(() => Utils.RoundUp(1.121m, 2) == 1.13m);
-            PAssert.That(() => Utils.RoundUp(1.129m, 2) == 1.13m);
-            PAssert.That(() => Utils.RoundUp(1000001.122m, 2) == 1000001.13m);
-            PAssert.That(() => Utils.RoundUp(1000001.129m, 2) == 1000001.13m);
-        }
-
-        [Fact]
         public void SimpleTransitiveClosureWorks()
         {
             var nodes = new[] { 2, 3, };


### PR DESCRIPTION
 - mostly remove dead code whereby dead means "only used by its own tests, and implausible to be useful in the future"
 - Simplify OrderByColumns.
 - Some really minor breakign changes like a method rename; a removal of `.ColumnCount` because you can do `.Columns.Length`  (I intend to bump the major version in followup PR, but if I do that here, I'll implicitly publish these pointless changes, and I'd rather do some real work here too.)

