### PR TITLE
Expand property mapper

### DIFF
--- a/src/ProgressOnderwijsUtils/Pocos/MetaObjectPropertyMapping.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/MetaObjectPropertyMapping.cs
@@ -17,7 +17,6 @@ namespace ProgressOnderwijsUtils
 
     public static class PropertyMapper
     {
-        [UsefulToKeep("Library function")]
         public static PropertyMappers CreateForValue<TProperty>(TProperty value)
             where TProperty : struct, Enum
             => CreateForFunc<TProperty>(_ => value);
@@ -43,7 +42,6 @@ namespace ProgressOnderwijsUtils
                 }
             );
 
-        [UsefulToKeep("Library function")]
         public static PropertyMappers CreateForIdentityMap<TProperty>()
             where TProperty : struct, Enum
             => CreateForFunc(NoopLambda<TProperty>.Instance);

--- a/src/ProgressOnderwijsUtils/Pocos/MetaObjectPropertyMapping.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/MetaObjectPropertyMapping.cs
@@ -151,6 +151,10 @@ namespace ProgressOnderwijsUtils
         public (Func<TId, TId> mapper, bool idNonIdentityMap) GetIdMapper<TId>()
             where TId : struct, Enum
             => mapperByPropertyType.TryGetValue(typeof(TId), out var pMapper) ? pMapper.CreateIdMapper<TId>() : (NoopLambda<TId>.Instance, false);
+
+        public TId MapId<TId>(TId id)
+            where TId : struct, Enum
+            => mapperByPropertyType.TryGetValue(typeof(TId), out var pMapper) ? pMapper.CreateIdMapper<TId>().mapper(id) : id;
     }
 
     public static class PropertyMappersExtensions

--- a/src/ProgressOnderwijsUtils/Pocos/MetaObjectPropertyMapping.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/MetaObjectPropertyMapping.cs
@@ -12,6 +12,7 @@ namespace ProgressOnderwijsUtils
         Func<TRow, TRow> CreateRowMapper<TRow>()
             where TRow : IWrittenImplicitly;
 
+        public (Func<TId, TId> mapper, bool idNonIdentityMap) CreateIdMapper<TId>();
         Type MappedPropertyType();
     }
 
@@ -67,6 +68,9 @@ namespace ProgressOnderwijsUtils
 
         public Type MappedPropertyType()
             => typeof(TProperty);
+
+        public (Func<TId, TId> mapper, bool idNonIdentityMap) CreateIdMapper<TId>()
+            => mapper is Func<TId, TId> reTyped ? (reTyped, true) : (NoopLambda<TId>.Instance, false);
 
         Func<T, T> IPropertyMapper.CreateRowMapper<T>()
             => Mappers<T>.Instance.Invoke(mapper);
@@ -143,6 +147,10 @@ namespace ProgressOnderwijsUtils
                 return copy;
             };
         }
+
+        public (Func<TId, TId> mapper, bool idNonIdentityMap) GetIdMapper<TId>()
+            where TId : struct, Enum
+            => mapperByPropertyType.TryGetValue(typeof(TId), out var pMapper) ? pMapper.CreateIdMapper<TId>() : (NoopLambda<TId>.Instance, false);
     }
 
     public static class PropertyMappersExtensions

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>83.1.0</Version>
-    <PackageReleaseNotes>Update SqlClient</PackageReleaseNotes>
+    <Version>83.2.0</Version>
+    <PackageReleaseNotes>Add PropertyMappers.GetIdMapper</PackageReleaseNotes>
 
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>

--- a/test/ProgressOnderwijsUtils.Tests/PropertyMappingTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/PropertyMappingTest.cs
@@ -12,6 +12,8 @@ namespace ProgressOnderwijsUtils.Tests
         sealed record TestObject : ICopyable<TestObject>, IWrittenImplicitly
         {
             public DayOfWeek EnumIntProperty { get; set; }
+            public DateTimeKind Kind { get; set; }
+            public string? Unused { get; set; }
         }
 
         [Fact]

--- a/test/ProgressOnderwijsUtils.Tests/PropertyMappingTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/PropertyMappingTest.cs
@@ -224,5 +224,28 @@ namespace ProgressOnderwijsUtils.Tests
             PAssert.That(() => mappers.Map(objects).SequenceEqual(expectedAfterSecondMapper));
         }
 
