### PR TITLE
Rene/Factory method voor deterministische RandomHelper

### DIFF
--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -150,7 +150,7 @@ namespace ProgressOnderwijsUtils
         static readonly MethodInfo getDateTimeOffset_SqlDataReader = typeof(SqlDataReader).GetMethod(nameof(SqlDataReader.GetDateTimeOffset), binding)!;
         const int AsciiUpperToLowerDiff = 'a' - 'A';
 
-        static ulong CaseInsensitiveHash([NotNull] string s)
+        public static ulong CaseInsensitiveHash([NotNull] string s)
         {
             //Much faster than StringComparer.OrdinalIgnoreCase.GetHashCode(...)
             //Based on java's String.hashCode(): http://docs.oracle.com/javase/6/docs/api/java/lang/String.html#hashCode%28%29

--- a/src/ProgressOnderwijsUtils/RandomHelper.cs
+++ b/src/ProgressOnderwijsUtils/RandomHelper.cs
@@ -17,7 +17,7 @@ namespace ProgressOnderwijsUtils
 
         [NotNull]
         public static RandomHelper JmplicitlyInsecure([CallerLineNumber] int linenumber = -1, [CallerFilePath] string filepath = "", [CallerMemberName] string membername = "")
-            => new RandomHelper(new Random((linenumber + filepath + membername).GetHashCode()).NextBytes);
+            => Insecure((linenumber + filepath + membername).GetHashCode());
 
         readonly Action<byte[]> fillWithRandomBytes;
 

--- a/src/ProgressOnderwijsUtils/RandomHelper.cs
+++ b/src/ProgressOnderwijsUtils/RandomHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 using JetBrains.Annotations;
@@ -13,6 +14,10 @@ namespace ProgressOnderwijsUtils
         [NotNull]
         public static RandomHelper Insecure(int seed)
             => new RandomHelper(new Random(seed).NextBytes);
+
+        [NotNull]
+        public static RandomHelper JmplicitlyInsecure([CallerLineNumber] int linenumber = -1, [CallerFilePath] string filepath = "", [CallerMemberName] string membername = "")
+            => new RandomHelper(new Random((linenumber + filepath + membername).GetHashCode()).NextBytes);
 
         readonly Action<byte[]> fillWithRandomBytes;
 

--- a/src/ProgressOnderwijsUtils/RandomHelper.cs
+++ b/src/ProgressOnderwijsUtils/RandomHelper.cs
@@ -16,7 +16,7 @@ namespace ProgressOnderwijsUtils
             => new RandomHelper(new Random(seed).NextBytes);
 
         [NotNull]
-        public static RandomHelper JmplicitlyInsecure([CallerLineNumber] int linenumber = -1, [CallerFilePath] string filepath = "", [CallerMemberName] string membername = "")
+        public static RandomHelper ImplicitlyInsecure([CallerLineNumber] int linenumber = -1, [CallerFilePath] string filepath = "", [CallerMemberName] string membername = "")
             => Insecure((linenumber + filepath + membername).GetHashCode());
 
         readonly Action<byte[]> fillWithRandomBytes;

--- a/src/ProgressOnderwijsUtils/RandomHelper.cs
+++ b/src/ProgressOnderwijsUtils/RandomHelper.cs
@@ -17,7 +17,7 @@ namespace ProgressOnderwijsUtils
 
         [NotNull]
         public static RandomHelper ImplicitlyInsecure([CallerLineNumber] int linenumber = -1, [CallerFilePath] string filepath = "", [CallerMemberName] string membername = "")
-            => Insecure(GetNaiveHashCode(filepath) ^ GetNaiveHashCode(membername) ^ linenumber);
+            => Insecure(GetNaiveHashCode(System.IO.Path.GetFileName(filepath)) + 1337 * GetNaiveHashCode(membername));
 
         static int GetNaiveHashCode(string str)
             => (int)ParameterizedSqlObjectMapper.CaseInsensitiveHash(str);

--- a/src/ProgressOnderwijsUtils/RandomHelper.cs
+++ b/src/ProgressOnderwijsUtils/RandomHelper.cs
@@ -17,10 +17,10 @@ namespace ProgressOnderwijsUtils
 
         [NotNull]
         public static RandomHelper ImplicitlyInsecure([CallerLineNumber] int linenumber = -1, [CallerFilePath] string filepath = "", [CallerMemberName] string membername = "")
-            => Insecure(StrToInt(filepath) + StrToInt(membername) + linenumber);
+            => Insecure(GetNaiveHashCode(filepath) + GetNaiveHashCode(membername) + linenumber);
 
-        static int StrToInt(string str)
-            => str.Select((character, index) => character << index).Sum();
+        static int GetNaiveHashCode(string str)
+            => str.Select((character, index) => character << index).Aggregate((x, y) => x ^ y);
 
         readonly Action<byte[]> fillWithRandomBytes;
 

--- a/src/ProgressOnderwijsUtils/RandomHelper.cs
+++ b/src/ProgressOnderwijsUtils/RandomHelper.cs
@@ -17,7 +17,10 @@ namespace ProgressOnderwijsUtils
 
         [NotNull]
         public static RandomHelper ImplicitlyInsecure([CallerLineNumber] int linenumber = -1, [CallerFilePath] string filepath = "", [CallerMemberName] string membername = "")
-            => Insecure((linenumber + filepath + membername).GetHashCode());
+            => Insecure(StrToInt(filepath) + StrToInt(membername) + linenumber);
+
+        static int StrToInt(string str)
+            => str.Select((character, index) => character << index).Sum();
 
         readonly Action<byte[]> fillWithRandomBytes;
 

--- a/src/ProgressOnderwijsUtils/RandomHelper.cs
+++ b/src/ProgressOnderwijsUtils/RandomHelper.cs
@@ -20,7 +20,7 @@ namespace ProgressOnderwijsUtils
             => Insecure(GetNaiveHashCode(filepath) ^ GetNaiveHashCode(membername) ^ linenumber);
 
         static int GetNaiveHashCode(string str)
-            => str.Select((character, index) => character << index).Aggregate((x, y) => x ^ y);
+            => (int)ParameterizedSqlObjectMapper.CaseInsensitiveHash(str);
 
         readonly Action<byte[]> fillWithRandomBytes;
 

--- a/src/ProgressOnderwijsUtils/RandomHelper.cs
+++ b/src/ProgressOnderwijsUtils/RandomHelper.cs
@@ -17,7 +17,7 @@ namespace ProgressOnderwijsUtils
 
         [NotNull]
         public static RandomHelper ImplicitlyInsecure([CallerLineNumber] int linenumber = -1, [CallerFilePath] string filepath = "", [CallerMemberName] string membername = "")
-            => Insecure(GetNaiveHashCode(filepath) + GetNaiveHashCode(membername) + linenumber);
+            => Insecure(GetNaiveHashCode(filepath) ^ GetNaiveHashCode(membername) ^ linenumber);
 
         static int GetNaiveHashCode(string str)
             => str.Select((character, index) => character << index).Aggregate((x, y) => x ^ y);

--- a/test/ProgressOnderwijsUtils.Tests/RandomHelperTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/RandomHelperTest.cs
@@ -60,7 +60,9 @@ namespace ProgressOnderwijsUtils.Tests
         {
             var randomHelper1 = RandomHelper.ImplicitlyInsecure();
             var randomHelper2 = RandomHelper.ImplicitlyInsecure();
+            var (randomHelper3, randomHelper4) = (RandomHelper.ImplicitlyInsecure(), RandomHelper.ImplicitlyInsecure());
             PAssert.That(() => randomHelper1.GetInt32() != randomHelper2.GetInt32());
+            PAssert.That(() => randomHelper3.GetInt32() == randomHelper4.GetInt32());
         }
     }
 }

