### PR TITLE
return number of rows affected with out var instead of returnvalue

### DIFF
--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -46,9 +46,13 @@ namespace ProgressOnderwijsUtils
         public static T ReadScalar<T>(this ParameterizedSql sql, SqlConnection sqlConn)
             => sql.OfScalar<T>().Execute(sqlConn);
 
-        /// <summary>Executes an sql statement and returns the number of rows affected.  Returns 0 without server interaction for whitespace-only commands.</summary>
-        public static int ExecuteNonQuery(this ParameterizedSql sql, SqlConnection sqlConn)
+        /// <summary>Executes an sql statement</summary>
+        public static void ExecuteNonQuery(this ParameterizedSql sql, SqlConnection sqlConn)
             => sql.OfNonQuery().Execute(sqlConn);
+
+        /// <summary>Executes an sql statement and returns the number of rows affected.  Returns 0 without server voideraction for whitespace-only commands.</summary>
+        public static void ExecuteNonQuery(this ParameterizedSql sql, SqlConnection sqlConn, out int nrOfRowsAffected)
+            => sql.OfNonQuery().Execute(sqlConn, out nrOfRowsAffected);
 
         /// <summary>
         /// Reads all records of the given query from the database, unpacking into a C# array using each item's publicly writable fields and properties.

--- a/src/ProgressOnderwijsUtils/Data/SqlBatch.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlBatch.cs
@@ -19,7 +19,6 @@ namespace ProgressOnderwijsUtils
         CommandTimeout CommandTimeout { get; }
     }
 
-
     public interface IWithTimeout<out TSelf> : INestableSql
         where TSelf : IWithTimeout<TSelf>
     {
@@ -44,14 +43,18 @@ namespace ProgressOnderwijsUtils
         public NonQuerySqlCommand(ParameterizedSql sql, CommandTimeout timeout)
             => (Sql, CommandTimeout) = (sql, timeout);
 
-        public int Execute(SqlConnection conn)
+        public void Execute(SqlConnection conn)
+            => Execute(conn, out _);
+
+        public void Execute(SqlConnection conn, out int nrOfRowsAffected)
         {
             using var cmd = this.ReusableCommand(conn);
             try {
                 if (string.IsNullOrWhiteSpace(cmd.Command.CommandText)) {
-                    return 0;
+                    nrOfRowsAffected = 0;
+                    return;
                 }
-                return cmd.Command.ExecuteNonQuery();
+                nrOfRowsAffected = cmd.Command.ExecuteNonQuery();
             } catch (Exception e) {
                 throw cmd.CreateExceptionWithTextAndArguments(e, this);
             }

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
     <Version>77.0.0</Version>
-    <PackageReleaseNotes>Instead of returning put nr of affected rows in out var for executing non-query</PackageReleaseNotes>
+    <PackageReleaseNotes>Executing a non-query now returns void and instead uses an out parameter to indicate the number of affected rows</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>76.3.0</Version>
-    <PackageReleaseNotes>Add support for extended ringle-S (U+01E9E)</PackageReleaseNotes>
+    <Version>77.0.0</Version>
+    <PackageReleaseNotes>Instead of returning put nr of affected rows in out var for executing non-query</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>


### PR DESCRIPTION
Same idea as https://github.com/progressonderwijs/progress/pull/42586

Make it possible to enforce always using return values