### PR TITLE
Benchtimer now excludes the two most deviating measurements.

### DIFF
--- a/src/ProgressOnderwijsUtils/BenchTimer.cs
+++ b/src/ProgressOnderwijsUtils/BenchTimer.cs
@@ -16,8 +16,7 @@ public static class BenchTimer
         var times = Enumerable.Range(0, numRuns)
             .Select(_ => Time(a))
             .OrderBy(t => t)
-            .Skip(1)
-            .SkipLast(1)
+            .SkipLast(2)
             .ToArray();
 
         return new(times.First(), times.Last(), times[numRuns / 2], TimeSpan.FromTicks((long)Math.Round(times.Average(time => time.Ticks))));

--- a/src/ProgressOnderwijsUtils/BenchTimer.cs
+++ b/src/ProgressOnderwijsUtils/BenchTimer.cs
@@ -4,27 +4,41 @@ public static class BenchTimer
 {
     public sealed record BenchMark(TimeSpan Min, TimeSpan Max, TimeSpan Median, TimeSpan Mean);
 
-    public static BenchMark Time(Action a, int numRuns)
+    /// <summary>
+    /// Run an action numRuns times and calculate benchmark on the elapsed times.
+    /// </summary>
+    /// <param name="action">The action to measure</param>
+    /// <param name="numRuns">The number if times the action is measured</param>
+    /// <param name="numOutliers">The number of slowest runs that will be excluded from the mean and median results.</param>
+    public static BenchMark Time(Action action, int numRuns, int numOutliers)
     {
-        if (numRuns < 5) {
-            throw new ArgumentException("Need to test for at least 5 runs", nameof(numRuns));
+        if (numRuns < 1) {
+            throw new ArgumentException("Need to test for at least 1 run", nameof(numRuns));
         }
-        if (numRuns % 2 == 0) {
+        if (numRuns <= numOutliers) {
+            throw new ArgumentException("Need to determine mean and median on at least 1 run", nameof(numRuns));
+        }
+        if ((numRuns - numOutliers) % 2 == 0) {
             throw new ArgumentException("Need to test an odd number of runs", nameof(numRuns));
         }
 
         var times = Enumerable.Range(0, numRuns)
-            .Select(_ => Time(a))
+            .Select(_ => Time(action))
             .OrderBy(t => t)
             .ToArray();
 
-        return new(times.First(), times.Last(), times.SkipLast(2).ToArray()[numRuns / 2], TimeSpan.FromTicks((long)Math.Round(times.SkipLast(2).Average(time => time.Ticks))));
+        return new(
+            times.First(),
+            times.Last(),
+            times.SkipLast(numOutliers).ToArray()[(numRuns - numOutliers) / 2],
+            TimeSpan.FromTicks((long)Math.Round(times.SkipLast(numOutliers).Average(time => time.Ticks)))
+        );
     }
 
-    public static TimeSpan Time(Action a)
+    public static TimeSpan Time(Action action)
     {
         var timer = Stopwatch.StartNew();
-        a();
+        action();
         return timer.Elapsed;
     }
 }

--- a/src/ProgressOnderwijsUtils/BenchTimer.cs
+++ b/src/ProgressOnderwijsUtils/BenchTimer.cs
@@ -16,10 +16,9 @@ public static class BenchTimer
         var times = Enumerable.Range(0, numRuns)
             .Select(_ => Time(a))
             .OrderBy(t => t)
-            .SkipLast(2)
             .ToArray();
 
-        return new(times.First(), times.Last(), times[numRuns / 2], TimeSpan.FromTicks((long)Math.Round(times.Average(time => time.Ticks))));
+        return new(times.First(), times.Last(), times.SkipLast(2).ToArray()[numRuns / 2], TimeSpan.FromTicks((long)Math.Round(times.SkipLast(2).Average(time => time.Ticks))));
     }
 
     public static TimeSpan Time(Action a)

--- a/src/ProgressOnderwijsUtils/BenchTimer.cs
+++ b/src/ProgressOnderwijsUtils/BenchTimer.cs
@@ -6,8 +6,8 @@ public static class BenchTimer
 
     public static BenchMark Time(Action a, int numRuns)
     {
-        if (numRuns < 1) {
-            throw new ArgumentException("Need to test for at least 1 run", nameof(numRuns));
+        if (numRuns < 5) {
+            throw new ArgumentException("Need to test for at least 5 runs", nameof(numRuns));
         }
         if (numRuns % 2 == 0) {
             throw new ArgumentException("Need to test an odd number of runs", nameof(numRuns));
@@ -16,6 +16,8 @@ public static class BenchTimer
         var times = Enumerable.Range(0, numRuns)
             .Select(_ => Time(a))
             .OrderBy(t => t)
+            .Skip(1)
+            .SkipLast(1)
             .ToArray();
 
         return new(times.First(), times.Last(), times[numRuns / 2], TimeSpan.FromTicks((long)Math.Round(times.Average(time => time.Ticks))));

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,9 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>89.1.0</Version>
-    <PackageReleaseNotes>Benchtimer now excludes the two most deviating measurements.
-It therefore requires a minimum of 5 runs.</PackageReleaseNotes>
+    <Version>90.0.0</Version>
+    <PackageReleaseNotes>Benchtimer now excludes a specified number of slowest outliers in its mean and median calculations.</PackageReleaseNotes>
 
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>89.0.0</Version>
-    <PackageReleaseNotes>BenchTimer now returns also max, mean, and median values.</PackageReleaseNotes>
+    <Version>89.1.0</Version>
+    <PackageReleaseNotes>Benchtimer now excludes the two most deviating measurements.
+It therefore requires a minimum of 5 runs.</PackageReleaseNotes>
 
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>

--- a/test/ProgressOnderwijsUtils.Tests/BenchmarkTimerTests.cs
+++ b/test/ProgressOnderwijsUtils.Tests/BenchmarkTimerTests.cs
@@ -4,11 +4,11 @@ public sealed class BenchmarkTimerTests
 {
     [Fact]
     public void ArgVerifyPositive()
-        => Assert.Throws<ArgumentException>(() => BenchTimer.Time(() => { }, 0));
+        => Assert.Throws<ArgumentException>(() => BenchTimer.Time(() => { }, 0, 0));
 
     [Fact]
     public void ArgVerifyOdd()
-        => Assert.Throws<ArgumentException>(() => BenchTimer.Time(() => { }, 8));
+        => Assert.Throws<ArgumentException>(() => BenchTimer.Time(() => { }, 8, 0));
 
     [Fact]
     public void Time_benchmark()
@@ -19,7 +19,8 @@ public sealed class BenchmarkTimerTests
                 Thread.Sleep(period);
                 period = period.Add(TimeSpan.FromMilliseconds(10));
             },
-            7
+            7,
+            2
         );
 
         PAssert.That(() => benchMark.Min < benchMark.Median);

--- a/test/ProgressOnderwijsUtils.Tests/Data/ConcatenateSqlTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/ConcatenateSqlTest.cs
@@ -21,7 +21,7 @@ public sealed class ConcatenateSqlTest
     public void ConcatenateIsFastEnoughForLargeSequences()
     {
         var someSqls = Enumerable.Range(0, 10000).Select(i => ParameterizedSql.CreateDynamic(i.ToStringInvariant())).ToArray();
-        var time = BenchTimer.Time(() => _ = someSqls.ConcatenateSql().CommandText(), 5).Min;
+        var time = BenchTimer.Time(() => _ = someSqls.ConcatenateSql().CommandText(), 6, 1).Min;
         //At 1ns per op (equiv to approx 4 clock cycles), a quadratic implementation would use some multiple of 100 ms.  Even with an extremely low
         //scaling factor, if it's faster than 25ms, it's almost certainly better than quadratic, and in any case fast enough.
         PAssert.That(() => time.TotalMilliseconds < 25);

--- a/test/ProgressOnderwijsUtils.Tests/EnumerableOfStringExtensionTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/EnumerableOfStringExtensionTest.cs
@@ -18,7 +18,7 @@ public sealed class EnumerableOfStringExtensionTest
     public void FastJoin()
     {
         var ints = Enumerable.Range(0, 20000).Select(i => i.ToStringInvariant()).ToArray();
-        var time = BenchTimer.Time(() => ints.JoinStrings(), 5).Min;
+        var time = BenchTimer.Time(() => ints.JoinStrings(), 6, 1).Min;
         PAssert.That(() => time.TotalMilliseconds < 5.0);
     }
 


### PR DESCRIPTION
It therefore requires a minimum of 5 runs.

I think this will result in more similar measurements across runs. Or are there better ways to do so?