### PR TITLE
Add COOP and COEP headers

### DIFF
--- a/src/ProgressOnderwijsUtils.AspNetCore/ProgressOnderwijsUtils.AspNetCore.csproj
+++ b/src/ProgressOnderwijsUtils.AspNetCore/ProgressOnderwijsUtils.AspNetCore.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup>
-    <Version>6.0.0</Version>
+    <Version>7.0.0</Version>
     <Title>ProgressOnderwijsUtils.AspNetCore</Title>
-    <Description>ProgressOnderwijs utility methods+classes for asp.net core.</Description>
+    <Description>Add Cross-Origin-Embedder-Policy and Cross-Origin-Opener-Policy to the default set of headers set.</Description>
     <PackageReleaseNotes>Bump dependency version to .net 6</PackageReleaseNotes>
     <PackageTags>ProgressOnderwijs</PackageTags>
     <TargetFramework>net6.0</TargetFramework>

--- a/src/ProgressOnderwijsUtils.AspNetCore/SecurityHeadersMiddleware.cs
+++ b/src/ProgressOnderwijsUtils.AspNetCore/SecurityHeadersMiddleware.cs
@@ -19,11 +19,9 @@ public sealed class SecurityHeadersMiddleware
         if (options.ContentSecurityPolicy != null) {
             context.Response.Headers["Content-Security-Policy"] = options.ContentSecurityPolicy;
         }
-
         if (options.ReferrerPolicy != null) {
             context.Response.Headers["Referrer-Policy"] = options.ReferrerPolicy;
         }
-
         if (options.XContentTypeOptions != null) {
             context.Response.Headers["X-Content-Type-Options"] = options.XContentTypeOptions;
         }

--- a/src/ProgressOnderwijsUtils.AspNetCore/SecurityHeadersMiddleware.cs
+++ b/src/ProgressOnderwijsUtils.AspNetCore/SecurityHeadersMiddleware.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
 
 namespace ProgressOnderwijsUtils.AspNetCore;
 
@@ -17,13 +18,13 @@ public sealed class SecurityHeadersMiddleware
     public Task Invoke(HttpContext context)
     {
         if (options.ContentSecurityPolicy != null) {
-            context.Response.Headers["Content-Security-Policy"] = options.ContentSecurityPolicy;
+            context.Response.Headers[HeaderNames.ContentSecurityPolicy] = options.ContentSecurityPolicy;
         }
         if (options.ReferrerPolicy != null) {
             context.Response.Headers["Referrer-Policy"] = options.ReferrerPolicy;
         }
         if (options.XContentTypeOptions != null) {
-            context.Response.Headers["X-Content-Type-Options"] = options.XContentTypeOptions;
+            context.Response.Headers[HeaderNames.XContentTypeOptions] = options.XContentTypeOptions;
         }
 
         return next(context);

--- a/src/ProgressOnderwijsUtils.AspNetCore/SecurityHeadersMiddleware.cs
+++ b/src/ProgressOnderwijsUtils.AspNetCore/SecurityHeadersMiddleware.cs
@@ -26,6 +26,12 @@ public sealed class SecurityHeadersMiddleware
         if (options.XContentTypeOptions != null) {
             context.Response.Headers[HeaderNames.XContentTypeOptions] = options.XContentTypeOptions;
         }
+        if (options.ReferrerPolicy != null) {
+            context.Response.Headers["Cross-Origin-Embedder-Policy"] = options.CrossOriginEmbedderPolicy;
+        }
+        if (options.ReferrerPolicy != null) {
+            context.Response.Headers["Cross-Origin-Opener-Policy"] = options.CrossOriginOpenerPolicy;
+        }
 
         return next(context);
     }

--- a/src/ProgressOnderwijsUtils.AspNetCore/SecurityHeadersMiddlewareOptions.cs
+++ b/src/ProgressOnderwijsUtils.AspNetCore/SecurityHeadersMiddlewareOptions.cs
@@ -1,8 +1,8 @@
 namespace ProgressOnderwijsUtils.AspNetCore;
 
-public sealed class SecurityHeadersMiddlewareOptions
+public sealed record SecurityHeadersMiddlewareOptions
 {
-    public string? ContentSecurityPolicy { get; set; } = "object-src 'self'; script-src 'self';";
-    public string? ReferrerPolicy { get; set; } = "same-origin";
-    public string? XContentTypeOptions { get; set; } = "nosniff";
+    public string? ContentSecurityPolicy { get; init; } = "object-src 'self'; script-src 'self';";
+    public string? ReferrerPolicy { get; init; } = "same-origin";
+    public string? XContentTypeOptions { get; init; } = "nosniff";
 }

--- a/src/ProgressOnderwijsUtils.AspNetCore/SecurityHeadersMiddlewareOptions.cs
+++ b/src/ProgressOnderwijsUtils.AspNetCore/SecurityHeadersMiddlewareOptions.cs
@@ -5,4 +5,6 @@ public sealed record SecurityHeadersMiddlewareOptions
     public string? ContentSecurityPolicy { get; init; } = "object-src 'self'; script-src 'self';";
     public string? ReferrerPolicy { get; init; } = "same-origin";
     public string? XContentTypeOptions { get; init; } = "nosniff";
+    public string? CrossOriginEmbedderPolicy { get; init; } = "require-corp";
+    public string? CrossOriginOpenerPolicy { get; init; } = "same-origin";
 }


### PR DESCRIPTION
Use as-strict-as-possible settings by default

See also:
 - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy
 - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy

That way, we don't need to be quite as careful on a case-by-case basis.