### PR TITLE
Optimize recursive tree building

### DIFF
--- a/src/ProgressOnderwijsUtils/Collections/CachedTreeBuilder.cs
+++ b/src/ProgressOnderwijsUtils/Collections/CachedTreeBuilder.cs
@@ -34,13 +34,14 @@ namespace ProgressOnderwijsUtils.Collections
         public static Tree<T> Resolve(T rootNodeValue, Func<T, IEnumerable<T>> kidLookup)
         {
             var needsGenerateOutput = new Stack<TreeNodeBuilder>(); //in order of creation; so junctions always before their kids.
+            var needsKids = new Stack<TreeNodeBuilder>();
 
             var rootBuilder = new TreeNodeBuilder { value = rootNodeValue, };
+
             needsGenerateOutput.Push(rootBuilder);
+            needsKids.Push(rootBuilder);
 
             var tempKidBuilders = new List<TreeNodeBuilder>();
-            var needsKids = new Stack<TreeNodeBuilder>();
-            needsKids.Push(rootBuilder);
 
             while (needsKids.Count > 0) {
                 var nodeBuilderThatWantsKids = needsKids.Pop();
@@ -55,11 +56,13 @@ namespace ProgressOnderwijsUtils.Collections
                         needsKids.Push(builderForKid);
                         tempKidBuilders.Add(builderForKid);
                     }
-                    nodeBuilderThatWantsKids.tempKids = tempKidBuilders.ToArray();
-                    tempKidBuilders.Clear();
-                } else {
-                    nodeBuilderThatWantsKids.finishedNode = Tree.Node(nodeBuilderThatWantsKids.value);
+                    if (tempKidBuilders.Count > 0) {
+                        nodeBuilderThatWantsKids.tempKids = tempKidBuilders.ToArray();
+                        tempKidBuilders.Clear();
+                        continue;
+                    }
                 }
+                nodeBuilderThatWantsKids.finishedNode = Tree.Node(nodeBuilderThatWantsKids.value);
             }
 
             while (needsGenerateOutput.Count > 0) {

--- a/src/ProgressOnderwijsUtils/Collections/CachedTreeBuilder.cs
+++ b/src/ProgressOnderwijsUtils/Collections/CachedTreeBuilder.cs
@@ -1,4 +1,4 @@
-#nullable disable
+﻿#nullable disable
 using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
@@ -58,7 +58,7 @@ namespace ProgressOnderwijsUtils.Collections
                     nodeBuilderThatWantsKids.tempKids = tempKidBuilders.ToArray();
                     tempKidBuilders.Clear();
                 } else {
-                    nodeBuilderThatWantsKids.tempKids = Array.Empty<TreeNodeBuilder>();
+                    nodeBuilderThatWantsKids.finishedNode = Tree.Node(nodeBuilderThatWantsKids.value);
                 }
             }
 

--- a/src/ProgressOnderwijsUtils/Collections/CachedTreeBuilder.cs
+++ b/src/ProgressOnderwijsUtils/Collections/CachedTreeBuilder.cs
@@ -38,6 +38,7 @@ namespace ProgressOnderwijsUtils.Collections
             var rootBuilder = new TreeNodeBuilder { value = rootNodeValue, };
             needsGenerateOutput.Push(rootBuilder);
 
+            var tempKidBuilders = new List<TreeNodeBuilder>();
             var needsKids = new Stack<TreeNodeBuilder>();
             needsKids.Push(rootBuilder);
 
@@ -45,7 +46,6 @@ namespace ProgressOnderwijsUtils.Collections
                 var nodeBuilderThatWantsKids = needsKids.Pop();
                 var kids = kidLookup(nodeBuilderThatWantsKids.value);
                 if (kids != null) { //allow null to represent absence of kids
-                    var tempKidBuilders = new List<TreeNodeBuilder>();
                     foreach (var kid in kids) {
                         var builderForKid = new TreeNodeBuilder { value = kid, };
                         if (needsGenerateOutput.Count >= 10_000_000) {
@@ -56,6 +56,7 @@ namespace ProgressOnderwijsUtils.Collections
                         tempKidBuilders.Add(builderForKid);
                     }
                     nodeBuilderThatWantsKids.tempKids = tempKidBuilders.ToArray();
+                    tempKidBuilders.Clear();
                 } else {
                     nodeBuilderThatWantsKids.tempKids = Array.Empty<TreeNodeBuilder>();
                 }

--- a/src/ProgressOnderwijsUtils/Collections/CachedTreeBuilder.cs
+++ b/src/ProgressOnderwijsUtils/Collections/CachedTreeBuilder.cs
@@ -48,7 +48,7 @@ namespace ProgressOnderwijsUtils.Collections
                     var tempKidBuilders = new List<TreeNodeBuilder>();
                     foreach (var kid in kids) {
                         var builderForKid = new TreeNodeBuilder { value = kid, };
-                        if (needsGenerateOutput.Count >= 100 * 1000 * 1000) {
+                        if (needsGenerateOutput.Count >= 10_000_000) {
                             throw new InvalidOperationException("Tree too large (possibly a cycle?)");
                         }
                         needsGenerateOutput.Push(builderForKid);

--- a/test/ProgressOnderwijsUtils.Tests/TreeTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/TreeTest.cs
@@ -238,12 +238,13 @@ namespace ProgressOnderwijsUtils.Tests
         [Fact]
         public void CanWorkWithDeepTreesWithoutStackoverflow()
         {
-            var input = Tree.BuildRecursively(0u, i => i < 100000 ? new[] { i + 1 } : new uint[0]);
-            var output = Tree.BuildRecursively(0L, i => i < 100000 ? new[] { i + 1 } : new long[0]);
+            const int targetHeight = 1000_000;
+            var input = Tree.BuildRecursively(1u, i => i < targetHeight ? new[] { i + 1 } : new uint[0]);
+            var output = Tree.BuildRecursively(1L, i => i < targetHeight ? new[] { i + 1 } : new long[0]);
             var mappedInput = input.Select(i => (long)i);
             var areEqual = mappedInput.Equals(output);
             PAssert.That(() => areEqual, "Deep trees should be selectable and comparable too");
-            PAssert.That(() => input.Height() == 100001);
+            PAssert.That(() => input.Height() == targetHeight);
         }
 
         [Fact]

--- a/test/ProgressOnderwijsUtils.Tests/TreeTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/TreeTest.cs
@@ -146,7 +146,7 @@ namespace ProgressOnderwijsUtils.Tests
             PAssert.That(() => root_a_b.NodeValue == "b" && root_b.NodeValue == "b", "Test should select 'b' branches correctly");
         }
 
-        [Fact(Skip = "This causes OOM post-xUnit conversion; still needs to be investigated")]
+        [Fact]
         public void BuildDetectsCycles()
         {
             // ReSharper disable once NotAccessedVariable


### PR DESCRIPTION
In particularly, less GC pressure. because only one smallish stack, instead of 2 stacks, one of which with a max-size that's covers all tree nodes, and additionally no need to collect tree kids separately from the tree kid array.

<s>Includes  #344, #346</s>