### PR TITLE
Minor api tweaks

### DIFF
--- a/src/ProgressOnderwijsUtils/Extensions/EnumerableExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/EnumerableExtensions.cs
@@ -79,20 +79,12 @@ namespace ProgressOnderwijsUtils
             => list.ToArray();
 
         [Pure]
-        public static HashSet<T> ToSet<T>(this IEnumerable<T> list)
-            => new HashSet<T>(list);
-
-        [Pure]
-        public static HashSet<T> ToSet<T>(this IEnumerable<T> list, IEqualityComparer<T> comparer)
-            => new HashSet<T>(list, comparer);
-
-        [Pure]
         public static bool SetEqual<T>(this IEnumerable<T> list, IEnumerable<T> other)
-            => list.ToSet().SetEquals(other);
+            => list.ToHashSet().SetEquals(other);
 
         [Pure]
         public static bool SetEqual<T>(this IEnumerable<T> list, IEnumerable<T> other, IEqualityComparer<T> comparer)
-            => list.ToSet(comparer).SetEquals(other);
+            => list.ToHashSet(comparer).SetEquals(other);
 
         [Pure]
         public static IEnumerable<T> EmptyIfNull<T>(this IEnumerable<T>? list)

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>80.0.1<!--todo bump major version--></Version>
-    <PackageReleaseNotes>Utils.Lazy return Func&lt;&gt; intead of Lazy&lt;&gt;.</PackageReleaseNotes>
+    <Version>81.0.0</Version>
+    <PackageReleaseNotes>Utils.Lazy returns Func&lt;&gt; intead of Lazy&lt;&gt; and no longer caches exceptions.  Utils.Swap removed (can be replaced by tuple assignment).  ToSet removed (can be replaced with Linq ToHashSet).</PackageReleaseNotes>
 
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>

--- a/src/ProgressOnderwijsUtils/Utils.cs
+++ b/src/ProgressOnderwijsUtils/Utils.cs
@@ -37,16 +37,6 @@ namespace ProgressOnderwijsUtils
             return () => LazyInitializer.EnsureInitialized(ref value, ref initialized, ref sync, factory);
         }
 
-        /// <summary>
-        /// Swap two objects.
-        /// </summary>
-        public static void Swap<T>(ref T one, ref T other)
-        {
-            var tmp = one;
-            one = other;
-            other = tmp;
-        }
-
         public static HashSet<T> TransitiveClosure<T>(IEnumerable<T> elems, Func<T, IEnumerable<T>> edgeLookup)
             => TransitiveClosure(elems, edgeLookup, EqualityComparer<T>.Default);
 

--- a/src/ProgressOnderwijsUtils/Utils.cs
+++ b/src/ProgressOnderwijsUtils/Utils.cs
@@ -279,18 +279,6 @@ namespace ProgressOnderwijsUtils
         public static int LogBase2RoundedUp(uint x)
             => x <= 1 ? 0 : LogBase2RoundedDown(x - 1) + 1;
 
-        public static bool IsEmailAdresGeldig(string emailAdres)
-        {
-            try {
-                // ReSharper disable ObjectCreationAsStatement
-                _ = new MailAddress(emailAdres);
-                // ReSharper restore ObjectCreationAsStatement
-                return true;
-            } catch {
-                return false;
-            }
-        }
-
         public static CancellationToken CreateLinkedTokenWith(this CancellationToken a, CancellationToken b)
             => b == CancellationToken.None
                 ? a