+        [Fact]
+        public void GetIdMapper_returns_identity_for_unmapped()
+        {
+            var dayOfWeekMapper = PropertyMapper.CreateForFunc((DayOfWeek day) => (DayOfWeek)(((int)day + 1) % 7));
+
+            var (func, isMapped) = dayOfWeekMapper.GetIdMapper<DateTimeKind>();
+
+            PAssert.That(() => !isMapped);
+            PAssert.That(() => func(DateTimeKind.Local) == DateTimeKind.Local);
+        }
+
+        [Fact]
+        public void GetIdMapper_returns_relevant_func_for_mapped()
+        {
+            var mapper = PropertyMapper
+                .CreateForFunc((DayOfWeek day) => (DayOfWeek)(((int)day + 1) % 7))
+                .CloneWithExtraMappers(PropertyMapper.CreateForFunc((DateTimeKind kind) => (DateTimeKind)(((int)kind + 2) % 3)));
+
+            var (func, isMapped) = mapper.GetIdMapper<DateTimeKind>();
+
+            PAssert.That(() => isMapped);
+            PAssert.That(() => func(DateTimeKind.Local) == DateTimeKind.Utc);
+        }
     }
 }

--- a/test/ProgressOnderwijsUtils.Tests/PropertyMappingTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/PropertyMappingTest.cs
@@ -149,5 +149,46 @@ namespace ProgressOnderwijsUtils.Tests
 
             PAssert.That(() => mapped.Single().NullableProperty == null);
         }
+
+        [Fact]
+        public void MapProperties_werkt_voor_multiple_types()
+        {
+            var objects = new[] {
+                new TestObject {
+                    EnumIntProperty = DayOfWeek.Wednesday,
+                    Unused = "as",
+                    Kind = DateTimeKind.Local,
+                },
+                new TestObject {
+                    EnumIntProperty = DayOfWeek.Monday,
+                    Unused = "X",
+                    Kind = DateTimeKind.Unspecified,
+                },
+            };
+            var copy = objects.ArraySelect(o => o with { });
+
+            var mapped = PropertyMapper
+                .CreateForFunc((DayOfWeek day) => (DayOfWeek)(((int)day + 1) % 7))
+                .CloneWithExtraMappers(PropertyMapper.CreateForFunc((DateTimeKind kind) => (DateTimeKind)(((int)kind + 2) % 3)))
+                .Map(objects);
+
+            PAssert.That(() => objects.SequenceEqual(copy), "Original objects should not be changed");
+
+            var expected = new[] {
+                new TestObject {
+                    EnumIntProperty = DayOfWeek.Thursday,
+                    Unused = "as",
+                    Kind = DateTimeKind.Utc,
+                },
+                new TestObject {
+                    EnumIntProperty = DayOfWeek.Tuesday,
+                    Unused = "X",
+                    Kind = DateTimeKind.Local,
+                },
+            };
+
+            PAssert.That(() => mapped.SequenceEqual(expected));
+        }
+
     }
 }

--- a/test/ProgressOnderwijsUtils.Tests/PropertyMappingTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/PropertyMappingTest.cs
@@ -233,6 +233,7 @@ namespace ProgressOnderwijsUtils.Tests
 
             PAssert.That(() => !isMapped);
             PAssert.That(() => func(DateTimeKind.Local) == DateTimeKind.Local);
+            PAssert.That(() => dayOfWeekMapper.MapId(DateTimeKind.Local) == DateTimeKind.Local);
         }
 
         [Fact]
@@ -246,6 +247,7 @@ namespace ProgressOnderwijsUtils.Tests
 
             PAssert.That(() => isMapped);
             PAssert.That(() => func(DateTimeKind.Local) == DateTimeKind.Utc);
+            PAssert.That(() => mapper.MapId(DateTimeKind.Local) == DateTimeKind.Utc);
         }
     }
 }

--- a/test/ProgressOnderwijsUtils.Tests/PropertyMappingTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/PropertyMappingTest.cs
@@ -62,6 +62,20 @@ namespace ProgressOnderwijsUtils.Tests
         }
 
         [Fact]
+        public void MapProperties_Identity_map_doet_niks()
+        {
+            var objects = new[] {
+                new TestObject {
+                    EnumIntProperty = DayOfWeek.Wednesday,
+                },
+            };
+
+            var mapped = PropertyMapper.CreateForIdentityMap<DayOfWeek>().Map(objects);
+
+            PAssert.That(() => objects.SequenceEqual(mapped));
+        }
+
+        [Fact]
         public void MapProperties_werkt_niet_voor_multiple_mappers_van_zelfde_type()
         {
             var mappers = PropertyMapper.CreateForDictionary(new Dictionary<DayOfWeek, DayOfWeek> { [DayOfWeek.Wednesday] = DayOfWeek.Thursday, });

--- a/test/ProgressOnderwijsUtils.Tests/PropertyMappingTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/PropertyMappingTest.cs
@@ -76,6 +76,25 @@ namespace ProgressOnderwijsUtils.Tests
         }
 
         [Fact]