--- a/test/ProgressOnderwijsUtils.Tests/RandomHelperTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/RandomHelperTest.cs
@@ -56,13 +56,18 @@ namespace ProgressOnderwijsUtils.Tests
         }
 
         [Fact]
-        public void ImplicitlyInsecure()
+        public void ImplicitlyInsecure_Gedrag_hangt_af_van_regelnummer()
         {
             var randomHelper1 = RandomHelper.ImplicitlyInsecure();
             var randomHelper2 = RandomHelper.ImplicitlyInsecure();
-            var (randomHelper3, randomHelper4) = (RandomHelper.ImplicitlyInsecure(), RandomHelper.ImplicitlyInsecure());
             PAssert.That(() => randomHelper1.GetInt32() != randomHelper2.GetInt32());
-            PAssert.That(() => randomHelper3.GetInt32() == randomHelper4.GetInt32());
+        }
+
+        [Fact]
+        public void ImplicitlyInsecure_Gedrag_is_deterministisch()
+        {
+            var (randomHelper1, randomHelper2) = (RandomHelper.ImplicitlyInsecure(), RandomHelper.ImplicitlyInsecure());
+            PAssert.That(() => randomHelper1.GetInt32() == randomHelper2.GetInt32());
         }
     }
 }

--- a/test/ProgressOnderwijsUtils.Tests/RandomHelperTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/RandomHelperTest.cs
@@ -56,14 +56,6 @@ namespace ProgressOnderwijsUtils.Tests
         }
 
         [Fact]
