### PR TITLE
Make AutomaticValueConverters support nullable-lifted cases.

### DIFF
--- a/src/ProgressOnderwijsUtils/Data/FromDbValueConverter.cs
+++ b/src/ProgressOnderwijsUtils/Data/FromDbValueConverter.cs
@@ -78,9 +78,13 @@ namespace ProgressOnderwijsUtils
             static Func<object?, T> ForConvertible(Type type, ValueConverter converter)
             {
                 if (type.IsNullableValueType() || !type.IsValueType) {
-                    return obj => obj == null ? default(T)! : obj is T alreadyCast ? alreadyCast : (T)converter.ConvertFromProvider(obj)!;
+                    return obj => obj == null
+                        ? default(T)!
+                        : obj is T alreadyCast
+                            ? alreadyCast
+                            : (T)converter.ConvertFromProvider(obj);
                 } else {
-                    return obj => obj == null ? throw new InvalidCastException("Cannot convert null to " + type.ToCSharpFriendlyTypeName()) : (T)converter.ConvertFromProvider(obj)!;
+                    return obj => obj == null ? throw new InvalidCastException("Cannot convert null to " + type.ToCSharpFriendlyTypeName()) : (T)converter.ConvertFromProvider(obj);
                 }
             }
         }
@@ -92,13 +96,27 @@ namespace ProgressOnderwijsUtils
             static Func<object?, T> MakeConverter(Type type)
             {
                 if (!type.IsValueType) {
-                    return obj => obj == null ? default! : obj is IHasValueConverter<T> && AutomaticValueConverters.GetOrNull(obj.GetType()) is {} converter ? (T)converter.ConvertToProvider(obj)! : (T)obj!;
+                    return obj => obj == null
+                        ? default(T)!
+                        : AutomaticValueConverters.GetOrNull(obj.GetType()) is { } converter
+                            ? (T)converter.ConvertToProvider(obj)
+                            : (T)obj;
                 }
                 var nonnullableUnderlyingType = type.IfNullableGetNonNullableType();
                 if (nonnullableUnderlyingType == null) {
-                    return obj => obj is IHasValueConverter && AutomaticValueConverters.GetOrNull(obj.GetType()) is {} converter ? (T)converter.ConvertToProvider(obj)! : (T)obj!;
+                    return obj =>
+                        obj is null
+                            ? throw new InvalidOperationException("Cannot convert null to non-nullable value type " + type.FriendlyName())
+                            : AutomaticValueConverters.GetOrNull(obj.GetType()) is { } converter
+                                ? (T)converter.ConvertToProvider(obj)
+                                : (T)obj;
                 }
-                return obj => obj == null ? default! : obj is IHasValueConverter && AutomaticValueConverters.GetOrNull(obj.GetType()) is {} converter ? (T)converter.ConvertToProvider(obj)! : (T)obj!;
+                return obj =>
+                    obj is null
+                    ? default(T)!
+                    : AutomaticValueConverters.GetOrNull(obj.GetType()) is { } converter
+                        ? (T)converter.ConvertToProvider(obj)
+                        : (T)obj;
             }
         }
 
@@ -121,9 +139,9 @@ namespace ProgressOnderwijsUtils
                     throw new InvalidCastException("Cannot cast (db)null to " + type.ToCSharpFriendlyTypeName());
                 }
                 return null;
