### PR TITLE
Allow implicitly dropping the value component of Maybes

### DIFF
--- a/src/ProgressOnderwijsUtils/Collections/Maybe.cs
+++ b/src/ProgressOnderwijsUtils/Collections/Maybe.cs
@@ -91,7 +91,7 @@ namespace ProgressOnderwijsUtils.Collections
                     (okValueIfOk, errorValueIfError) = (default(TOk)! /*okValueIfOk is annotated MaybeNull*/, errValue.Error);
                     return false;
                 default:
-                    throw new($"Maybe is neither Ok nor Error.");
+                    throw new("Maybe is neither Ok nor Error.");
             }
         }
 

--- a/src/ProgressOnderwijsUtils/Collections/Maybe.cs
+++ b/src/ProgressOnderwijsUtils/Collections/Maybe.cs
@@ -81,6 +81,13 @@ namespace ProgressOnderwijsUtils.Collections
         public static implicit operator Maybe<TOk, TError>(Maybe_Ok<TOk> err)
             => new(err);
 
+        /// <summary>
+        /// Allow discarding the return value. A lot of methods only need to return whether they succeeded, but a lot of sources of maybe return a result
+        /// </summary>
+        [Pure]
+        public static implicit operator Maybe<Unit, TError>(Maybe<TOk, TError> maybe)
+            => maybe.WhenOk(_ => { });
+
         public bool TryGet([MaybeNullWhen(false)] out TOk okValueIfOk, [MaybeNullWhen(true)] out TError errorValueIfError)
         {
             switch (okOrError) {

--- a/src/ProgressOnderwijsUtils/Collections/MaybeExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Collections/MaybeExtensions.cs
@@ -1,18 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Resources;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace ProgressOnderwijsUtils.Collections
 {
     public static class MaybeExtensions
     {
-        [return: MaybeNull]
         [Pure]
-        public static TError ErrorOrNull<TOk, TError>(this Maybe<TOk, TError> state)
+        public static TError? ErrorOrNull<TOk, TError>(this Maybe<TOk, TError> state)
             where TError : class?
             => state.TryGet(out _, out var whenError) ? null : whenError;
 
@@ -26,9 +22,8 @@ namespace ProgressOnderwijsUtils.Collections
             where TError : struct
             => state.TryGet(out _, out var whenError) ? default(TError?) : whenError;
 
-        [return: MaybeNull]
         [Pure]
-        public static TOk ValueOrNull<TOk, TError>(this Maybe<TOk, TError> state)
+        public static TOk? ValueOrNull<TOk, TError>(this Maybe<TOk, TError> state)
             where TOk : class?
             => state.TryGet(out var whenOk, out _) ? whenOk : null;
 
@@ -43,13 +38,13 @@ namespace ProgressOnderwijsUtils.Collections
             => state.TryGet(out var okValue, out _) ? okValue : default(TOk?);
 
         public static TOk AssertOk<TOk, TError>(this Maybe<TOk, TError> state)
-            => state.TryGet(out var okValue, out var error) ? okValue : throw new Exception("Assertion that Maybe is Ok failed; error state: " + error);
+            => state.TryGet(out var okValue, out var error) ? okValue : throw new("Assertion that Maybe is Ok failed; error state: " + error);
 
         public static TOk AssertOk<TOk, TError>(this Maybe<TOk, TError> state, Func<TError, Exception?> exceptionWhenError)
             => state.TryGet(out var okValue, out var error) ? okValue : throw exceptionWhenError(error) ?? new Exception("Assertion that Maybe is Ok failed; error state: " + error);
 
         public static TError AssertError<TOk, TError>(this Maybe<TOk, TError> state)
-            => state.TryGet(out var okValue, out var error) ? throw new Exception("Assertion that Maybe is Error failed; ok state: " + okValue) : error;
+            => state.TryGet(out var okValue, out var error) ? throw new("Assertion that Maybe is Error failed; ok state: " + okValue) : error;
 
         /// <summary>
         /// Maps a possibly failed value to a new value.
@@ -274,7 +269,7 @@ namespace ProgressOnderwijsUtils.Collections
         public static Maybe<TOk[], TError[]> WhenAllOk<TOk, TError>(this IEnumerable<Maybe<TOk, TError>> maybes)
         {
             var (okValues, errValues) = maybes.Partition();
-            return errValues.Any() ? (Maybe<TOk[], TError[]>)Maybe.Error(errValues) : Maybe.Ok(okValues).AsMaybeWithoutError<TError[]>();
+            return errValues.Any() ? Maybe.Error(errValues) : Maybe.Ok(okValues);
         }
 
         [Pure]

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>75.1.0</Version>
-    <PackageReleaseNotes>Added Maybe.Verify convenience method</PackageReleaseNotes>
+    <Version>76.0.0</Version>
+    <PackageReleaseNotes>Add conversion from any maybe to maybe of Unit</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>


### PR DESCRIPTION
To prevent ```.WhenOk(_ => Unit.Value)``` of ```.WhenOk(_ => {})``` at the end of methods to confirm to return type