### PR TITLE
Fix DbColumnMetaData.Create 

### DIFF
--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>78.1.0</Version>
-    <PackageReleaseNotes>Add support for scripting sql numeric and time types</PackageReleaseNotes>
+    <Version>78.1.1</Version>
+    <PackageReleaseNotes>Bugfix: support for scripting sql numeric and time types now roundtrips when using DbColumnMetaData.Create</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
@@ -68,8 +68,8 @@ namespace ProgressOnderwijsUtils.SchemaReflection
                     SqlSystemTypeId.DateTime2 or SqlSystemTypeId.DateTimeOffset or SqlSystemTypeId.Time => (0, 7),
                     _ => (0, 0)
                 };
-            var metaData = new DbColumnMetaData(name, typeId, maxLengthForSqlServer, (byte)precision, (byte)scale);
-            return metaData with { IsNullable = dataType.CanBeNull(), IsPrimaryKey = isKey, };
+
+            return new(name, typeId, maxLengthForSqlServer, (byte)precision, (byte)scale) { IsNullable = dataType.CanBeNull(), IsPrimaryKey = isKey, };
         }
 
         public bool IsString

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
@@ -57,8 +57,10 @@ namespace ProgressOnderwijsUtils.SchemaReflection
             var typeId = SqlSystemTypeIdExtensions.DotnetTypeToSqlType(dataType);
 
             var maxLengthForSqlServer = (short)(typeId switch {
-                SqlSystemTypeId.NVarChar or SqlSystemTypeId.NChar => maxLength * 2 ?? -1,
-                SqlSystemTypeId.VarChar or SqlSystemTypeId.Char or SqlSystemTypeId.VarBinary or SqlSystemTypeId.Binary => maxLength ?? -1,
+                SqlSystemTypeId.NVarChar => maxLength * 2 ?? -1,
+                SqlSystemTypeId.NChar => maxLength * 2 ?? 2,
+                SqlSystemTypeId.VarChar or SqlSystemTypeId.VarBinary => maxLength ?? -1,
+                SqlSystemTypeId.Char or SqlSystemTypeId.Binary => maxLength ?? 1,
                 _ => 0,
             });
 

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
@@ -65,6 +65,7 @@ namespace ProgressOnderwijsUtils.SchemaReflection
             var (precision, scale) =
                 typeId switch {
                     SqlSystemTypeId.Decimal or SqlSystemTypeId.Numeric => (38, 2),
+                    SqlSystemTypeId.DateTime2 or SqlSystemTypeId.DateTimeOffset or SqlSystemTypeId.Time => (0, 7),
                     _ => (0, 0)
                 };
             var metaData = new DbColumnMetaData(name, typeId, maxLengthForSqlServer, (byte)precision, (byte)scale);

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
@@ -63,7 +63,10 @@ namespace ProgressOnderwijsUtils.SchemaReflection
             });
 
             var (precision, scale) =
