### PR TITLE
Annoyingly, MS releases EF core packages in lockstep, and this is inc…

### DIFF
--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="AngleSharp" Version="0.17.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.9" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
     <EmbeddedResource Include="SingleSignOn\*.xsd" />

--- a/tools/ProgressOnderwijsUtilsBenchmarks/ProgressOnderwijsUtilsBenchmarks.csproj
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/ProgressOnderwijsUtilsBenchmarks.csproj
@@ -12,6 +12,5 @@
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.116" />
     <ProjectReference Include="..\..\src\ProgressOnderwijsUtils\ProgressOnderwijsUtils.csproj" />
     <ProjectReference Include="..\..\test\ProgressOnderwijsUtils.Tests\ProgressOnderwijsUtils.Tests.csproj" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.8" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
…onvenient with dependabot.

Pragmatic workaround: just depend on the most-specific package, even if we don't need it, to reduce future dependabot noise

(ref #739 + #740)