### PR TITLE
Avoid exception-catching behavior in Lazy

### DIFF
--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>80.0.1</Version>
-    <PackageReleaseNotes>Remove any MS-shipped user-table from the database description; e.g. the dbo.dtproperties system table.</PackageReleaseNotes>
+    <Version>80.0.1<!--todo bump major version--></Version>
+    <PackageReleaseNotes>Utils.Lazy return Func&lt;&gt; intead of Lazy&lt;&gt;.</PackageReleaseNotes>
 
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>

--- a/src/ProgressOnderwijsUtils/Utils.cs
+++ b/src/ProgressOnderwijsUtils/Utils.cs
@@ -27,8 +27,15 @@ namespace ProgressOnderwijsUtils
             return x == y || delta / magnitude < relativeEpsilon;
         }
 
-        public static Lazy<T> Lazy<T>(Func<T> factory)
-            => new Lazy<T>(factory, LazyThreadSafetyMode.ExecutionAndPublication);
+        public static Func<T> Lazy<T>(Func<T> factory)
+        {
+            //Ideally we'd use Lazy<T>, but that either caches exceptions or fails to lock around initialization. see: https://github.com/dotnet/runtime/issues/27421#issuecomment-424732179
+            var value = default(T?);
+            var initialized = false;
+            var sync = (object)factory;
+
+            return () => LazyInitializer.EnsureInitialized(ref value, ref initialized, ref sync, factory);
+        }
 
         /// <summary>
         /// Swap two objects.

--- a/test/ProgressOnderwijsUtils.Tests/UtilsTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/UtilsTest.cs
@@ -85,6 +85,24 @@ namespace ProgressOnderwijsUtils.Tests
         }
 
         [Fact]
+        public void LazyRetriesExceptions()
+        {
+            var count = 1;
+            var nonFailingLazy = Utils.Lazy(() => ++count);
+            var sometimesFailingLazy = Utils.Lazy(() => ++count % 4 == 0 ? count : throw new("gotcha!"));
+
+            PAssert.That(() => count == 1);
+            PAssert.That(() => nonFailingLazy.Value == 2);
+            PAssert.That(() => count == 2);
+            PAssert.That(() => nonFailingLazy.Value == 2, "A second read of the lazily computed value should not change the value");
+            PAssert.That(() => count == 2, "A second read of the lazily computed value must not have side-effects");
+
+            _ = Assert.Throws<Exception>(() => _ = sometimesFailingLazy.Value);
+            PAssert.That(() => count == 3);
+            PAssert.That(() => sometimesFailingLazy.Value == 4);
+        }
+
+        [Fact]
         public void SwapValue()
         {
             var one = 1;

--- a/test/ProgressOnderwijsUtils.Tests/UtilsTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/UtilsTest.cs
@@ -92,14 +92,14 @@ namespace ProgressOnderwijsUtils.Tests
             var sometimesFailingLazy = Utils.Lazy(() => ++count % 4 == 0 ? count : throw new("gotcha!"));
 
             PAssert.That(() => count == 1);
-            PAssert.That(() => nonFailingLazy.Value == 2);
+            PAssert.That(() => nonFailingLazy() == 2);
             PAssert.That(() => count == 2);
-            PAssert.That(() => nonFailingLazy.Value == 2, "A second read of the lazily computed value should not change the value");
+            PAssert.That(() => nonFailingLazy() == 2, "A second read of the lazily computed value should not change the value");
             PAssert.That(() => count == 2, "A second read of the lazily computed value must not have side-effects");
 
-            _ = Assert.Throws<Exception>(() => _ = sometimesFailingLazy.Value);
+            _ = Assert.Throws<Exception>(() => _ = sometimesFailingLazy());
             PAssert.That(() => count == 3);
-            PAssert.That(() => sometimesFailingLazy.Value == 4);
+            PAssert.That(() => sometimesFailingLazy() == 4);
         }
 
         [Fact]


### PR DESCRIPTION
So that our services don't go down on an intermittent initialization failure.