+        public void MapProperties_CreateForValue_ignores_input()
+        {
+            var objects = new[] {
+                new TestObject { Kind = DateTimeKind.Utc, EnumIntProperty = DayOfWeek.Thursday },
+                new TestObject { Kind = DateTimeKind.Local, EnumIntProperty = DayOfWeek.Friday, },
+                new TestObject { Kind = DateTimeKind.Unspecified, EnumIntProperty = DayOfWeek.Monday, },
+            };
+            var expected = new[] {
+                new TestObject { Kind = DateTimeKind.Unspecified, EnumIntProperty = DayOfWeek.Thursday },
+                new TestObject { Kind = DateTimeKind.Unspecified, EnumIntProperty = DayOfWeek.Friday, },
+                new TestObject { Kind = DateTimeKind.Unspecified, EnumIntProperty = DayOfWeek.Monday, },
+            };
+
+            var mapped = PropertyMapper.CreateForValue(DateTimeKind.Unspecified).Map(objects);
+
+            PAssert.That(() => mapped.SequenceEqual(expected));
+        }
+
+        [Fact]
         public void MapProperties_werkt_niet_voor_multiple_mappers_van_zelfde_type()
         {
             var mappers = PropertyMapper.CreateForDictionary(new Dictionary<DayOfWeek, DayOfWeek> { [DayOfWeek.Wednesday] = DayOfWeek.Thursday, });

--- a/test/ProgressOnderwijsUtils.Tests/PropertyMappingTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/PropertyMappingTest.cs
@@ -62,7 +62,7 @@ namespace ProgressOnderwijsUtils.Tests
         }
 
         [Fact]
-        public void MapProperties_werkt_niet_voor_multiple_mapper()
+        public void MapProperties_werkt_niet_voor_multiple_mappers_van_zelfde_type()
         {
             var mappers = PropertyMapper.CreateForDictionary(new Dictionary<DayOfWeek, DayOfWeek> { [DayOfWeek.Wednesday] = DayOfWeek.Thursday, });
 

--- a/test/ProgressOnderwijsUtils.Tests/PropertyMappingTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/PropertyMappingTest.cs
@@ -190,5 +190,39 @@ namespace ProgressOnderwijsUtils.Tests
             PAssert.That(() => mapped.SequenceEqual(expected));
         }
 
+        [Fact]
+        public void AddToPropertyMappers_werkt()
+        {
+            var objects = new[] {
+                new TestObject { EnumIntProperty = DayOfWeek.Wednesday, Kind = DateTimeKind.Local, },
+                new TestObject { EnumIntProperty = DayOfWeek.Monday, Kind = DateTimeKind.Unspecified, },
+            };
+            var original = objects.ArraySelect(o => o with { });
+            var firstMap = new SingleIdMapping<DayOfWeek>[] { new(DayOfWeek.Wednesday, DayOfWeek.Monday), new(DayOfWeek.Monday, DayOfWeek.Wednesday), };
+            var secondMap = new SingleIdMapping<DateTimeKind>[] { new(DateTimeKind.Local, DateTimeKind.Unspecified), new(DateTimeKind.Unspecified, DateTimeKind.Local), };
+
+            var mappers = new PropertyMappers();
+
+            PAssert.That(() => mappers.Map(objects).SequenceEqual(original), "Empty mapper does nothing");
+
+            _ = firstMap.AddToPropertyMappers(ref mappers);
+
+            var expectedAfterFirstMapper = new[] {
+                new TestObject { EnumIntProperty = DayOfWeek.Monday, Kind = DateTimeKind.Local, },
+                new TestObject { EnumIntProperty = DayOfWeek.Wednesday, Kind = DateTimeKind.Unspecified, },
+            };
+
+            PAssert.That(() => mappers.Map(objects).SequenceEqual(expectedAfterFirstMapper));
+
+            _ = secondMap.AddToPropertyMappers(ref mappers);
+
+            var expectedAfterSecondMapper = new[] {
+                new TestObject { EnumIntProperty = DayOfWeek.Monday, Kind = DateTimeKind.Unspecified, },
+                new TestObject { EnumIntProperty = DayOfWeek.Wednesday, Kind = DateTimeKind.Local, },
+            };
+
+            PAssert.That(() => mappers.Map(objects).SequenceEqual(expectedAfterSecondMapper));
+        }
+
     }
 }


### PR DESCRIPTION
So I can explicitly extract a single property type's mapping.

And expand test coverage