### PR TITLE
Allow straightforward reference-based equality for DistinctArray's.

### DIFF
--- a/src/ProgressOnderwijsUtils/DistinctArray.cs
+++ b/src/ProgressOnderwijsUtils/DistinctArray.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 using System.Linq;
-using JetBrains.Annotations;
 
 namespace ProgressOnderwijsUtils
 {
@@ -38,7 +39,7 @@ namespace ProgressOnderwijsUtils
     }
 
     [Serializable]
-    public struct DistinctArray<T> : IReadOnlyList<T>
+    public struct DistinctArray<T> : IReadOnlyList<T>, IEquatable<DistinctArray<T>>
     {
         public static DistinctArray<T> Empty
             => new DistinctArray<T>(Array.Empty<T>());
@@ -63,7 +64,6 @@ namespace ProgressOnderwijsUtils
         DistinctArray(T[] items)
             => this.items = items;
 
-        [NotNull]
         public T[] UnderlyingArrayThatShouldNeverBeMutated()
             => items ?? Array.Empty<T>();
 
@@ -73,15 +73,18 @@ namespace ProgressOnderwijsUtils
         public T this[int index]
             => UnderlyingArrayThatShouldNeverBeMutated()[index];
 
+        public bool Equals(DistinctArray<T> other)
+            => UnderlyingArrayThatShouldNeverBeMutated() == other.UnderlyingArrayThatShouldNeverBeMutated();
+
         /// <inheritdoc />
         public override bool Equals(object? obj)
-            => obj is DistinctArray<T> other && this == other;
+            => obj is DistinctArray<T> other && Equals(other);
 
         public override int GetHashCode()
             => UnderlyingArrayThatShouldNeverBeMutated().GetHashCode();
 
         public static bool operator ==(DistinctArray<T> a, DistinctArray<T> b)
-            => a.UnderlyingArrayThatShouldNeverBeMutated() == b.UnderlyingArrayThatShouldNeverBeMutated();
+            => a.Equals(b);
 
         public static bool operator !=(DistinctArray<T> a, DistinctArray<T> b)
             => !(a == b);

--- a/src/ProgressOnderwijsUtils/DistinctArray.cs
+++ b/src/ProgressOnderwijsUtils/DistinctArray.cs
@@ -73,6 +73,19 @@ namespace ProgressOnderwijsUtils
         public T this[int index]
             => UnderlyingArrayThatShouldNeverBeMutated()[index];
 
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
+            => obj is DistinctArray<T> other && this == other;
+
+        public override int GetHashCode()
+            => UnderlyingArrayThatShouldNeverBeMutated().GetHashCode();
+
+        public static bool operator ==(DistinctArray<T> a, DistinctArray<T> b)
+            => a.UnderlyingArrayThatShouldNeverBeMutated() == b.UnderlyingArrayThatShouldNeverBeMutated();
+
+        public static bool operator !=(DistinctArray<T> a, DistinctArray<T> b)
+            => !(a == b);
+
         public Enumerator GetEnumerator()
             => new Enumerator(UnderlyingArrayThatShouldNeverBeMutated());
 

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>52.3.1</Version>
-    <PackageReleaseNotes>Also support ReadPlain&lt;T&gt; for IPocoConvertibleProperty's.</PackageReleaseNotes>
+    <Version>52.4.1</Version>
+    <PackageReleaseNotes>Allow reference-based equality for DistinctArray.</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>

--- a/test/ProgressOnderwijsUtils.Tests/DistinctArrayTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/DistinctArrayTest.cs
@@ -90,6 +90,41 @@ namespace ProgressOnderwijsUtils.Tests
         }
 
         [Fact]
+        public void EqualityIsByReferenceNotValue()
+        {
+            PAssert.That(() => Enumerable.Range(1, 4).ToDistinctArray() != Enumerable.Range(1, 4).ToDistinctArray());
+            var existingArr = new[] { "a", "b", "c" };
+            var existingDistinctArr = existingArr.ToDistinctArrayFromDistinct_Unchecked();
+            var aliasedDistinctArr = existingArr.ToDistinctArrayFromDistinct_Unchecked();
+            var nonAliasedCopy = existingArr.ToDistinctArray();
+
+            PAssert.That(() => existingDistinctArr == aliasedDistinctArr);
+            PAssert.That(() => !(existingDistinctArr != aliasedDistinctArr));
+            PAssert.That(() => existingDistinctArr.Equals(aliasedDistinctArr));
+            PAssert.That(() => existingDistinctArr.GetHashCode() == aliasedDistinctArr.GetHashCode());
+
+            PAssert.That(() => existingDistinctArr != nonAliasedCopy);
+            PAssert.That(() => !(existingDistinctArr == nonAliasedCopy));
+            PAssert.That(() => !existingDistinctArr.Equals(nonAliasedCopy));
+            PAssert.That(() => existingDistinctArr.GetHashCode() != nonAliasedCopy.GetHashCode());
+
+            var defaultValue = default(DistinctArray<string>);
+            var explicitlyEmpty = new string[0].ToDistinctArray();
+            PAssert.That(() => defaultValue == explicitlyEmpty);
+        }
+
+        [Fact]
+        public void EmptyCreatedInDifferentWaysAreEqual()
+        {
+            var defaultValue = default(DistinctArray<string>);
+            var explicitlyEmpty = new string[0].ToDistinctArray();
+            PAssert.That(() => defaultValue == explicitlyEmpty);
+            PAssert.That(() => defaultValue.Equals(explicitlyEmpty));
+            PAssert.That(() => defaultValue.GetHashCode() == explicitlyEmpty.GetHashCode());
+            PAssert.That(() => defaultValue.UnderlyingArrayThatShouldNeverBeMutated() == explicitlyEmpty.UnderlyingArrayThatShouldNeverBeMutated());
+        }
+
+        [Fact]
         public void OverloadForSetsWorks()
         {
             var hashSet = new[] { 1, 2, 4, 5 }.ToSet();


### PR DESCRIPTION
Why reference based?  Well, it's really simple, it's fast, and with value-based equality you need to answer annoyingly tricky questions about which comparer to use.

