### PR TITLE
Various nullability-inspired cleanups & general version bump.

### DIFF
--- a/src/ProgressOnderwijsUtils/Collections/SList.cs
+++ b/src/ProgressOnderwijsUtils/Collections/SList.cs
@@ -72,7 +72,8 @@ namespace ProgressOnderwijsUtils.Collections
         {
             var hash = (ulong)(typeHash + 1);
             for (var current = list; current != null; current = current.Tail) {
-                hash = hash * 137ul + (ulong)elemEquality.GetHashCode(current.Head);
+                // ReSharper disable once CompareNonConstrainedGenericWithNull
+                hash = hash * 137ul + (current.Head == null ? 0 : (ulong)elemEquality.GetHashCode(current.Head));
             }
             return (int)hash ^ (int)(hash >> 32);
         }

--- a/src/ProgressOnderwijsUtils/Collections/SList.cs
+++ b/src/ProgressOnderwijsUtils/Collections/SList.cs
@@ -125,16 +125,6 @@ namespace ProgressOnderwijsUtils.Collections
         }
 
         [Pure]
-        public static SList<T> PrependReversed<T>(this SList<T> self, [NotNull] IEnumerable<T> items)
-        {
-            var retval = self;
-            foreach (var item in items) {
-                retval = retval.Prepend(item);
-            }
-            return retval;
-        }
-
-        [Pure]
         public static SList<T> Reverse<T>(this SList<T> self)
         {
             var retval = default(SList<T>);

--- a/src/ProgressOnderwijsUtils/Collections/SList.cs
+++ b/src/ProgressOnderwijsUtils/Collections/SList.cs
@@ -13,9 +13,9 @@ namespace ProgressOnderwijsUtils.Collections
         sealed class Impl
         {
             public readonly T Head;
-            public readonly Impl Tail;
+            public readonly Impl? Tail;
 
-            public Impl(T head, Impl tail)
+            public Impl(T head, Impl? tail)
             {
                 Head = head;
                 Tail = tail;
@@ -30,7 +30,7 @@ namespace ProgressOnderwijsUtils.Collections
         public SList(T head, SList<T> tail)
             : this(new Impl(head, tail.list)) { }
 
-        readonly Impl list;
+        readonly Impl? list;
 
         public static SList<T> Empty
             => default;

--- a/src/ProgressOnderwijsUtils/Collections/SList.cs
+++ b/src/ProgressOnderwijsUtils/Collections/SList.cs
@@ -22,7 +22,7 @@ namespace ProgressOnderwijsUtils.Collections
             }
         }
 
-        SList(Impl list)
+        SList(Impl? list)
             => this.list = list;
 
         public SList(T head, SList<T> tail)

--- a/src/ProgressOnderwijsUtils/Collections/SList.cs
+++ b/src/ProgressOnderwijsUtils/Collections/SList.cs
@@ -37,10 +37,10 @@ namespace ProgressOnderwijsUtils.Collections
             => list == null;
 
         public T Head
-            => list.Head;
+            => list.AssertNotNull().Head;
 
         public SList<T> Tail
-            => new SList<T>(list.Tail);
+            => new SList<T>(list.AssertNotNull().Tail);
 
         static readonly int typeHash = typeof(T).GetHashCode();
         static readonly IEqualityComparer<T> elemEquality = EqualityComparer<T>.Default;

--- a/src/ProgressOnderwijsUtils/Collections/SList.cs
+++ b/src/ProgressOnderwijsUtils/Collections/SList.cs
@@ -23,9 +23,7 @@ namespace ProgressOnderwijsUtils.Collections
         }
 
         SList(Impl list)
-        {
-            this.list = list;
-        }
+            => this.list = list;
 
         public SList(T head, SList<T> tail)
             : this(new Impl(head, tail.list)) { }

--- a/src/ProgressOnderwijsUtils/Data/SqlServerUtils.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlServerUtils.cs
@@ -31,7 +31,7 @@ namespace ProgressOnderwijsUtils
         }
 
         static bool IsSpidAlreadyDeadException(Exception exception)
-            => exception.Message?.Contains("is not an active process ID.", StringComparison.Ordinal) == true
+            => exception.Message != null && exception.Message.Contains("is not an active process ID.", StringComparison.Ordinal)
                 || exception.InnerException != null && IsSpidAlreadyDeadException(exception.InnerException);
     }
 }

