### PR TITLE
Maak een gebruiksvriendelijker alternatief voor maybe.either

### DIFF
--- a/src/ProgressOnderwijsUtils/Collections/Maybe.cs
+++ b/src/ProgressOnderwijsUtils/Collections/Maybe.cs
@@ -135,6 +135,12 @@ namespace ProgressOnderwijsUtils.Collections
         public static Maybe<TOk, TError> Either<TOk, TError>(bool isOk, TOk whenOk, TError whenError)
             => isOk ? Ok(whenOk).AsMaybeWithoutError<TError>() : Error(whenError);
 
+        public static Maybe<Unit, TError> Verify<TError>(bool isOk, Func<TError> whenError)
+            => isOk ? Ok().AsMaybeWithoutError<TError>() : Error(whenError());
+
+        public static Maybe<Unit, TError> Verify<TError>(bool isOk, TError whenError)
+            => isOk ? Ok().AsMaybeWithoutError<TError>() : Error(whenError);
+
         /// <summary>
         /// Converts a possibly null error to a Maybe&lt;Unit, TError&gt;. When the input is null; return OK, otherwise - returns error.
         /// </summary>

--- a/src/ProgressOnderwijsUtils/Collections/Maybe.cs
+++ b/src/ProgressOnderwijsUtils/Collections/Maybe.cs
@@ -95,7 +95,7 @@ namespace ProgressOnderwijsUtils.Collections
             }
         }
 
-        public void Deconstruct(out bool isOk, [MaybeNull] out TOk okValueIfOk, [MaybeNull] out TError errorValueIfError)
+        public void Deconstruct(out bool isOk, out TOk? okValueIfOk, out TError? errorValueIfError)
             => isOk = TryGet(out okValueIfOk, out errorValueIfError);
     }
 

--- a/src/ProgressOnderwijsUtils/Collections/Maybe.cs
+++ b/src/ProgressOnderwijsUtils/Collections/Maybe.cs
@@ -64,7 +64,7 @@ namespace ProgressOnderwijsUtils.Collections
             => okOrError switch {
                 Maybe_Ok<TOk> okValue => ifOk(okValue.Value),
                 Maybe_Error<TError> errValue => ifError(errValue.Error),
-                _ => throw new Exception($"Maybe is neither Ok nor Error.")
+                _ => throw new($"Maybe is neither Ok nor Error.")
             };
 
         /// <summary>
@@ -72,14 +72,14 @@ namespace ProgressOnderwijsUtils.Collections
         /// </summary>
         [Pure]
         public static implicit operator Maybe<TOk, TError>(Maybe_Error<TError> err)
-            => new Maybe<TOk, TError>(err);
+            => new(err);
 
         /// <summary>
         /// Converts an untyped error message into a specific type of failed Maybe.  This operator is a  workaround to make it easy to create an error message without redundant type info.
         /// </summary>
         [Pure]
         public static implicit operator Maybe<TOk, TError>(Maybe_Ok<TOk> err)
-            => new Maybe<TOk, TError>(err);
+            => new(err);
 
         public bool TryGet([MaybeNullWhen(false)] out TOk okValueIfOk, [MaybeNullWhen(true)] out TError errorValueIfError)
         {
@@ -91,7 +91,7 @@ namespace ProgressOnderwijsUtils.Collections
                     (okValueIfOk, errorValueIfError) = (default(TOk)! /*okValueIfOk is annotated MaybeNull*/, errValue.Error);
                     return false;
                 default:
-                    throw new Exception($"Maybe is neither Ok nor Error.");
+                    throw new($"Maybe is neither Ok nor Error.");
             }
         }
 
@@ -106,28 +106,28 @@ namespace ProgressOnderwijsUtils.Collections
         /// </summary>
         [Pure]
         public static Maybe_Ok<T> Ok<T>(T val)
-            => new Maybe_Ok<T>(val);
+            => new(val);
 
         /// <summary>
         /// Creates a succesful Maybe value without a value.
         /// </summary>
         [Pure]
         public static Maybe_Ok<Unit> Ok()
-            => new Maybe_Ok<Unit>(Unit.Value);
+            => new(Unit.Value);
 
         /// <summary>
         /// Create a failed maybe with an error state describing a failed operation.
         /// </summary>
         [Pure]
         public static Maybe_Error<TError> Error<TError>(TError error)
-            => new Maybe_Error<TError>(error);
+            => new(error);
 
         /// <summary>
         /// Create a failed maybe without any additional information about the error.
         /// </summary>
         [Pure]
         public static Maybe_Error<Unit> Error()
