### PR TITLE
Various code cleanups designed to hopefully make tuple-returning SqlDataReader unpackers easier to implement.

### DIFF
--- a/src/ProgressOnderwijsUtils/Data/ColumnSort.cs
+++ b/src/ProgressOnderwijsUtils/Data/ColumnSort.cs
@@ -30,8 +30,7 @@ public readonly struct ColumnSort : IEquatable<ColumnSort>
 
     [Pure]
     public bool Equals(ColumnSort other)
-        => string.Equals(ColumnName, other.ColumnName, StringComparison.OrdinalIgnoreCase) &&
-            SortDirection == other.SortDirection;
+        => string.Equals(ColumnName, other.ColumnName, StringComparison.OrdinalIgnoreCase) && SortDirection == other.SortDirection;
 
     [Pure]
     public override bool Equals(object? obj)

--- a/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
+++ b/src/ProgressOnderwijsUtils/Data/OrderByColumns.cs
@@ -9,7 +9,7 @@ namespace ProgressOnderwijsUtils;
 /// ColumnSortOrder is een struct; zijn default waarde representeerd "geen sorteering".
 /// </summary>
 [Serializable]
-public struct OrderByColumns : IEquatable<OrderByColumns>
+public readonly struct OrderByColumns : IEquatable<OrderByColumns>
 {
     readonly ColumnSort[]? sortColumns;
 

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -55,7 +55,6 @@ public static class ParameterizedSqlObjectMapper
         => q.OfPocos<T>().Execute(sqlConn);
 
     internal static string UnpackingErrorMessage<T>(SqlDataReader? reader, int lastColumnRead)
-        where T : IWrittenImplicitly
     {
         if (reader?.IsClosed != false || lastColumnRead < 0) {
             return "";

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -364,12 +364,9 @@ public static class ParameterizedSqlObjectMapper
                     )) {
                     errors.Add($"Cannot resolve IDataReader column {cols[columnIndex]} in type {FriendlyName()}");
                 } else if (propertyFlags[propertyIndex].coveredByReaderColumn) {
-                    errors.Add($"The C# property {pocoProperties.PocoType.ToCSharpFriendlyTypeName()}.{member.Name} has already been mapped; are there two identically names columns?");
+                    errors.Add($"The C# property {FriendlyName()}.{member.Name} has already been mapped; are there two identically names columns?");
                 } else if (!IsSupportedType(member.DataType)) {
-                    errors.Add(
-                        "The C# property " + pocoProperties.PocoType.ToCSharpFriendlyTypeName() + "." + member.Name + " if of type " + member.DataType.ToCSharpFriendlyTypeName()
-                        + " which has no supported conversion from a DbDataReaderColumn."
-                    );
+                    errors.Add($"The C# property {FriendlyName()}.{member.Name} if of type {member.DataType.ToCSharpFriendlyTypeName()} which has no supported conversion from a DbDataReaderColumn.");
                 } else {
                     propertyFlags[propertyIndex].coveredByReaderColumn = true;
                     var variable = Expression.Variable(member.DataType, member.Name);

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -300,7 +300,7 @@ public static class ParameterizedSqlObjectMapper
             }
 
             static readonly Func<ColumnOrdering, (TRowReader<T> rowToPoco, IPocoProperty<T>[] unmappedProperties)> constructTRowReaderWithCols = columnOrdering => {
-                var (rowToPoco, unmappedProperties) = ConstructPocoTRowReader(columnOrdering, typeof(TRowReader<T>), PocoProperties<T>.Instance);
+                var (rowToPoco, unmappedProperties) = ConstructPocoTRowReader(columnOrdering.Cols, typeof(TRowReader<T>), PocoProperties<T>.Instance);
                 return (rowToPoco: (TRowReader<T>)rowToPoco, unmappedProperties.ArraySelect(o => (IPocoProperty<T>)o));
             };
         }
@@ -338,12 +338,11 @@ public static class ParameterizedSqlObjectMapper
             }
         }
 