-                dataType == typeof(decimal) || dataType == typeof(decimal?) || dataType == typeof(double) || dataType == typeof(double?) ? (38, 2) : (0, 0);
+                typeId switch {
+                    SqlSystemTypeId.Decimal or SqlSystemTypeId.Numeric => (38, 2),
+                    _ => (0, 0)
+                };
             var metaData = new DbColumnMetaData(name, typeId, maxLengthForSqlServer, (byte)precision, (byte)scale);
             return metaData with { IsNullable = dataType.CanBeNull(), IsPrimaryKey = isKey, };
         }

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
@@ -55,7 +55,6 @@ namespace ProgressOnderwijsUtils.SchemaReflection
         public static DbColumnMetaData Create(string name, Type dataType, bool isKey, int? maxLength)
         {
             var typeId = SqlSystemTypeIdExtensions.DotnetTypeToSqlType(dataType);
-            var hasDecimalStyleScale = dataType == typeof(decimal) || dataType == typeof(decimal?) || dataType == typeof(double) || dataType == typeof(double?);
 
             var maxLengthForSqlServer = (short)(typeId switch {
                 SqlSystemTypeId.NVarChar or SqlSystemTypeId.NChar => maxLength * 2 ?? -1,
@@ -63,8 +62,8 @@ namespace ProgressOnderwijsUtils.SchemaReflection
                 _ => 0,
             });
 
-            var precision = hasDecimalStyleScale ? 38 : 0;
-            var scale = hasDecimalStyleScale ? 2 : 0;
+            var (precision, scale) =
+                dataType == typeof(decimal) || dataType == typeof(decimal?) || dataType == typeof(double) || dataType == typeof(double?) ? (38, 2) : (0, 0);
             var metaData = new DbColumnMetaData(name, typeId, maxLengthForSqlServer, (byte)precision, (byte)scale);
             return metaData with { IsNullable = dataType.CanBeNull(), IsPrimaryKey = isKey, };
         }

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
@@ -58,7 +58,7 @@ namespace ProgressOnderwijsUtils.SchemaReflection
 
             var maxLengthForSqlServer = (short)(typeId switch {
                 SqlSystemTypeId.NVarChar or SqlSystemTypeId.NChar => maxLength * 2 ?? -1,
-                SqlSystemTypeId.VarChar or SqlSystemTypeId.Char or SqlSystemTypeId.VarBinary or SqlSystemTypeId.Binary => maxLength * 2 ?? -1,
+                SqlSystemTypeId.VarChar or SqlSystemTypeId.Char or SqlSystemTypeId.VarBinary or SqlSystemTypeId.Binary => maxLength ?? -1,
                 _ => 0,
             });
 

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
@@ -55,10 +55,13 @@ namespace ProgressOnderwijsUtils.SchemaReflection
         public static DbColumnMetaData Create(string name, Type dataType, bool isKey, int? maxLength)
         {
             var typeId = SqlSystemTypeIdExtensions.DotnetTypeToSqlType(dataType);
-
             var hasDecimalStyleScale = dataType == typeof(decimal) || dataType == typeof(decimal?) || dataType == typeof(double) || dataType == typeof(double?);
 
-            var maxLengthForSqlServer = (short)(dataType == typeof(string) ? maxLength * 2 ?? -1 : -1);
+            var maxLengthForSqlServer = (short)(typeId switch {
+                SqlSystemTypeId.NVarChar or SqlSystemTypeId.NChar => maxLength * 2 ?? -1,
+                SqlSystemTypeId.VarChar or SqlSystemTypeId.Char or SqlSystemTypeId.VarBinary or SqlSystemTypeId.Binary => maxLength * 2 ?? -1,
+                _ => 0,
+            });
 
             var precision = hasDecimalStyleScale ? 38 : 0;
             var scale = hasDecimalStyleScale ? 2 : 0;

--- a/test/ProgressOnderwijsUtils.Tests/Data/DbColumnMetaDataTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/DbColumnMetaDataTest.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Data.SqlClient;
+using System.Linq;
+using ExpressionToCodeLib;
+using ProgressOnderwijsUtils.SchemaReflection;
+using Xunit;
+using static ProgressOnderwijsUtils.SafeSql;
+
+namespace ProgressOnderwijsUtils.Tests.Data
+{
+    public sealed class DbColumnMetaDataTest : TransactedLocalConnection
+    {
+        public sealed record SamplePoco : IWrittenImplicitly, IReadImplicitly
+        {
+            public DayOfWeek AnEnum { get; set; }
+            public DateTime? ADateTime { get; set; }
+            public string? SomeString { get; set; }
+            public decimal? LotsOfMoney { get; set; }
+            public double VagueNumber { get; set; }
+            public DateTime DateTime { get; set; }
+            public TimeSpan TimeSpan { get; set; }
+        }
+
+        [Fact]
+        public void CreatedTempTableMetaDataRoundTrips()
+        {
+            var columnsFromCode = PocoProperties<SamplePoco>.Instance.ArraySelect(prop => DbColumnMetaData.Create(prop.Name, prop.DataType, prop.IsKey, null));
+
+            var tempTableName = SQL($"#test");
+            columnsFromCode.CreateNewTableQuery(tempTableName).ExecuteNonQuery(Connection);
+
+            var columnsFromCodeAsSql = columnsFromCode.ArraySelect(c => c.ToSqlColumnDefinition());
+            var columnsFromDbAsSql = DbColumnMetaData.ColumnMetaDatas(Connection, tempTableName).ArraySelect(c => c.ToSqlColumnDefinition());
+
+            PAssert.That(() => columnsFromCodeAsSql.SequenceEqual(columnsFromDbAsSql));
+        }
+    }
+}

--- a/test/ProgressOnderwijsUtils.Tests/Data/DbColumnMetaDataTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/DbColumnMetaDataTest.cs
@@ -35,5 +35,17 @@ namespace ProgressOnderwijsUtils.Tests.Data
 
             PAssert.That(() => columnsFromCodeAsSql.SequenceEqual(columnsFromDbAsSql));
         }
+
+        [Fact]
+        public void Varbinary_ToSqlColumnDefinition_ExampleWorks()
+            => PAssert.That(() => DbColumnMetaData.Create("test", typeof(byte[]), false, 42).ToSqlColumnDefinition() == "test VarBinary(42) null");
+
+        [Fact]
+        public void VarbinaryMax_ToSqlColumnDefinition_ExampleWorks()
+            => PAssert.That(() => DbColumnMetaData.Create("test", typeof(byte[]), false, null).ToSqlColumnDefinition() == "test VarBinary(max) null");
+
+        [Fact]
+        public void NVarchar_ToSqlColumnDefinition_ExampleWorks()
+            => PAssert.That(() => DbColumnMetaData.Create("test3", typeof(string), false, 42).ToSqlColumnDefinition() == "test3 NVarChar(42) null");
     }
 }

--- a/test/ProgressOnderwijsUtils.Tests/Data/DbColumnMetaDataTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/DbColumnMetaDataTest.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.SqlClient;
 using System.Linq;
 using ExpressionToCodeLib;
 using ProgressOnderwijsUtils.SchemaReflection;
@@ -47,5 +45,9 @@ namespace ProgressOnderwijsUtils.Tests.Data
         [Fact]
         public void NVarchar_ToSqlColumnDefinition_ExampleWorks()
             => PAssert.That(() => DbColumnMetaData.Create("test3", typeof(string), false, 42).ToSqlColumnDefinition() == "test3 NVarChar(42) null");
+
+        [Fact]
+        public void NChar_ToSqlColumnDefinition_ExampleWorks()
+            => PAssert.That(() => DbColumnMetaData.Create("test", typeof(char), false, null).ToSqlColumnDefinition() == "test NChar(1) not null");
     }
 }


### PR DESCRIPTION
DbColumnMetaData.Create is no longer in sync with ToSqlTypeName.ToSqlTypeName, after #600 

This means we can't round-trip certain types, and thus cannot create some temp tables, which is a problem.

This PR fixes the issue (#601 was prep)