### PR TITLE
DML Table triggers are added to the DatabaseDescription

### DIFF
--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>72.0.0</Version>
-    <PackageReleaseNotes>DatabaseDescription: cleanup api slightly, and expose FK by unqualified name lookup</PackageReleaseNotes>
+    <Version>72.1.0</Version>
+    <PackageReleaseNotes>DML Table triggers are added to the DatabaseDescription</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DmlTableTrigger.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DmlTableTrigger.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Data.SqlClient;
+using static ProgressOnderwijsUtils.SafeSql;
+
+namespace ProgressOnderwijsUtils.SchemaReflection
+{
+    public sealed record DmlTableTrigger(DbObjectId ObjectId, string Name, DbObjectId TableObjectId) : IWrittenImplicitly
+    {
+        public static DmlTableTrigger[] LoadAll(SqlConnection conn)
+            => SQL($@"
+                    select
+                        ObjectId = tr.object_id
+                        , tr.name
+                        , TableObjectId = t.object_id
+                    from sys.triggers tr
+                    join sys.tables t on t.object_id = tr.parent_id
+                    where 1=1
+                        and tr.parent_class = 1
+                ").ReadPocos<DmlTableTrigger>(conn);
+    }
+}

--- a/test/ProgressOnderwijsUtils.Tests/Data/DatabaseDescriptionTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/DatabaseDescriptionTest.cs
@@ -91,6 +91,20 @@ namespace ProgressOnderwijsUtils.Tests.Data
         }
 
         [Fact]
+        public void CheckTableTriggers_works()
+        {
+            SQL($"create table dbo.TableTriggerTest (Iets int null)").ExecuteNonQuery(Connection);
+            SQL($"create trigger dbo.EenTrigger on dbo.TableTriggerTest for insert as begin do_nothing: end;").ExecuteNonQuery(Connection);
+
+            var db = DatabaseDescription.LoadFromSchemaTables(Connection);
+            var table = db.GetTableByName("dbo.TableTriggerTest");
+            var trigger = table.Triggers.Single();
+
+            PAssert.That(() => trigger.Name == "EenTrigger");
+            PAssert.That(() => trigger.TableObjectId == table.ObjectId);
+        }
+
+        [Fact]
         public void CheckIsStringAndIsUnicode_works()
         {
             SQL(


### PR DESCRIPTION
So we can check whether a table has triggers within the CascadeDelete implementation, because the output clause depends on it.

Plus it may replace the check whether a table has a trigger or not within the dependant Progress repo.