-            } else if (AutomaticValueConverters.GetOrNull(type) is {} targetConvertible) {
+            } else if (AutomaticValueConverters.GetOrNull(type) is { } targetConvertible) {
                 return targetConvertible.ConvertFromProvider(val);
-            } else if (AutomaticValueConverters.GetOrNull(val.GetType()) is {} sourceConvertible && sourceConvertible.ProviderClrType == type.GetNonNullableType()) {
+            } else if (AutomaticValueConverters.GetOrNull(val.GetType()) is { } sourceConvertible && sourceConvertible.ProviderClrType == type.GetNonNullableType()) {
                 return sourceConvertible.ConvertToProvider(val);
             } else {
                 return genericCastMethod.MakeGenericMethod(type).Invoke(null, new[] { val });

--- a/src/ProgressOnderwijsUtils/Data/PocoDataReader.cs
+++ b/src/ProgressOnderwijsUtils/Data/PocoDataReader.cs
@@ -144,7 +144,7 @@ namespace ProgressOnderwijsUtils
                         columnBoxedAsColumnType = columnBoxedAsObject;
                         WhenNullable_IsColumnDBNull = null;
                     } else {
-                        var propertyIsNotNull = IsExpressionNonNull(propertyValue);
+                        var propertyIsNotNull = AutomaticValueConverters.IsExpressionNonNull(propertyValue);
                         columnBoxedAsColumnType = Expression.Condition(propertyIsNotNull, columnBoxedAsObject, Expression.Constant(DBNull.Value, typeof(object)));
                         WhenNullable_IsColumnDBNull = Expression.Lambda<Func<T, bool>>(Expression.Not(propertyIsNotNull), pocoParameter).CompileFast();
                     }
@@ -161,7 +161,7 @@ namespace ProgressOnderwijsUtils
                         columnBoxedAsColumnType = columnBoxedAsObject;
                         WhenNullable_IsColumnDBNull = null;
                     } else {
-                        var propertyIsNotNull = IsExpressionNonNull(propertyValue);
+                        var propertyIsNotNull = AutomaticValueConverters.IsExpressionNonNull(propertyValue);
                         columnBoxedAsColumnType = Expression.Coalesce(columnValueAsNonNullable, Expression.Constant(DBNull.Value, typeof(object)));
                         WhenNullable_IsColumnDBNull = Expression.Lambda<Func<T, bool>>(Expression.Not(propertyIsNotNull), pocoParameter).CompileFast();
                     }
@@ -169,11 +169,6 @@ namespace ProgressOnderwijsUtils
                     TypedNonNullableGetter = Expression.Lambda(typeof(Func<,>).MakeGenericType(typeof(T), ColumnType), propertyValueAsNoNullable, pocoParameter).CompileFast();
                 }
             }
-
-            static Expression IsExpressionNonNull(Expression propertyValue)
-                => propertyValue.Type.IsNullableValueType() ? Expression.Property(propertyValue, nameof(Nullable<int>.HasValue))
-                    : propertyValue.Type.IsValueType ? Expression.Constant(false)
-                    : Expression.NotEqual(Expression.Default(typeof(object)), Expression.Convert(propertyValue, typeof(object)));
         }
 
         static readonly ColumnInfo[] columnInfos;

--- a/src/ProgressOnderwijsUtils/Pocos/AutomaticValueConverters.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/AutomaticValueConverters.cs
@@ -45,10 +45,13 @@ namespace ProgressOnderwijsUtils
 
         static readonly ValueConverter<ulong, byte[]> ulongConverter = Define<ulong, byte[]>(codeVal => QueryScalarParameterComponent.UInt64ToSqlBinary(codeVal), dbVal => ParameterizedSqlObjectMapper.SqlBinaryToUInt64(dbVal));
         static readonly ValueConverter<uint, byte[]> uintConverter = Define<uint, byte[]>(codeVal => QueryScalarParameterComponent.UInt32ToSqlBinary(codeVal), dbVal => ParameterizedSqlObjectMapper.SqlBinaryToUInt32(dbVal));