-            => new Maybe_Error<Unit>(Unit.Value);
+            => new(Unit.Value);
 
         public static Maybe<TOk, TError> Either<TOk, TError>(bool isOk, Func<TOk> whenOk, Func<TError> whenError)
             => isOk ? Ok(whenOk()).AsMaybeWithoutError<TError>() : Error(whenError());
@@ -171,13 +171,13 @@ namespace ProgressOnderwijsUtils.Collections
         /// Usage: Maybe.Try( () => Some.Thing.That(Can.Fail())).Catch&lt;SomeException&gt;()
         /// </summary>
         public static MaybeTryBody Try(Action tryBody)
-            => new MaybeTryBody(tryBody);
+            => new(tryBody);
 
         /// <summary>
         /// Usage: Maybe.Try( () => Some.Thing.That(Can.Fail())).Catch&lt;SomeException&gt;()
         /// </summary>
         public static MaybeTryBody<TOk> Try<TOk>(Func<TOk> tryBody)
-            => new MaybeTryBody<TOk>(tryBody);
+            => new(tryBody);
     }
 
     public readonly struct MaybeTryBody

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>75.0.0</Version>
-    <PackageReleaseNotes>Remove GenericExtensions (you can use C# pattern matching instead)</PackageReleaseNotes>
+    <Version>75.1.0</Version>
+    <PackageReleaseNotes>Added Maybe.Verify convenience method</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>

--- a/test/ProgressOnderwijsUtils.Tests/MaybeTests.cs
+++ b/test/ProgressOnderwijsUtils.Tests/MaybeTests.cs
@@ -16,7 +16,7 @@ namespace ProgressOnderwijsUtils.Tests
             // ReSharper disable once RedundantCast
             PAssert.That(() => Maybe.Ok((string?)"42").AsMaybeWithoutError<Unit>().Contains(default(string)) == false);
 #pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable 8620 //R# bug?
+#pragma warning disable 8620 //R# bugje?
             PAssert.That(() => Maybe.Ok(default(string)).AsMaybeWithoutError<Unit>().Contains(default(string)));
 #pragma warning restore 8620
 #pragma warning restore IDE0079 // Remove unnecessary suppression

--- a/test/ProgressOnderwijsUtils.Tests/MaybeTests.cs
+++ b/test/ProgressOnderwijsUtils.Tests/MaybeTests.cs
@@ -86,14 +86,14 @@ namespace ProgressOnderwijsUtils.Tests
             cleanupCalled = 0;
             maybeWithCleanup = Maybe.Try(() => int.Parse("42e")).Finally(() => {
                 cleanupCalled++;
-                throw new Exception();
+                throw new();
             });
             PAssert.That(() => cleanupCalled == 1 && maybeWithCleanup.ContainsError(e => e is AggregateException));
 
             cleanupCalled = 0;
-            var unitMaybeWithCleanup = Maybe.Try(() => throw new Exception("bla")).Finally(() => {
+            var unitMaybeWithCleanup = Maybe.Try(() => throw new("bla")).Finally(() => {
                 cleanupCalled++;
-                throw new Exception();
+                throw new();
             });
             PAssert.That(() => cleanupCalled == 1 && unitMaybeWithCleanup.ContainsError(e => e is AggregateException));
         }

--- a/test/ProgressOnderwijsUtils.Tests/MaybeTests.cs
+++ b/test/ProgressOnderwijsUtils.Tests/MaybeTests.cs
@@ -57,6 +57,15 @@ namespace ProgressOnderwijsUtils.Tests
         }
 
         [Fact]
+        public void Maybe_check_returns_Unit_or_error()
+        {
+            PAssert.That(() => Maybe.Verify(true, "an error").IsOk);
+            PAssert.That(() => Maybe.Verify(false, "an error").ContainsError(err=> err== "an error"));
+            PAssert.That(() => Maybe.Verify(true, () => "an error").IsOk);
+            PAssert.That(() => Maybe.Verify(false, () => "an error").ContainsError(err=> err== "an error"));
+        }
+
+        [Fact]
         public void Maybe_try_is_ok_unless_exception_is_thrown()
         {
             PAssert.That(() => Maybe.Try(() => int.Parse("42")).Catch<Exception>().Contains(42));


### PR DESCRIPTION
Voor situaties waar alleen een error kan optreden, maar geen returnvalue is

Ter illustratie: https://github.com/progressonderwijs/progress/pull/41802