--- a/src/ProgressOnderwijsUtils/DistinctArray.cs
+++ b/src/ProgressOnderwijsUtils/DistinctArray.cs
@@ -59,7 +59,7 @@ namespace ProgressOnderwijsUtils
         public static DistinctArray<T> FromPossiblyNotDistinct([NotNull] IEnumerable<T> items, IEqualityComparer<T> comparer)
             => new DistinctArray<T>(new HashSet<T>(items, comparer).ToArray());
 
-        readonly T[] items;
+        readonly T[]? items;
 
         DistinctArray(T[] items)
             => this.items = items;

--- a/src/ProgressOnderwijsUtils/Extensions/StringExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/StringExtensions.cs
@@ -19,7 +19,6 @@ namespace ProgressOnderwijsUtils
             => string.IsNullOrWhiteSpace(s);
 
         [Pure]
-        [return: NotNullIfNotNull("str")]
         public static string? NullIfWhiteSpace(this string? str)
         {
             if (string.IsNullOrWhiteSpace(str)) {

--- a/src/ProgressOnderwijsUtils/Extensions/StringUtils.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/StringUtils.cs
@@ -50,7 +50,7 @@ namespace ProgressOnderwijsUtils
         }
 
         [Pure]
-        static bool IsUpperAscii(string str)
+        public static bool IsUpperAscii(string str)
         {
             foreach (var c in str) {
                 if (c < 'A' || c > 'Z') {

--- a/src/ProgressOnderwijsUtils/Extensions/StringUtils.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/StringUtils.cs
@@ -82,8 +82,8 @@ namespace ProgressOnderwijsUtils
         }
 
         [Pure]
-        public static string VervangRingelS(string str, bool upper)
-            => str.Replace("ß", upper ? "SS" : "ss");
+        public static string VervangRingelS(string str)
+            => str.Replace("ß", "ss");
 
         [Pure]
         public static string SepaTekenset(string s)
@@ -98,7 +98,7 @@ namespace ProgressOnderwijsUtils
             }
 
             s = VerwijderDiakrieten(s);
-            s = VervangRingelS(s, false);
+            s = VervangRingelS(s);
             s = SepaTekenset(s);
             return s;
         }

--- a/src/ProgressOnderwijsUtils/Html/HtmlHelpers.cs
+++ b/src/ProgressOnderwijsUtils/Html/HtmlHelpers.cs
@@ -127,7 +127,7 @@ namespace ProgressOnderwijsUtils.Html
             => element is IHtmlElementAllowingContent elemWithContent ? elemWithContent.ChildNodes() : HtmlFragment.EmptyNodes;
 
         public static HtmlFragment[] ChildNodes([NotNull] this IHtmlElementAllowingContent elemWithContent)
-            => elemWithContent.GetContent().NodesOfFragment() ?? HtmlFragment.EmptyNodes;
+            => elemWithContent.GetContent().NodesOfFragment();
 
         public static HtmlAttributes ToHtmlAttributes([NotNull] this IEnumerable<HtmlAttribute> attributes)
             => attributes as HtmlAttributes? ?? HtmlAttributes.FromArray(attributes as HtmlAttribute[] ?? attributes.ToArray());

--- a/src/ProgressOnderwijsUtils/ProcessRunner.cs
+++ b/src/ProgressOnderwijsUtils/ProcessRunner.cs
@@ -15,11 +15,11 @@ namespace ProgressOnderwijsUtils
 {
     public struct ProcessStartSettings
     {
-        public string ExecutableName;
-        public string Arguments;
-        public string Stdlnput;
-        public string WorkingDirectory;
-        public Dictionary<string, string> Environment;
+        public string? ExecutableName;
+        public string? Arguments;
+        public string? Stdlnput;
+        public string? WorkingDirectory;
+        public Dictionary<string, string>? Environment;
 
         public void PrintProcessArgs(int? exitCode)
         {

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -8,7 +8,7 @@
     <PackageTags>ProgressOnderwijs</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="0.13.0" />
+    <PackageReference Include="AngleSharp" Version="0.14.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.3" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>58.0.1</Version>
-    <PackageReleaseNotes>Update dependencies</PackageReleaseNotes>
+    <Version>59.0.0</Version>
+    <PackageReleaseNotes>Update dependencies; improve nullabilty annotations; a few small method signature tweaks</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>

--- a/test/ProgressOnderwijsUtils.Tests/SListTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/SListTest.cs
@@ -89,7 +89,7 @@ namespace ProgressOnderwijsUtils.Tests
             PAssert.That(() => list.Tail.Tail.Tail.IsEmpty);
             PAssert.That(() => list.Tail.Prepend(1) == list);
             // ReSharper disable once UnusedVariable
-            Assert.Throws<NullReferenceException>(() => {
+            Assert.Throws<Exception>(() => {
                 var x = list.Tail.Tail.Tail.Tail;
             });
         }
@@ -103,7 +103,7 @@ namespace ProgressOnderwijsUtils.Tests
             PAssert.That(() => list.Tail.Head == 2);
             PAssert.That(() => list.Tail.Tail.Head == 3);
             // ReSharper disable once UnusedVariable
-            Assert.Throws<NullReferenceException>(() => {
+            Assert.Throws<Exception>(() => {
                 var x = list.Tail.Tail.Tail.Head;
             });
         }

--- a/test/ProgressOnderwijsUtils.Tests/SListTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/SListTest.cs
@@ -39,6 +39,13 @@ namespace ProgressOnderwijsUtils.Tests
         }
 
         [Fact]
+        public void SkipTest()
+        {
+            var list = SList.Create(new[] { 1, 3, 4, 1 });
+            PAssert.That(() => list.Skip(2).SequenceEqual(new[] { 4, 1 }));
+        }
+
+        [Fact]
         public void EqualsTest()
         {
             var a = SList.Create(new[] { 1, 2, 3 });

--- a/test/ProgressOnderwijsUtils.Tests/StringExtensionsTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/StringExtensionsTest.cs
@@ -47,11 +47,9 @@ namespace ProgressOnderwijsUtils.Tests
         [Fact]
         public void ReplaceRingelS()
         {
-            PAssert.That(() => StringUtils.VervangRingelS("ß", false) == "ss");
-            PAssert.That(() => StringUtils.VervangRingelS("ß", true) == "SS");
-            PAssert.That(() => StringUtils.VervangRingelS("aßb", false) == "assb");
-            PAssert.That(() => StringUtils.VervangRingelS("ßsß", true) == "SSsSS");
-            PAssert.That(() => StringUtils.VervangRingelS("", false) == "");
+            PAssert.That(() => StringUtils.VervangRingelS("ß") == "ss");
+            PAssert.That(() => StringUtils.VervangRingelS("aßb") == "assb");
+            PAssert.That(() => StringUtils.VervangRingelS("") == "");
         }
 
         [Fact]

--- a/test/ProgressOnderwijsUtils.Tests/StringUtilsTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/StringUtilsTest.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Globalization;
+using System.Threading;
+using ExpressionToCodeLib;
+using Xunit;
+
+namespace ProgressOnderwijsUtils.Tests
+{
+    public sealed class StringUtilsTest
+    {
+        [Fact]
+        public void IsUpperAscii()
+        {
+            PAssert.That(() => !StringUtils.IsUpperAscii("  as"));
+            PAssert.That(() => StringUtils.IsUpperAscii("XYZ"));
+            PAssert.That(() => !StringUtils.IsUpperAscii("XYZ "));
+            PAssert.That(() => !StringUtils.IsUpperAscii("b"));
+        }
+
+        [Fact]
+        public void SepaTekensetEnModificaties()
+        {
+            PAssert.That(() => StringUtils.SepaTekensetEnModificaties("Antonín Dvořák") == "Antonin Dvorak");
+            PAssert.That(() => StringUtils.SepaTekensetEnModificaties("@ß!#$!@SDfef9{ɚ0 df0o4[[") == "ssSDfef90 df0o4[[");
+            PAssert.That(() => StringUtils.SepaTekensetEnModificaties(null) == null);
+        }
+
+        [Fact]
+        public void TryParseInt32()
+        {
+            PAssert.That(() => " 10 00 ".TryParseInt32() == null);
+            PAssert.That(() => " 1000 ".TryParseInt32() == 1000);
+            PAssert.That(() => default(string?).TryParseInt32() == null);
+        }
+
+        [Fact]
+        public void TryParseInt64()
+        {
+            PAssert.That(() => " 10 00 ".TryParseInt64() == null);
+            PAssert.That(() => " 1000 ".TryParseInt64() == 1000);
+            PAssert.That(() => default(string?).TryParseInt64() == null);
+        }
+    }
+}


### PR DESCRIPTION
Motivatie: foutieve nullability tips in R# 2020 die veroorzaakt worden door annotaties hier mogelijk verhelpen.

Maar ik heb ook waar nodig wat test coverage verhoogd, en methods versimpeld waar ik te lui was om de hele api te testen, zodat code die ik in deze PR aanraak iig geen unused methods heeft (en hopelijk 100% method coverage).

Review bij commit zou redelijk moeten zijn.