+        static readonly ValueConverter<int, int> intPassThroughConverter = Define<int, int>(codeVal => codeVal, dbVal => dbVal);
         static readonly ConcurrentDictionary<Type, ValueConverter?> propertyConverterCache = new();
 
         static readonly Func<Type, ValueConverter?> cachedFactoryDelegate = type => {
-            if (type == typeof(ulong)) {
+            if (GetLiftedNullableConverter(type) is { } valueConverter) {
+                return valueConverter;
+            } else if (type == typeof(ulong)) {
                 return ulongConverter;
             } else if (type == typeof(uint)) {
                 return uintConverter;
@@ -58,10 +61,12 @@ namespace ProgressOnderwijsUtils
                     return (ValueConverter)LiftToEnum_OpenGenericMethod.MakeGenericMethod(type, underlyingType, ulongConverter.ProviderClrType).Invoke(null, new object[] { ulongConverter }).AssertNotNull();
                 } else if (underlyingType == typeof(uint)) {
                     return (ValueConverter)LiftToEnum_OpenGenericMethod.MakeGenericMethod(type, underlyingType, uintConverter.ProviderClrType).Invoke(null, new object[] { uintConverter }).AssertNotNull();
+                } else if (underlyingType == typeof(int)) {
+                    return (ValueConverter)LiftToEnum_OpenGenericMethod.MakeGenericMethod(type, underlyingType, intPassThroughConverter.ProviderClrType).Invoke(null, new object[] { intPassThroughConverter }).AssertNotNull();
                 }
             }
 
-            return type.GetNonNullableUnderlyingType()
+            return type
                 .GetInterfaces()
                 .Where(i => i.IsConstructedGenericType && i.GetGenericTypeDefinition() == typeof(IHasValueConverter<,,>))
                 .Select(
@@ -75,7 +80,45 @@ namespace ProgressOnderwijsUtils
                 .SingleOrNull();
         };
 
+        static ValueConverter? GetLiftedNullableConverter(Type nullableModelType)
+        {
+            if (nullableModelType.IfNullableGetNonNullableType() is not { } nonNullableModelType || GetOrNull(nonNullableModelType) is not { } nonNullableValueTypeConverter) {
+                return null;
+            }
+            var providerType = nonNullableValueTypeConverter.ProviderClrType;
+            var possiblyNullableProviderType = providerType.MakeNullableType() ?? providerType;
+
+            var nullableModelArg = Expression.Parameter(nullableModelType, "nullableModelVal");
+            var origModelArg = nonNullableValueTypeConverter.ConvertToProviderExpression.Parameters.Single();
+            var nullableModelToProviderBody = Expression.Condition(
+                IsExpressionNonNull(nullableModelArg),
+                Expression.Convert(ReplacingExpressionVisitor.Replace(origModelArg, Expression.Convert(nullableModelArg, origModelArg.Type), nonNullableValueTypeConverter.ConvertToProviderExpression.Body), possiblyNullableProviderType),
+                Expression.Default(possiblyNullableProviderType)
+            );
+            var modelToProviderFuncType = typeof(Func<,>).MakeGenericType(nullableModelType, possiblyNullableProviderType);
+            var modelToProviderLambda = Expression.Lambda(modelToProviderFuncType, nullableModelToProviderBody, nullableModelArg);
+
+            var nullableProviderArg = Expression.Parameter(possiblyNullableProviderType, "nullableProviderVal");
+            var origProviderArg = nonNullableValueTypeConverter.ConvertFromProviderExpression.Parameters.Single();
+            var nullableProviderToModelBody = Expression.Condition(
+                IsExpressionNonNull(nullableProviderArg),
+                Expression.Convert(ReplacingExpressionVisitor.Replace(origProviderArg, Expression.Convert(nullableProviderArg, origProviderArg.Type), nonNullableValueTypeConverter.ConvertFromProviderExpression.Body), nullableModelType),
+                Expression.Default(nullableModelType)
+            );
+            var providerToModelFuncType = typeof(Func<,>).MakeGenericType(possiblyNullableProviderType, nullableModelType);
+            var providerToModelLambda = Expression.Lambda(providerToModelFuncType, nullableProviderToModelBody, nullableProviderArg);
+
+            return (ValueConverter)Activator.CreateInstance(typeof(ValueConverter<,>).MakeGenericType(nullableModelType, possiblyNullableProviderType), modelToProviderLambda, providerToModelLambda, null).AssertNotNull();
+        }
+
         public static ValueConverter? GetOrNull(Type propertyType)
             => propertyConverterCache.GetOrAdd(propertyType, cachedFactoryDelegate);
+
+        public static Expression IsExpressionNonNull(Expression propertyValue)
+            => propertyValue.Type.IsNullableValueType()
+                ? Expression.Property(propertyValue, nameof(Nullable<int>.HasValue))
+                : propertyValue.Type.IsValueType
+                    ? Expression.Constant(false)
+                    : Expression.NotEqual(Expression.Default(typeof(object)), Expression.Convert(propertyValue, typeof(object)));
     }
 }

