### PR TITLE
Marked obsolete Maybe.WhenOk overload as warning, so that it can be d…

### DIFF
--- a/src/ProgressOnderwijsUtils/Collections/MaybeExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Collections/MaybeExtensions.cs
@@ -73,7 +73,7 @@ namespace ProgressOnderwijsUtils.Collections
             }
         }
 
-        [Obsolete("When the state of a Maybe is a nested Maybe, the error of that nested state can easily be ignored.", true)]
+        [Obsolete("When the state of a Maybe is a nested Maybe, the error of that nested state can easily be ignored.")]
         public static Maybe<Maybe<TOkOut, TIgnoredError>, TError> WhenOk<TOk, TError, TOkOut, TIgnoredError>(this Maybe<TOk, TError> state, Func<TOk, Maybe<TOkOut, TIgnoredError>> map)
             => state.TryGet(out var okValue, out var error) ? Maybe.Ok(map(okValue)) : Maybe.Error(error).AsMaybeWithoutValue<Maybe<TOkOut, TIgnoredError>>();
 

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>62.0.0</Version>
-    <PackageReleaseNotes>Added obsolete overload for Maybe.WhenOk to ensure that resulted Maybe does not contain another Maybe as its state.
-This can occur when the programmer mistakenly uses WhenOk instead of the wanted WhenOkTry (typo). The possible error of teh nested maybe can then easily be ignored.</PackageReleaseNotes>
+    <Version>62.1.0</Version>
+    <PackageReleaseNotes>Marked obsolete Maybe.WhenOk overload as warning, so that it can be disabled if absolutely needed.</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>


### PR DESCRIPTION
…isabled if absolutely needed.