### PR TITLE
fix internal setters

### DIFF
--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -404,7 +404,7 @@ public static class ParameterizedSqlObjectMapper
         public static (BlockExpression constructRowExpr, string[] unmappedProperties) ReadAllFieldsExpression(ParameterExpression dataReaderParamExpr, string[] cols, ParameterExpression lastColumnReadParamExpr, Dictionary<string, (MemberInfo Member, Type DataType)> pocoProperties, Type rowType)
         {
             static bool CanWrite(MemberInfo member)
-                => member is not PropertyInfo { CanWrite: false, };
+                => member is not PropertyInfo pi || pi.CanWrite && pi.SetMethod?.IsPublic == true;
             var statements = new List<Expression>(2 + cols.Length * 2);
 
             var propertyFlags = new Dictionary<MemberInfo, MemberMapping>();

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>85.1.0</Version>
-    <PackageReleaseNotes>Added ParameterizedSql.ReadTuples. Ignore [NotMapped] properties in ParameterizedSql.ReadPocos.</PackageReleaseNotes>
+    <Version>85.1.1</Version>
+    <PackageReleaseNotes>Ignore properties with internal setters in ParameterizedSql.ReadPocos (revert unintentional change from 85.1.0).</PackageReleaseNotes>
 
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>

--- a/test/ProgressOnderwijsUtils.Tests/Data/PocoPropertyConvertibleLoaderTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/PocoPropertyConvertibleLoaderTest.cs
@@ -64,6 +64,15 @@ public sealed class PocoPropertyConvertibleLoaderTest : TransactedLocalConnectio
         public int SomeUnmappedValue { get; internal set; }
     }
 
+    public sealed class BlaOk3_partially_constructor_mapped : IWrittenImplicitly, IReadImplicitly
+    {
+        public CustomBla Bla2 { get; set; }
+        public string? Bla { get; internal set; }
+
+        public BlaOk3_partially_constructor_mapped(string? bla)
+            => Bla = bla;
+    }
+
     public sealed record BlaOk4 : IWrittenImplicitly, IReadImplicitly
     {
         public int Id { get; set; }
@@ -134,7 +143,6 @@ public sealed class PocoPropertyConvertibleLoaderTest : TransactedLocalConnectio
         PAssert.That(() => SampleObjects.Select(s => s.Bla2).SequenceEqual(fromDb.Select(x => x.Bla2.AsString)));
     }
 
-    
     [Fact]
     public void PocoMapperIgnores_properties_with_internal_setters()
     {
@@ -145,6 +153,19 @@ public sealed class PocoPropertyConvertibleLoaderTest : TransactedLocalConnectio
 
         var fromDb = SQL($"select Bla2 from #MyTable order by Id").ReadPocos<BlaOk3_with_unmapped2>(Connection);
         PAssert.That(() => SampleObjects.Select(s => s.Bla2).SequenceEqual(fromDb.Select(x => x.Bla2.AsString)));
+    }
+
+    [Fact]
+    public void PocoMapper_supports_properties_with_internal_setters_when_initializable_via_constructor()
+    {
+        PAssert.That(() => new CustomBla("aap").AsString == "aap");
+
+        var target = CreateTempTable();
+        SampleObjects.BulkCopyToSqlServer(Connection, target);
+
+        var fromDb = SQL($"select Bla2, Bla from #MyTable order by Id").ReadPocos<BlaOk3_partially_constructor_mapped>(Connection);
+        PAssert.That(() => SampleObjects.Select(s => s.Bla2).SequenceEqual(fromDb.Select(x => x.Bla2.AsString)));
+        PAssert.That(() => SampleObjects.Select(s => s.Bla).SequenceEqual(fromDb.Select(x => x.Bla)));
     }
 
     [Fact]

--- a/test/ProgressOnderwijsUtils.Tests/Data/PocoPropertyConvertibleLoaderTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/PocoPropertyConvertibleLoaderTest.cs
@@ -58,6 +58,12 @@ public sealed class PocoPropertyConvertibleLoaderTest : TransactedLocalConnectio
         public int SomeUnmappedValue { get; set; }
     }
 
+    public sealed record BlaOk3_with_unmapped2 : IWrittenImplicitly, IReadImplicitly
+    {
+        public CustomBla Bla2 { get; set; }
+        public int SomeUnmappedValue { get; internal set; }
+    }
+
     public sealed record BlaOk4 : IWrittenImplicitly, IReadImplicitly
     {
         public int Id { get; set; }
@@ -128,6 +134,18 @@ public sealed class PocoPropertyConvertibleLoaderTest : TransactedLocalConnectio
         PAssert.That(() => SampleObjects.Select(s => s.Bla2).SequenceEqual(fromDb.Select(x => x.Bla2.AsString)));
     }
 
+    
+    [Fact]
+    public void PocoMapperIgnores_properties_with_internal_setters()
+    {
+        PAssert.That(() => new CustomBla("aap").AsString == "aap");
+
+        var target = CreateTempTable();
+        SampleObjects.BulkCopyToSqlServer(Connection, target);
+
+        var fromDb = SQL($"select Bla2 from #MyTable order by Id").ReadPocos<BlaOk3_with_unmapped2>(Connection);
+        PAssert.That(() => SampleObjects.Select(s => s.Bla2).SequenceEqual(fromDb.Select(x => x.Bla2.AsString)));
+    }
 
     [Fact]
     public void PocoSupportsCustomObject_multiple_properties()

--- a/test/ProgressOnderwijsUtils.Tests/EnumerableExtensionsTests.cs
+++ b/test/ProgressOnderwijsUtils.Tests/EnumerableExtensionsTests.cs
@@ -77,6 +77,7 @@ public sealed class EnumerableExtensionsTests
         PAssert.That(() => default(int[]).EmptyIfNull().SequenceEqual(new int[] { }));
         PAssert.That(() => default(int[]) == null);
         // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalse
         PAssert.That(() => default(int[]) != default(int[]).EmptyIfNull());
         var arr = new[] { 0, 1, 2, };
         PAssert.That(() => arr.EmptyIfNull() == arr);


### PR DESCRIPTION
Regression in #672 

We probably not actually _need_ this behavior, but it's how it used to work, and changing consumers is more hassle than retaining the behavior.