--- a/test/ProgressOnderwijsUtils.Tests/FromDbValueConverterTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/FromDbValueConverterTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using ExpressionToCodeLib;
 using ProgressOnderwijsUtils.Tests.Data;
 using Xunit;
@@ -92,8 +93,8 @@ namespace ProgressOnderwijsUtils.Tests
             => PAssert.That(() => DbValueConverter.FromDb<DayOfWeek>(2) == DayOfWeek.Tuesday);
 
         [Fact]
-        public void NonUnderlyingIntsConvertToEnum_crashes()
-            => Assert.Throws<InvalidCastException>(() => DbValueConverter.FromDb<DayOfWeek>((short)2) == DayOfWeek.Tuesday);
+        public void NonUnderlyingIntsConvertToEnum_can_work()
+            => PAssert.That(() => DbValueConverter.FromDb<DayOfWeek>((short)2) == DayOfWeek.Tuesday);
 
         [Fact]
         public void DoublesConvertToInt_crashes()
@@ -156,7 +157,27 @@ namespace ProgressOnderwijsUtils.Tests
 
         [Fact]
         public void CanCastToNullableFromConvertible()
-            => PAssert.That(() => DbValueConverter.ToDb<int?>(new TrivialValue<int?>(3)) == 3);
+            => PAssert.That(() => 3 == DbValueConverter.ToDb<int?>(new TrivialValue<int?>(3)));
+
+        [Fact]
+        public void CanCastToNullableFromEnum()
+            => PAssert.That(() => 3 == DbValueConverter.ToDb<int?>(DayOfWeek.Wednesday));
+
+        [Fact]
+        public void CanCastToByteArrayFromULong()
+            => PAssert.That(() => DbValueConverter.ToDb<byte[]>(ulong.MaxValue).SequenceEqual(Enumerable.Repeat((byte)255, 8)));
+
+        [Fact]
+        public void CanCastToByteArrayFromNullableULong()
+            => PAssert.That(() => null == DbValueConverter.ToDb<byte[]?>(default(ulong?)));
+
+        [Fact]
+        public void CanCastFromByteArrayToNullableULong()
+        {
+            var allBitsOn = Enumerable.Repeat((byte)255, 8).ToArray();
+            PAssert.That(() => null == DbValueConverter.FromDb<ulong?>(default(byte[]?)));
+            PAssert.That(() => ulong.MaxValue == DbValueConverter.FromDb<ulong?>(allBitsOn));
+        }
 
         [Fact]
         public void CanCastToNullableConvertibleOfReferenceType()
@@ -198,6 +219,17 @@ namespace ProgressOnderwijsUtils.Tests
             PAssert.That(() => 3 == (int?)DbValueConverter.DynamicCast(DayOfWeek.Wednesday, typeof(int?)));
             PAssert.That(() => DayOfWeek.Wednesday == (DayOfWeek?)DbValueConverter.DynamicCast(3, typeof(DayOfWeek)));
             PAssert.That(() => DayOfWeek.Wednesday == (DayOfWeek?)DbValueConverter.DynamicCast(3, typeof(DayOfWeek?)));
+        }
+
+        [Fact]
+        public void CanConvertIntsFromDbToEnums()
+        {
+            PAssert.That(() => DayOfWeek.Wednesday == DbValueConverter.FromDb<DayOfWeek?>(3));
+            PAssert.That(() => DayOfWeek.Wednesday == DbValueConverter.FromDb<DayOfWeek>(3));
+            PAssert.That(() => null == DbValueConverter.FromDb<DayOfWeek?>(null));
+            PAssert.That(() => 3 == DbValueConverter.ToDb<int>(DayOfWeek.Wednesday));
+            PAssert.That(() => 3 == DbValueConverter.ToDb<int?>(DayOfWeek.Wednesday));
+            PAssert.That(() => null == DbValueConverter.ToDb<int?>(null));
         }
 
         [Fact]


### PR DESCRIPTION
EF and the poco mapper don't need this, but GenericBusinessEdit does.