-        public static (Delegate rowToPoco, IPocoProperty[] unmappedProperties) ConstructPocoTRowReader(ColumnOrdering columnOrdering, Type constructedTRowReaderType, IPocoProperties<IPocoProperty> pocoProperties)
+        public static (Delegate rowToPoco, IPocoProperty[] unmappedProperties) ConstructPocoTRowReader(string[] readerFieldOrder, Type constructedTRowReaderType, IPocoProperties<IPocoProperty> pocoProperties)
         {
-            var cols = columnOrdering.Cols;
             var dataReaderParamExpr = Expression.Parameter(typeof(TReader), "dataReader");
             var lastColumnReadParamExpr = Expression.Parameter(typeof(int).MakeByRefType(), "lastColumnRead");
-            var (constructRowExpr, unmappedProperties) = ReadAllFieldsExpression(dataReaderParamExpr, cols, lastColumnReadParamExpr, pocoProperties);
+            var (constructRowExpr, unmappedProperties) = ReadAllFieldsExpression(dataReaderParamExpr, readerFieldOrder, lastColumnReadParamExpr, pocoProperties);
             var rowToPocoParamExprs = new[] { dataReaderParamExpr, lastColumnReadParamExpr, };
             var rowToPocoLambda = Expression.Lambda(constructedTRowReaderType, constructRowExpr, "RowToPoco", rowToPocoParamExprs);
             return (rowToPoco: rowToPocoLambda.Compile(), unmappedProperties);

--- a/src/ProgressOnderwijsUtils/Data/PocoDataReader.cs
+++ b/src/ProgressOnderwijsUtils/Data/PocoDataReader.cs
@@ -36,10 +36,8 @@ public sealed class PocoDataReader<T> : DbDataReaderBase, IOptionalObjectListFor
     readonly IEnumerator<T> pocos;
     readonly IReadOnlyList<T>? objectsOrNull_ForDebugging;
     Optional current;
-    int rowsProcessed;
 
-    public int RowsProcessed
-        => rowsProcessed;
+    public int RowsProcessed { get; private set; }
 
     public PocoDataReader(IEnumerable<T> objects, CancellationToken cancellationToken)
     {
@@ -62,7 +60,7 @@ public sealed class PocoDataReader<T> : DbDataReaderBase, IOptionalObjectListFor
         var hasnext = pocos.MoveNext();
         if (hasnext) {
             current = new(pocos.Current);
-            rowsProcessed++;
+            RowsProcessed++;
         } else {
             current = Optional.Empty;
         }

--- a/src/ProgressOnderwijsUtils/Data/PocoDataReader.cs
+++ b/src/ProgressOnderwijsUtils/Data/PocoDataReader.cs
@@ -115,7 +115,7 @@ public sealed class PocoDataReader<T> : DbDataReaderBase, IOptionalObjectListFor
         //TypedNonNullableGetter is of type Func<T, _> such that typeof(_) == ColumnType - therefore cannot return nulls!
         public readonly Delegate TypedNonNullableGetter;
 
-        public ColumnInfo(IReadonlyPocoProperty<T> pocoProperty)
+        public ColumnInfo(IPocoProperty<T> pocoProperty)
         {
             var propertyType = pocoProperty.DataType;
             var pocoParameter = Expression.Parameter(typeof(T));

--- a/src/ProgressOnderwijsUtils/Data/SqlBatch.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlBatch.cs
@@ -25,7 +25,7 @@ public interface ITypedSqlCommand<out TQueryReturnValue>
     TQueryReturnValue Execute(SqlConnection conn);
 }
 
-public readonly struct NonQuerySqlCommand : IWithTimeout<NonQuerySqlCommand>
+public readonly record struct NonQuerySqlCommand : IWithTimeout<NonQuerySqlCommand>
 {
     public ParameterizedSql Sql { get; }
     public CommandTimeout CommandTimeout { get; }
@@ -57,7 +57,7 @@ public readonly struct NonQuerySqlCommand : IWithTimeout<NonQuerySqlCommand>
 /// <summary>
 /// Executes a DataTable-returning query op basis van het huidige commando met de huidige parameters
 /// </summary>
-public readonly struct DataTableSqlCommand : ITypedSqlCommand<DataTable>, IWithTimeout<DataTableSqlCommand>
+public readonly record struct DataTableSqlCommand : ITypedSqlCommand<DataTable>, IWithTimeout<DataTableSqlCommand>
 {
     public ParameterizedSql Sql { get; }
     public CommandTimeout CommandTimeout { get; }
@@ -89,7 +89,7 @@ public readonly struct DataTableSqlCommand : ITypedSqlCommand<DataTable>, IWithT
     }
 }
 
-public readonly struct ScalarSqlCommand<T> : ITypedSqlCommand<T?>, IWithTimeout<ScalarSqlCommand<T>>
+public readonly record struct ScalarSqlCommand<T> : ITypedSqlCommand<T?>, IWithTimeout<ScalarSqlCommand<T>>
 {
     public ParameterizedSql Sql { get; }
     public CommandTimeout CommandTimeout { get; }
@@ -114,7 +114,7 @@ public readonly struct ScalarSqlCommand<T> : ITypedSqlCommand<T?>, IWithTimeout<
     }
 }
 
-public readonly struct BuiltinsSqlCommand<T> : ITypedSqlCommand<T?[]>, IWithTimeout<BuiltinsSqlCommand<T>>
+public readonly record struct BuiltinsSqlCommand<T> : ITypedSqlCommand<T?[]>, IWithTimeout<BuiltinsSqlCommand<T>>
 {
     public ParameterizedSql Sql { get; }
     public CommandTimeout CommandTimeout { get; }
@@ -136,7 +136,7 @@ public readonly struct BuiltinsSqlCommand<T> : ITypedSqlCommand<T?[]>, IWithTime
     }
 }
 