-        public void ImplicitlyInsecure_Gedrag_hangt_af_van_regelnummer()
-        {
-            var randomHelper1 = RandomHelper.ImplicitlyInsecure();
-            var randomHelper2 = RandomHelper.ImplicitlyInsecure();
-            PAssert.That(() => randomHelper1.GetInt32() != randomHelper2.GetInt32());
-        }
-
-        [Fact]
         public void ImplicitlyInsecure_Gedrag_is_deterministisch()
         {
             var randomHelper = RandomHelper.ImplicitlyInsecure();

--- a/test/ProgressOnderwijsUtils.Tests/RandomHelperTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/RandomHelperTest.cs
@@ -67,7 +67,8 @@ namespace ProgressOnderwijsUtils.Tests
         public void ImplicitlyInsecure_Gedrag_is_deterministisch()
         {
             var randomHelper = RandomHelper.ImplicitlyInsecure();
-            PAssert.That(() => randomHelper.GetInt32() == 1801197674);
+            var pseudoRandomInteger = randomHelper.GetInt32();
+            PAssert.That(() => pseudoRandomInteger == -20762718);
         }
     }
 }

--- a/test/ProgressOnderwijsUtils.Tests/RandomHelperTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/RandomHelperTest.cs
@@ -66,8 +66,8 @@ namespace ProgressOnderwijsUtils.Tests
         [Fact]
         public void ImplicitlyInsecure_Gedrag_is_deterministisch()
         {
-            var (randomHelper1, randomHelper2) = (RandomHelper.ImplicitlyInsecure(), RandomHelper.ImplicitlyInsecure());
-            PAssert.That(() => randomHelper1.GetInt32() == randomHelper2.GetInt32());
+            var randomHelper = RandomHelper.ImplicitlyInsecure();
+            PAssert.That(() => randomHelper.GetInt32() == 1801197674);
         }
     }
 }

--- a/test/ProgressOnderwijsUtils.Tests/RandomHelperTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/RandomHelperTest.cs
@@ -54,5 +54,13 @@ namespace ProgressOnderwijsUtils.Tests
             PAssert.That(() => Regex.IsMatch(RandomHelper.Secure.GetStringOfLatinLower(7), "[a-z]{7}"));
             PAssert.That(() => Regex.IsMatch(RandomHelper.Secure.GetStringOfLatinUpperOrLower(10), "[a-zA-Z]{10}"));
         }
+
+        [Fact]
+        public void ImplicitlyInsecure()
+        {
+            var randomHelper1 = RandomHelper.ImplicitlyInsecure();
+            var randomHelper2 = RandomHelper.ImplicitlyInsecure();
+            PAssert.That(() => randomHelper1.GetInt32() != randomHelper2.GetInt32());
+        }
     }
 }


### PR DESCRIPTION
Zonder expliciete seed te hoeven meegeven. 

Dit is handig in testcode die database-records aanmaakt op basis van pseudo-random data. Daarbij is het belangrijk dat de gekozen seed niet elke keer hetzelfde is (om dubbele keys te voorkomen), maar je wilt niet handmatig elke keer een andere seed hard-coden.

----
Comments welcome.