### PR TITLE
Some cleanups, workaround a few nullability issues.

### DIFF
--- a/src/ProgressOnderwijsUtils/Collections/ArrayComparer.cs
+++ b/src/ProgressOnderwijsUtils/Collections/ArrayComparer.cs
@@ -41,7 +41,7 @@ namespace ProgressOnderwijsUtils.Collections
             if (arr != null) {
                 buffer = start;
                 foreach (var obj in arr) {
-                    buffer = buffer * 997 + (ulong)underlying.GetHashCode(obj);
+                    buffer = buffer * 997 + (obj is null ? 0 : (ulong)underlying.GetHashCode(obj));
                 }
             } else {
                 buffer = ~start;

--- a/src/ProgressOnderwijsUtils/Collections/MaybeExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Collections/MaybeExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using JetBrains.Annotations;
 
@@ -7,7 +8,7 @@ namespace ProgressOnderwijsUtils.Collections
 {
     public static class MaybeExtensions
     {
-        [CanBeNull]
+        [return: MaybeNull]
         [Pure]
         public static TError ErrorOrNull<TOk, TError>(this Maybe<TOk, TError> state)
             where TError : class?
@@ -23,7 +24,7 @@ namespace ProgressOnderwijsUtils.Collections
             where TError : struct
             => state.TryGet(out _, out var whenError) ? default(TError?) : whenError;
 
-        [CanBeNull]
+        [return: MaybeNull]
         [Pure]
         public static TOk ValueOrNull<TOk, TError>(this Maybe<TOk, TError> state)
             where TOk : class?

--- a/src/ProgressOnderwijsUtils/Collections/MaybeExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Collections/MaybeExtensions.cs
@@ -269,15 +269,14 @@ namespace ProgressOnderwijsUtils.Collections
         }
 
         [Pure]
-        public static Maybe<TOk[], TError[]> WhenAllOk<TOk, TError>([NotNull] this IEnumerable<Maybe<TOk, TError>> maybes)
+        public static Maybe<TOk[], TError[]> WhenAllOk<TOk, TError>(this IEnumerable<Maybe<TOk, TError>> maybes)
         {
             var (okValues, errValues) = maybes.Partition();
             return errValues.Any() ? (Maybe<TOk[], TError[]>)Maybe.Error(errValues) : Maybe.Ok(okValues).AsMaybeWithoutError<TError[]>();
         }
 
-        [NotNull]
         [Pure]
-        public static IEnumerable<TOk> WhereOk<TOk, TError>([NotNull] this IEnumerable<Maybe<TOk, TError>> maybes)
+        public static IEnumerable<TOk> WhereOk<TOk, TError>(this IEnumerable<Maybe<TOk, TError>> maybes)
         {
             foreach (var state in maybes) {
                 var isOk = state.TryGet(out var okValue, out _);
@@ -287,9 +286,8 @@ namespace ProgressOnderwijsUtils.Collections
             }
         }
 
-        [NotNull]
         [Pure]
-        public static IEnumerable<TError> WhereError<TOk, TError>([NotNull] this IEnumerable<Maybe<TOk, TError>> maybes)
+        public static IEnumerable<TError> WhereError<TOk, TError>(this IEnumerable<Maybe<TOk, TError>> maybes)
         {
             foreach (var state in maybes) {
                 var isOk = state.TryGet(out _, out var error);
@@ -300,7 +298,7 @@ namespace ProgressOnderwijsUtils.Collections
         }
 
         [Pure]
-        public static (TOk[] okValues, TError[] errorValues) Partition<TOk, TError>([NotNull] this IEnumerable<Maybe<TOk, TError>> maybes)
+        public static (TOk[] okValues, TError[] errorValues) Partition<TOk, TError>(this IEnumerable<Maybe<TOk, TError>> maybes)
         {
             var okValues = new List<TOk>();
             var errValues = new List<TError>();

--- a/src/ProgressOnderwijsUtils/Collections/Tree.cs
+++ b/src/ProgressOnderwijsUtils/Collections/Tree.cs
@@ -205,10 +205,10 @@ namespace ProgressOnderwijsUtils.Collections
                 }
                 // ReSharper restore HeuristicUnreachableCode
                 // ReSharper restore ConditionIsAlwaysTrueOrFalse
-                ulong hash = (uint)ValueComparer.GetHashCode(obj.NodeValue);
+                ulong hash = obj.NodeValue is null ? 0 : (uint)ValueComparer.GetHashCode(obj.NodeValue);
                 ulong offset = 1; //keep offset odd to ensure no bits are lost in scaling.
                 foreach (var node in obj.PreorderTraversal()) {
-                    hash += offset * ((uint)ValueComparer.GetHashCode(node.NodeValue) + ((ulong)node.Children.Count << 32));
+                    hash += offset * ((uint)(node.NodeValue is null ? 0 : ValueComparer.GetHashCode(node.NodeValue!)) + ((ulong)node.Children.Count << 32));
                     offset += 2;
                 }
                 return (int)((uint)(hash >> 32) + (uint)hash);

--- a/src/ProgressOnderwijsUtils/Collections/Tree.cs
+++ b/src/ProgressOnderwijsUtils/Collections/Tree.cs
@@ -190,9 +190,9 @@ namespace ProgressOnderwijsUtils.Collections
             bool ShallowEquals(NodePair pair)
                 // ReSharper disable RedundantCast
                 //workaround resharper issue: object comparison is by reference, and faster than ReferenceEquals
-                => (object)pair.A == (object)pair.B ||
                     (object)pair.A != null && (object)pair.B != null
                     && pair.A.Children.Count == pair.B.Children.Count
+                => ReferenceEquals(pair.A, pair.B) ||
                     && ValueComparer.Equals(pair.A.NodeValue, pair.B.NodeValue);
             // ReSharper restore RedundantCast
 

--- a/src/ProgressOnderwijsUtils/Collections/Tree.cs
+++ b/src/ProgressOnderwijsUtils/Collections/Tree.cs
@@ -190,9 +190,8 @@ namespace ProgressOnderwijsUtils.Collections
             bool ShallowEquals(NodePair pair)
                 // ReSharper disable RedundantCast
                 //workaround resharper issue: object comparison is by reference, and faster than ReferenceEquals
-                    (object)pair.A != null && (object)pair.B != null
-                    && pair.A.Children.Count == pair.B.Children.Count
                 => ReferenceEquals(pair.A, pair.B) ||
+                    pair.A.Children.Count == pair.B.Children.Count
                     && ValueComparer.Equals(pair.A.NodeValue, pair.B.NodeValue);
             // ReSharper restore RedundantCast
 

--- a/src/ProgressOnderwijsUtils/Data/ColumnSort.cs
+++ b/src/ProgressOnderwijsUtils/Data/ColumnSort.cs
@@ -12,7 +12,7 @@ namespace ProgressOnderwijsUtils
     [Serializable]
     public readonly struct ColumnSort : IEquatable<ColumnSort>
     {
-        public string ColumnName { get; }
+        public string? ColumnName { get; } //intrinsically nullable due to binary serialization
         public SortDirection SortDirection { get; }
 
         [NotNull]
@@ -30,7 +30,7 @@ namespace ProgressOnderwijsUtils
 
         [Pure]
         public ColumnSort WithReverseDirection()
-            => new ColumnSort(ColumnName, SortDirection == SortDirection.Asc ? SortDirection.Desc : SortDirection.Asc);
+            => new ColumnSort(ColumnName.AssertNotNull(), SortDirection == SortDirection.Asc ? SortDirection.Desc : SortDirection.Asc);
 
         [Pure]
         public ColumnSort WithDifferentName(string newColumn)
@@ -47,6 +47,6 @@ namespace ProgressOnderwijsUtils
 
         [Pure]
         public override int GetHashCode()
-            => StringComparer.OrdinalIgnoreCase.GetHashCode(ColumnName) + 51 * (int)SortDirection;
+            => StringComparer.OrdinalIgnoreCase.GetHashCode(ColumnName ?? "") + 51 * (int)SortDirection;
     }
 }

--- a/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
+++ b/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
@@ -33,7 +33,7 @@ namespace ProgressOnderwijsUtils
             var retval = new List<ColumnSort>();
             var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var col in order) {
-                if (names.Add(col.ColumnName)) {
+                if (names.Add(col.ColumnName.AssertNotNull())) {
                     retval.Add(col);
                 }
             }

--- a/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
+++ b/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
@@ -23,7 +23,7 @@ namespace ProgressOnderwijsUtils
             => sortColumns.EmptyIfNull();
 
         public static OrderByColumns Empty
-            => default(OrderByColumns);
+            => default;
 
         public OrderByColumns(IEnumerable<ColumnSort> order)
             => sortColumns = DeduplicateByName(order);

--- a/src/ProgressOnderwijsUtils/Data/PocoDataReader.cs
+++ b/src/ProgressOnderwijsUtils/Data/PocoDataReader.cs
@@ -92,7 +92,7 @@ namespace ProgressOnderwijsUtils
             return getter(current);
         }
 
-        struct ColumnInfo
+        readonly struct ColumnInfo
         {
             public readonly string Name;
 

--- a/src/ProgressOnderwijsUtils/Utils.cs
+++ b/src/ProgressOnderwijsUtils/Utils.cs
@@ -245,14 +245,14 @@ namespace ProgressOnderwijsUtils
             if (precision > 0) {
                 do {
                     var tmp = x;
-                    x = x / 10;
+                    x /= 10;
                     str[idx++] = (char)('0' + (tmp - x * 10));
                 } while (idx < precision);
                 str[idx++] = fI.PercentDecimalSeparator[0];
             }
             do {
                 var tmp = x;
-                x = x / 10;
+                x /= 10;
                 str[idx++] = (char)('0' + (tmp - x * 10));
             } while (x != 0);
             if (isNeg) {
@@ -275,19 +275,19 @@ namespace ProgressOnderwijsUtils
             var res = 0;
             if (x >= 1 << 16) {
                 res += 16;
-                x = x >> 16;
+                x >>= 16;
             }
             if (x >= 1 << 8) {
                 res += 8;
-                x = x >> 8;
+                x >>= 8;
             }
             if (x >= 1 << 4) {
                 res += 4;
-                x = x >> 4;
+                x >>= 4;
             }
             if (x >= 1 << 2) {
                 res += 2;
-                x = x >> 2;
+                x >>= 2;
             }
             if (x >= 1 << 1) {
                 res += 1;

--- a/src/ProgressOnderwijsUtils/Utils.cs
+++ b/src/ProgressOnderwijsUtils/Utils.cs
@@ -326,9 +326,7 @@ namespace ProgressOnderwijsUtils
         readonly Comparison<T> comparer;
 
         public ComparisonComparer(Comparison<T> comparer)
-        {
-            this.comparer = comparer;
-        }
+            => this.comparer = comparer;
 
         public int Compare(T x, T y)
             => comparer(x, y);

--- a/src/ProgressOnderwijsUtils/Utils.cs
+++ b/src/ProgressOnderwijsUtils/Utils.cs
@@ -328,8 +328,8 @@ namespace ProgressOnderwijsUtils
         public ComparisonComparer(Comparison<T> comparer)
             => this.comparer = comparer;
 
-        public int Compare(T x, T y)
-            => comparer(x, y);
+        public int Compare([AllowNull] T x, [AllowNull] T y)
+            => comparer(x!, y!);
     }
 
     public sealed class EqualsEqualityComparer<T> : IEqualityComparer<T>

--- a/tools/ProgressOnderwijsUtilsBenchmarks/HtmlFragmentBenchmark.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/HtmlFragmentBenchmark.cs
@@ -23,9 +23,7 @@ namespace ProgressOnderwijsUtilsBenchmarks
 
         [Benchmark]
         public void SerializeLargeDocument()
-        {
-            htmlFragment.ToStringWithDoctype();
-        }
+            => htmlFragment.ToStringWithDoctype();
 
         [Benchmark]
         public void WriteToStream()
@@ -59,58 +57,45 @@ namespace ProgressOnderwijsUtilsBenchmarks
 
         [Benchmark]
         public void CreateLargeDocument()
-        {
-            WikiPageHtml5.MakeHtml();
-        }
+            => WikiPageHtml5.MakeHtml();
 
         [Benchmark]
         public void CreateAndSerializeLargeDocument()
-        {
-            WikiPageHtml5.MakeHtml().ToStringWithDoctype();
-        }
+            => WikiPageHtml5.MakeHtml().ToStringWithDoctype();
 
         [Benchmark]
         public void SerializeLargeDocumentToCSharp()
-        {
-            htmlFragment.ToCSharp();
-        }
+            => htmlFragment.ToCSharp();
 
         [Benchmark]
         public void JustConvertToUtf8()
         {
-            using (var stream = new MemoryStream())
-            using (var writer = new StreamWriter(stream, Encoding.UTF8)) {
-                writer.Write(htmlString);
-            }
+            using var stream = new MemoryStream();
+            using var writer = new StreamWriter(stream, Encoding.UTF8);
+            writer.Write(htmlString);
         }
 
         [Benchmark]
         public void JustSerializeToUtf8LargeDocument()
         {
-            using (var stream = new MemoryStream()) {
-                htmlFragment.SaveHtmlFragmentToStream(stream, Encoding.UTF8);
-            }
+            using var stream = new MemoryStream();
+            htmlFragment.SaveHtmlFragmentToStream(stream, Encoding.UTF8);
         }
 
         [Benchmark]
         public void AngleSharpParseFromString()
-        {
-            new HtmlParser().ParseDocument(htmlString);
-        }
+            => new HtmlParser().ParseDocument(htmlString);
 
         [Benchmark]
         public void AngleSharpParseFromUtf8()
         {
-            using (var stream = new MemoryStream(htmlUtf8)) {
-                new HtmlParser().ParseDocument(stream);
-            }
+            using var stream = new MemoryStream(htmlUtf8);
+            new HtmlParser().ParseDocument(stream);
         }
 
         [Benchmark]
         public void AngleSharpToString()
-        {
-            angleSharpDocument.DocumentElement.ToHtml();
-        }
+            => angleSharpDocument.DocumentElement.ToHtml();
 
         /**/
     }


### PR DESCRIPTION
There are some nasty annotations in mscorlib; and things like ComparisonComparer are rather impractical due to such issues.

Opening ProgressOnderwijsUtils and trying to fix nullability annotations is an exercise in seeing the limitations of nullability annotations in the first place.

I doubt we'll get all these both correct and useful (because of course we can get em correct simply by throwing on null all over the place, but that's not very useful).

If you care about nullability, there are plently more issues left, and trying to solve a few is a good excercise in the problems with the C# 8 approach to nullability; this isn't always easy, especially since mscorlib is poorly designed with nullability in mind.