### PR TITLE
Add support for extended ringle-S (U+01E9E)

### DIFF
--- a/src/ProgressOnderwijsUtils/Extensions/StringUtils.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/StringUtils.cs
@@ -83,7 +83,7 @@ namespace ProgressOnderwijsUtils
 
         [Pure]
         public static string VervangRingelS(string str)
-            => str.Replace("ß", "ss");
+            => str.Replace("ß", "ss").Replace("ẞ", "ss");
 
         [Pure]
         public static string SepaTekenset(string s)

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>76.2.0</Version>
-    <PackageReleaseNotes>Use BOM-less UTF-8 for approved files.</PackageReleaseNotes>
+    <Version>76.3.0</Version>
+    <PackageReleaseNotes>Add support for extended ringle-S (U+01E9E)</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>

--- a/test/ProgressOnderwijsUtils.Tests/StringExtensionsTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/StringExtensionsTest.cs
@@ -49,7 +49,9 @@ namespace ProgressOnderwijsUtils.Tests
         public void ReplaceRingelS()
         {
             PAssert.That(() => StringUtils.VervangRingelS("ß") == "ss");
+            PAssert.That(() => StringUtils.VervangRingelS("ẞ") == "ss");
             PAssert.That(() => StringUtils.VervangRingelS("aßb") == "assb");
+            PAssert.That(() => StringUtils.VervangRingelS("ßẞ") == "ssss");
             PAssert.That(() => StringUtils.VervangRingelS("") == "");
         }
 

--- a/test/ProgressOnderwijsUtils.Tests/StringUtilsTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/StringUtilsTest.cs
@@ -18,7 +18,7 @@ namespace ProgressOnderwijsUtils.Tests
         public void SepaTekensetEnModificaties()
         {
             PAssert.That(() => StringUtils.SepaTekensetEnModificaties("Antonín Dvořák") == "Antonin Dvorak");
-            PAssert.That(() => StringUtils.SepaTekensetEnModificaties("@ß!#$!@SDfef9{ɚ0 df0o4[[") == "ssSDfef90 df0o4[[");
+            PAssert.That(() => StringUtils.SepaTekensetEnModificaties("@ßẞ!#$!@SDfef9{ɚ0 df0o4[[") == "ssssSDfef90 df0o4[[");
             PAssert.That(() => StringUtils.SepaTekensetEnModificaties(null) == null);
         }
 


### PR DESCRIPTION
It seems that Studielink uses this extended unicode character as a ringle-S