-public readonly struct PocosSqlCommand<
+public readonly record struct PocosSqlCommand<
     [MeansImplicitUse(ImplicitUseKindFlags.Assign, ImplicitUseTargetFlags.WithMembers)]
     T
 > : ITypedSqlCommand<T[]>, IWithTimeout<PocosSqlCommand<T>>
@@ -179,7 +179,7 @@ public readonly struct PocosSqlCommand<
     }
 }
 
-public readonly struct EnumeratedObjectsSqlCommand<T> : ITypedSqlCommand<IEnumerable<T>>, IWithTimeout<EnumeratedObjectsSqlCommand<T>>
+public readonly record struct EnumeratedObjectsSqlCommand<T> : ITypedSqlCommand<IEnumerable<T>>, IWithTimeout<EnumeratedObjectsSqlCommand<T>>
     where T : IWrittenImplicitly
 {
     public ParameterizedSql Sql { get; }

--- a/src/ProgressOnderwijsUtils/Data/SqlBatch.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlBatch.cs
@@ -33,8 +33,8 @@ public readonly struct NonQuerySqlCommand : IWithTimeout<NonQuerySqlCommand>
     public NonQuerySqlCommand WithTimeout(CommandTimeout timeout)
         => new(Sql, timeout);
 
-    public NonQuerySqlCommand(ParameterizedSql sql, CommandTimeout timeout)
-        => (Sql, CommandTimeout) = (sql, timeout);
+    public NonQuerySqlCommand(ParameterizedSql Sql, CommandTimeout CommandTimeout)
+        => (this.Sql, this.CommandTimeout) = (Sql, CommandTimeout);
 
     public void Execute(SqlConnection conn)
         => Execute(conn, out _);
@@ -70,8 +70,8 @@ public readonly struct DataTableSqlCommand : ITypedSqlCommand<DataTable>, IWithT
     public DataTableSqlCommand WithMissingSchemaAction(MissingSchemaAction missingSchemaAction)
         => new(Sql, CommandTimeout, missingSchemaAction);
 
-    public DataTableSqlCommand(ParameterizedSql sql, CommandTimeout timeout, MissingSchemaAction missingSchemaAction)
-        => (Sql, CommandTimeout, MissingSchemaAction) = (sql, timeout, missingSchemaAction);
+    public DataTableSqlCommand(ParameterizedSql Sql, CommandTimeout CommandTimeout, MissingSchemaAction MissingSchemaAction)
+        => (this.Sql, this.CommandTimeout, this.MissingSchemaAction) = (Sql, CommandTimeout, MissingSchemaAction);
 
     [MustUseReturnValue]
     public DataTable Execute(SqlConnection conn)
@@ -94,8 +94,8 @@ public readonly struct ScalarSqlCommand<T> : ITypedSqlCommand<T?>, IWithTimeout<
     public ParameterizedSql Sql { get; }
     public CommandTimeout CommandTimeout { get; }
 
-    public ScalarSqlCommand(ParameterizedSql sql, CommandTimeout timeout)
-        => (Sql, CommandTimeout) = (sql, timeout);
+    public ScalarSqlCommand(ParameterizedSql Sql, CommandTimeout CommandTimeout)
+        => (this.Sql, this.CommandTimeout) = (Sql, CommandTimeout);
 
     public ScalarSqlCommand<T> WithTimeout(CommandTimeout timeout)
         => new(Sql, timeout);
@@ -119,8 +119,8 @@ public readonly struct BuiltinsSqlCommand<T> : ITypedSqlCommand<T?[]>, IWithTime
     public ParameterizedSql Sql { get; }
     public CommandTimeout CommandTimeout { get; }
 
-    public BuiltinsSqlCommand(ParameterizedSql sql, CommandTimeout timeout)
-        => (Sql, CommandTimeout) = (sql, timeout);
+    public BuiltinsSqlCommand(ParameterizedSql Sql, CommandTimeout CommandTimeout)
+        => (this.Sql, this.CommandTimeout) = (Sql, CommandTimeout);
 
     public BuiltinsSqlCommand<T> WithTimeout(CommandTimeout timeout)
         => new(Sql, timeout);
@@ -146,8 +146,8 @@ public readonly struct PocosSqlCommand<
     public CommandTimeout CommandTimeout { get; }
     public readonly FieldMappingMode FieldMapping;
 
-    public PocosSqlCommand(ParameterizedSql sql, CommandTimeout timeout, FieldMappingMode fieldMapping)
-        => (Sql, CommandTimeout, FieldMapping) = (sql, timeout, fieldMapping);
+    public PocosSqlCommand(ParameterizedSql Sql, CommandTimeout CommandTimeout, FieldMappingMode FieldMapping)
+        => (this.Sql, this.CommandTimeout, this.FieldMapping) = (Sql, CommandTimeout, FieldMapping);
 
     [UsefulToKeepAttribute("lib method")]
     public PocosSqlCommand<T> WithFieldMappingMode(FieldMappingMode fieldMapping)
@@ -186,8 +186,8 @@ public readonly struct EnumeratedObjectsSqlCommand<T> : ITypedSqlCommand<IEnumer
     public CommandTimeout CommandTimeout { get; }
     public readonly FieldMappingMode FieldMapping;
 
-    public EnumeratedObjectsSqlCommand(ParameterizedSql sql, CommandTimeout timeout, FieldMappingMode fieldMapping)
-        => (Sql, CommandTimeout, FieldMapping) = (sql, timeout, fieldMapping);
+    public EnumeratedObjectsSqlCommand(ParameterizedSql Sql, CommandTimeout CommandTimeout, FieldMappingMode FieldMapping)
+        => (this.Sql, this.CommandTimeout, this.FieldMapping) = (Sql, CommandTimeout, FieldMapping);
 
     public EnumeratedObjectsSqlCommand<T> WithTimeout(CommandTimeout timeout)
         => new(Sql, timeout, FieldMapping);

--- a/src/ProgressOnderwijsUtils/Data/SqlBatch.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlBatch.cs
@@ -28,7 +28,7 @@ public interface ITypedSqlCommand<out TQueryReturnValue>
 public readonly record struct NonQuerySqlCommand(ParameterizedSql Sql, CommandTimeout CommandTimeout) : IWithTimeout<NonQuerySqlCommand>
 {
     public NonQuerySqlCommand WithTimeout(CommandTimeout timeout)
-        => new(Sql, timeout);
+        => this with { CommandTimeout = timeout };
 
     public void Execute(SqlConnection conn)
         => Execute(conn, out _);
@@ -54,11 +54,11 @@ public readonly record struct NonQuerySqlCommand(ParameterizedSql Sql, CommandTi
 public readonly record struct DataTableSqlCommand(ParameterizedSql Sql, CommandTimeout CommandTimeout, MissingSchemaAction MissingSchemaAction) : ITypedSqlCommand<DataTable>, IWithTimeout<DataTableSqlCommand>
 {
     public DataTableSqlCommand WithTimeout(CommandTimeout timeout)
-        => new(Sql, timeout, MissingSchemaAction);
+        => this with { CommandTimeout = timeout };
 
     [UsefulToKeep("lib method")]
     public DataTableSqlCommand WithMissingSchemaAction(MissingSchemaAction missingSchemaAction)
-        => new(Sql, CommandTimeout, missingSchemaAction);
+        => this with { MissingSchemaAction = missingSchemaAction };
 
     [MustUseReturnValue]
     public DataTable Execute(SqlConnection conn)
@@ -79,7 +79,7 @@ public readonly record struct DataTableSqlCommand(ParameterizedSql Sql, CommandT
 public readonly record struct ScalarSqlCommand<T>(ParameterizedSql Sql, CommandTimeout CommandTimeout) : ITypedSqlCommand<T?>, IWithTimeout<ScalarSqlCommand<T>>
 {
     public ScalarSqlCommand<T> WithTimeout(CommandTimeout timeout)
-        => new(Sql, timeout);
+        => this with { CommandTimeout = timeout };
 
     [MustUseReturnValue]
     public T? Execute(SqlConnection conn)
@@ -98,7 +98,7 @@ public readonly record struct ScalarSqlCommand<T>(ParameterizedSql Sql, CommandT
 public readonly record struct BuiltinsSqlCommand<T>(ParameterizedSql Sql, CommandTimeout CommandTimeout) : ITypedSqlCommand<T?[]>, IWithTimeout<BuiltinsSqlCommand<T>>
 {
     public BuiltinsSqlCommand<T> WithTimeout(CommandTimeout timeout)
-        => new(Sql, timeout);
+        => this with { CommandTimeout = timeout };
 
     public T?[] Execute(SqlConnection conn)
     {
@@ -119,13 +119,13 @@ public readonly record struct PocosSqlCommand<
 {
     [UsefulToKeepAttribute("lib method")]
     public PocosSqlCommand<T> WithFieldMappingMode(FieldMappingMode fieldMapping)
-        => new(Sql, CommandTimeout, fieldMapping);
+        => this with { FieldMapping = fieldMapping };
 
     public EnumeratedObjectsSqlCommand<T> ToLazilyEnumeratedCommand()
         => new(Sql, CommandTimeout, FieldMapping);
 
     public PocosSqlCommand<T> WithTimeout(CommandTimeout commandTimeout)
-        => new(Sql, commandTimeout, FieldMapping);
+        => this with { CommandTimeout = commandTimeout };
 
     public T[] Execute(SqlConnection conn)
     {
@@ -151,11 +151,11 @@ public readonly record struct EnumeratedObjectsSqlCommand<T>(ParameterizedSql Sq
     where T : IWrittenImplicitly
 {
     public EnumeratedObjectsSqlCommand<T> WithTimeout(CommandTimeout timeout)
-        => new(Sql, timeout, FieldMapping);
+        => this with { CommandTimeout = timeout };
 
     [UsefulToKeep("lib method")]
     public EnumeratedObjectsSqlCommand<T> WithFieldMappingMode(FieldMappingMode fieldMapping)
-        => new(Sql, CommandTimeout, fieldMapping);
+        => this with { FieldMapping = fieldMapping };
 
     [UsefulToKeep("lib method")]
     public PocosSqlCommand<T> ToEagerlyEnumeratedCommand()

--- a/src/ProgressOnderwijsUtils/Data/SqlBatch.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlBatch.cs
@@ -25,16 +25,10 @@ public interface ITypedSqlCommand<out TQueryReturnValue>
     TQueryReturnValue Execute(SqlConnection conn);
 }
 
-public readonly record struct NonQuerySqlCommand : IWithTimeout<NonQuerySqlCommand>
+public readonly record struct NonQuerySqlCommand(ParameterizedSql Sql, CommandTimeout CommandTimeout) : IWithTimeout<NonQuerySqlCommand>
 {
-    public ParameterizedSql Sql { get; }
-    public CommandTimeout CommandTimeout { get; }
-
     public NonQuerySqlCommand WithTimeout(CommandTimeout timeout)
         => new(Sql, timeout);
-
-    public NonQuerySqlCommand(ParameterizedSql Sql, CommandTimeout CommandTimeout)
-        => (this.Sql, this.CommandTimeout) = (Sql, CommandTimeout);
 
     public void Execute(SqlConnection conn)
         => Execute(conn, out _);
@@ -57,21 +51,14 @@ public readonly record struct NonQuerySqlCommand : IWithTimeout<NonQuerySqlComma
 /// <summary>
 /// Executes a DataTable-returning query op basis van het huidige commando met de huidige parameters
 /// </summary>
-public readonly record struct DataTableSqlCommand : ITypedSqlCommand<DataTable>, IWithTimeout<DataTableSqlCommand>
+public readonly record struct DataTableSqlCommand(ParameterizedSql Sql, CommandTimeout CommandTimeout, MissingSchemaAction MissingSchemaAction) : ITypedSqlCommand<DataTable>, IWithTimeout<DataTableSqlCommand>
 {
-    public ParameterizedSql Sql { get; }
-    public CommandTimeout CommandTimeout { get; }
-    public MissingSchemaAction MissingSchemaAction { get; }
-
     public DataTableSqlCommand WithTimeout(CommandTimeout timeout)
         => new(Sql, timeout, MissingSchemaAction);
 
     [UsefulToKeep("lib method")]
     public DataTableSqlCommand WithMissingSchemaAction(MissingSchemaAction missingSchemaAction)
         => new(Sql, CommandTimeout, missingSchemaAction);
-
-    public DataTableSqlCommand(ParameterizedSql Sql, CommandTimeout CommandTimeout, MissingSchemaAction MissingSchemaAction)
-        => (this.Sql, this.CommandTimeout, this.MissingSchemaAction) = (Sql, CommandTimeout, MissingSchemaAction);
 
     [MustUseReturnValue]
     public DataTable Execute(SqlConnection conn)
@@ -89,14 +76,8 @@ public readonly record struct DataTableSqlCommand : ITypedSqlCommand<DataTable>,
     }
 }
 
-public readonly record struct ScalarSqlCommand<T> : ITypedSqlCommand<T?>, IWithTimeout<ScalarSqlCommand<T>>
+public readonly record struct ScalarSqlCommand<T>(ParameterizedSql Sql, CommandTimeout CommandTimeout) : ITypedSqlCommand<T?>, IWithTimeout<ScalarSqlCommand<T>>
 {
-    public ParameterizedSql Sql { get; }
-    public CommandTimeout CommandTimeout { get; }
-
-    public ScalarSqlCommand(ParameterizedSql Sql, CommandTimeout CommandTimeout)
-        => (this.Sql, this.CommandTimeout) = (Sql, CommandTimeout);
-
     public ScalarSqlCommand<T> WithTimeout(CommandTimeout timeout)
         => new(Sql, timeout);
 
@@ -114,14 +95,8 @@ public readonly record struct ScalarSqlCommand<T> : ITypedSqlCommand<T?>, IWithT
     }
 }
 
-public readonly record struct BuiltinsSqlCommand<T> : ITypedSqlCommand<T?[]>, IWithTimeout<BuiltinsSqlCommand<T>>
+public readonly record struct BuiltinsSqlCommand<T>(ParameterizedSql Sql, CommandTimeout CommandTimeout) : ITypedSqlCommand<T?[]>, IWithTimeout<BuiltinsSqlCommand<T>>
 {
-    public ParameterizedSql Sql { get; }
-    public CommandTimeout CommandTimeout { get; }
-
-    public BuiltinsSqlCommand(ParameterizedSql Sql, CommandTimeout CommandTimeout)
-        => (this.Sql, this.CommandTimeout) = (Sql, CommandTimeout);
-
     public BuiltinsSqlCommand<T> WithTimeout(CommandTimeout timeout)
         => new(Sql, timeout);
 
@@ -139,16 +114,9 @@ public readonly record struct BuiltinsSqlCommand<T> : ITypedSqlCommand<T?[]>, IW
 public readonly record struct PocosSqlCommand<
     [MeansImplicitUse(ImplicitUseKindFlags.Assign, ImplicitUseTargetFlags.WithMembers)]
     T
-> : ITypedSqlCommand<T[]>, IWithTimeout<PocosSqlCommand<T>>
+>(ParameterizedSql Sql, CommandTimeout CommandTimeout, FieldMappingMode FieldMapping) : ITypedSqlCommand<T[]>, IWithTimeout<PocosSqlCommand<T>>
     where T : IWrittenImplicitly
 {
-    public ParameterizedSql Sql { get; }
-    public CommandTimeout CommandTimeout { get; }
-    public readonly FieldMappingMode FieldMapping;
-
-    public PocosSqlCommand(ParameterizedSql Sql, CommandTimeout CommandTimeout, FieldMappingMode FieldMapping)
-        => (this.Sql, this.CommandTimeout, this.FieldMapping) = (Sql, CommandTimeout, FieldMapping);
-
     [UsefulToKeepAttribute("lib method")]
     public PocosSqlCommand<T> WithFieldMappingMode(FieldMappingMode fieldMapping)
         => new(Sql, CommandTimeout, fieldMapping);
@@ -179,16 +147,9 @@ public readonly record struct PocosSqlCommand<
     }
 }
 
-public readonly record struct EnumeratedObjectsSqlCommand<T> : ITypedSqlCommand<IEnumerable<T>>, IWithTimeout<EnumeratedObjectsSqlCommand<T>>
+public readonly record struct EnumeratedObjectsSqlCommand<T>(ParameterizedSql Sql, CommandTimeout CommandTimeout, FieldMappingMode FieldMapping) : ITypedSqlCommand<IEnumerable<T>>, IWithTimeout<EnumeratedObjectsSqlCommand<T>>
     where T : IWrittenImplicitly
 {
-    public ParameterizedSql Sql { get; }
-    public CommandTimeout CommandTimeout { get; }
-    public readonly FieldMappingMode FieldMapping;
-
-    public EnumeratedObjectsSqlCommand(ParameterizedSql Sql, CommandTimeout CommandTimeout, FieldMappingMode FieldMapping)
-        => (this.Sql, this.CommandTimeout, this.FieldMapping) = (Sql, CommandTimeout, FieldMapping);
-
     public EnumeratedObjectsSqlCommand<T> WithTimeout(CommandTimeout timeout)
         => new(Sql, timeout, FieldMapping);
 

--- a/src/ProgressOnderwijsUtils/Data/SqlBatch.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlBatch.cs
@@ -117,7 +117,7 @@ public readonly record struct PocosSqlCommand<
 >(ParameterizedSql Sql, CommandTimeout CommandTimeout, FieldMappingMode FieldMapping) : ITypedSqlCommand<T[]>, IWithTimeout<PocosSqlCommand<T>>
     where T : IWrittenImplicitly
 {
-    [UsefulToKeepAttribute("lib method")]
+    [UsefulToKeep("lib method")]
     public PocosSqlCommand<T> WithFieldMappingMode(FieldMappingMode fieldMapping)
         => this with { FieldMapping = fieldMapping };
 

--- a/src/ProgressOnderwijsUtils/Pocos/PocoProperties.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/PocoProperties.cs
@@ -13,13 +13,11 @@ public sealed class PocoProperties<T> : IPocoProperties<IPocoProperty<T>>
     where T : IPoco
 {
     readonly IPocoProperty<T>[] Properties;
-    readonly IReadOnlyDictionary<string, int> indexByName;
 
     public Type PocoType
         => typeof(T);
 
-    public IReadOnlyDictionary<string, int> IndexByName
-        => indexByName;
+    public IReadOnlyDictionary<string, int> IndexByName { get; }
 
     public static readonly PocoProperties<T> Instance = new();
 
@@ -36,11 +34,11 @@ public sealed class PocoProperties<T> : IPocoProperties<IPocoProperty<T>>
         foreach (var property in Properties) { //perf:avoid LINQ.
             dictionary.Add(property.Name, property.Index);
         }
-        indexByName = dictionary;
+        IndexByName = dictionary;
     }
 
     public IPocoProperty<T> GetByName(string name)
-        => Properties[indexByName[name]];
+        => Properties[IndexByName[name]];
 
     public int Count
         => Properties.Length;
@@ -60,7 +58,7 @@ public sealed class PocoProperties<T> : IPocoProperties<IPocoProperty<T>>
     public IPocoProperty<T> GetByExpression<TProp>(Expression<Func<T, TProp>> propertyExpression)
     {
         var memberInfo = PocoUtils.GetMemberInfo(propertyExpression);
-        if (indexByName.TryGetValue(memberInfo.Name, out var propIdx)) {
+        if (IndexByName.TryGetValue(memberInfo.Name, out var propIdx)) {
             var prop = Properties[propIdx];
             if (prop.PropertyInfo == memberInfo) {
                 return prop;

--- a/src/ProgressOnderwijsUtils/Pocos/PocoProperties.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/PocoProperties.cs
@@ -10,7 +10,6 @@ public interface IPocoProperties<out T> : IReadOnlyList<T>
 }
 
 public sealed class PocoProperties<T> : IPocoProperties<IPocoProperty<T>>
-    where T : IPoco
 {
     readonly IPocoProperty<T>[] Properties;
 

--- a/src/ProgressOnderwijsUtils/Pocos/PocoProperty.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/PocoProperty.cs
@@ -29,13 +29,11 @@ public interface IPocoProperty
     int Index { get; }
 }
 
-public interface IReadonlyPocoProperty<in TOwner> : IPocoProperty
+
+public interface IPocoProperty<TOwner> : IPocoProperty
 {
     Func<TOwner, object?>? Getter { get; }
-}
 
-public interface IPocoProperty<TOwner> : IReadonlyPocoProperty<TOwner>
-{
     Setter<TOwner>? Setter { get; }
 }
 

--- a/src/ProgressOnderwijsUtils/Pocos/PocoUtils.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/PocoUtils.cs
@@ -24,7 +24,7 @@ public static class PocoUtils
     {
         [UsefulToKeep("library method for getting base-class poco-property")]
         [Pure]
-        public static IReadonlyPocoProperty<TPoco> Get<TParent, T>(Expression<Func<TParent, T>> propertyExpression)
+        public static IPocoProperty<TPoco> Get<TParent, T>(Expression<Func<TParent, T>> propertyExpression)
         {
             var memberInfo = GetMemberInfo(propertyExpression);
             if (typeof(TParent).IsClass || typeof(TParent) == typeof(TPoco)) {

--- a/src/ProgressOnderwijsUtils/Pocos/PocoUtils.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/PocoUtils.cs
@@ -8,7 +8,6 @@ public static class PocoUtils
     public static IPocoProperties<IPocoProperty> GetProperties(this IPoco poco)
         => GetCache(poco.GetType());
 
-    // ReSharper disable once UnusedParameter.Global
     [Pure]
     public static PocoProperties<T> GetProperties<T>()
         where T : IPoco

--- a/src/ProgressOnderwijsUtils/Pocos/PocoUtils.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/PocoUtils.cs
@@ -6,20 +6,17 @@ public static class PocoUtils
 {
     [Pure]
     public static IPocoProperties<IPocoProperty> GetProperties(this IPoco poco)
-        => GetCache(poco.GetType());
+        => GetProperties(poco.GetType());
 
     [Pure]
     public static PocoProperties<T> GetProperties<T>()
-        where T : IPoco
         => PocoProperties<T>.Instance;
 
     [Pure]
     public static IPocoProperty<TPoco> GetByExpression<TPoco, T>(Expression<Func<TPoco, T>> propertyExpression)
-        where TPoco : IPoco
         => PocoProperties<TPoco>.Instance.GetByExpression(propertyExpression);
 
     public static class GetByInheritedExpression<TPoco>
-        where TPoco : IPoco
     {
         [UsefulToKeep("library method for getting base-class poco-property")]
         [Pure]
@@ -92,20 +89,9 @@ public static class PocoUtils
         => bodyExpr is UnaryExpression unaryExpression && unaryExpression.NodeType == ExpressionType.Convert ? unaryExpression.Operand : bodyExpr;
 
     [Pure]
-    public static IReadOnlyList<IPocoProperty> GetProperties(Type t)
-    {
-        if (!typeof(IPoco).IsAssignableFrom(t)) {
-            throw new InvalidOperationException($"Can't get poco-properties from type {t}, it's not a {typeof(IPoco)}");
-        }
-        while (t.BaseType != null && !t.BaseType.IsAbstract && typeof(IPoco).IsAssignableFrom(t.BaseType)) {
-            t = t.BaseType;
-        }
-        return GetCache(t);
-    }
+    public static IPocoProperties<IPocoProperty> GetProperties(Type t)
+        => memoizedGetProperties(t);
 
-    static readonly MethodInfo genGetCache = Utils.F(GetProperties<IPoco>).Method.GetGenericMethodDefinition();
-
-    [Pure]
-    static IPocoProperties<IPocoProperty> GetCache(Type t)
-        => (IPocoProperties<IPocoProperty>)genGetCache.MakeGenericMethod(t).Invoke(null, null)!;
+    static readonly MethodInfo genericMethodInfo_GetProperties = Utils.F(GetProperties<object>).Method.GetGenericMethodDefinition();
+    static readonly Func<Type, IPocoProperties<IPocoProperty>> memoizedGetProperties = Utils.F((Type t) => (IPocoProperties<IPocoProperty>)genericMethodInfo_GetProperties.MakeGenericMethod(t).Invoke(null, null)!).ThreadSafeMemoize();
 }


### PR DESCRIPTION
In particular, lift restriction on IPocoProperties that it can only return information for IPoco subtypes.

Also make the INestableSql implementations a little easier to copy-paste, since that's what I'm about to do...