--- a/src/ProgressOnderwijsUtils/Utils.cs
+++ b/src/ProgressOnderwijsUtils/Utils.cs
@@ -58,7 +58,7 @@ namespace ProgressOnderwijsUtils
 
         public static HashSet<T> TransitiveClosure<T>(IEnumerable<T> elems, Func<DistinctArray<T>, IEnumerable<T>> multiEdgeLookup, IEqualityComparer<T> comparer)
         {
-            var set = elems.ToSet(comparer);
+            var set = elems.ToHashSet(comparer);
             var distinctNewlyReachable = set.ToDistinctArray();
             while (distinctNewlyReachable.Count > 0) {
                 distinctNewlyReachable = multiEdgeLookup(distinctNewlyReachable).Where(set.Add).ToArray().ToDistinctArrayFromDistinct_Unchecked();

--- a/src/ProgressOnderwijsUtils/XmlCompression.cs
+++ b/src/ProgressOnderwijsUtils/XmlCompression.cs
@@ -17,7 +17,7 @@ namespace ProgressOnderwijsUtils
             if (doc.Root == null) {
                 throw new InvalidOperationException("empty documents not supported");
             }
-            var usedNamespaces = doc.Descendants().Select(el => el.Name.Namespace).ToSet();
+            var usedNamespaces = doc.Descendants().Select(el => el.Name.Namespace).ToHashSet();
             usedNamespaces.UnionWith(doc.Descendants().Attributes().Select(attr => attr.Name.Namespace));
 
             var unusedRootNamespaceDeclarations = doc.Descendants().Attributes()

--- a/test/ProgressOnderwijsUtils.Tests/Collections/ProjectingEqualityComparerTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Collections/ProjectingEqualityComparerTest.cs
@@ -7,6 +7,7 @@ namespace ProgressOnderwijsUtils.Tests.Collections
 {
     public sealed class ProjectingEqualityComparerTest
     {
+        // ReSharper disable once NotAccessedPositionalProperty.Local
         sealed record Example(string A, int B, DateTime? C, int[]? D);
 
         readonly ProjectingEqualityComparer<Example> EmptyComparer = new();

--- a/test/ProgressOnderwijsUtils.Tests/Collections/ProjectingEqualityComparerTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Collections/ProjectingEqualityComparerTest.cs
@@ -1,6 +1,5 @@
 using System;
 using ExpressionToCodeLib;
-using ProgressOnderwijsUtils;
 using ProgressOnderwijsUtils.Collections;
 using Xunit;
 

--- a/test/ProgressOnderwijsUtils.Tests/DistinctArrayTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/DistinctArrayTest.cs
@@ -132,7 +132,7 @@ namespace ProgressOnderwijsUtils.Tests
         [Fact]
         public void OverloadForSetsWorks()
         {
-            var hashSet = new[] { 1, 2, 4, 5 }.ToSet();
+            var hashSet = new[] { 1, 2, 4, 5 }.ToHashSet();
             var sut = hashSet.ToDistinctArray();
 
             PAssert.That(() => sut.Count == 4);

--- a/test/ProgressOnderwijsUtils.Tests/UtilsTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/UtilsTest.cs
@@ -103,26 +103,6 @@ namespace ProgressOnderwijsUtils.Tests
         }
 
         [Fact]
-        public void SwapValue()
-        {
-            var one = 1;
-            var other = 2;
-            Utils.Swap(ref one, ref other);
-            PAssert.That(() => one == 2);
-            PAssert.That(() => other == 1);
-        }
-
-        [Fact]
-        public void SwapReference()
-        {
-            var one = "1";
-            var other = "2";
-            Utils.Swap(ref one, ref other);
-            PAssert.That(() => one == "2");
-            PAssert.That(() => other == "1");
-        }
-
-        [Fact]
         public void MaandSpanTest()
         {
             PAssert.That(() => Utils.MaandSpan(new DateTime(2000, 1, 1), new DateTime(2000, 1, 1)) == 0);

--- a/tools/ProgressOnderwijsUtilsBenchmarks/ProgressOnderwijsUtilsBenchmarks.csproj
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/ProgressOnderwijsUtilsBenchmarks.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
     <PackageReference Include="Dapper" Version="2.0.90" />
     <PackageReference Include="IncrementalMeanVarianceAccumulator" Version="1.0.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />


### PR DESCRIPTION
<span>Utils.Lazy returns Func&lt;&gt; intead of Lazy&lt;&gt; and no longer caches exceptions. Utils.Swap removed (can be replaced by tuple assignment). ToSet removed (can be replaced with Linq ToHashSet).</span>

Bumped version.