### PR TITLE
add download directory option

### DIFF
--- a/src/ProgressOnderwijsUtils.SeleniumWebDriverPool/WebDriverPool.cs
+++ b/src/ProgressOnderwijsUtils.SeleniumWebDriverPool/WebDriverPool.cs
@@ -17,7 +17,7 @@ public sealed class WebDriverPool : IDisposable
     readonly ICommandServer server;
     readonly Func<IWebDriver> driverFactory;
 
-    public static WebDriverPool ChromePool(bool runHeadless)
+    public static WebDriverPool ChromePool(bool runHeadless, bool supressContentPopups, string? downloadDirectory)
     {
         var driverService = ChromeDriverService.CreateDefaultService();
         driverService.Start();
@@ -25,6 +25,17 @@ public sealed class WebDriverPool : IDisposable
         driverOptions.SetLoggingPreference(LogType.Browser, LogLevel.All);
         driverOptions.SetLoggingPreference(LogType.Driver, LogLevel.Warning);
         driverOptions.AddArgument("window-size=1920,1080");
+        if (!supressContentPopups) {
+            driverOptions.AddUserProfilePreference("profile.default_content_settings.popups", 0);
+        }
+        if (!string.IsNullOrEmpty(downloadDirectory)) {
+            driverOptions.AddUserProfilePreference("download.default_directory", downloadDirectory);
+        }
+
+        if (!supressContentPopups || !string.IsNullOrEmpty(downloadDirectory)) {
+            driverOptions.AddUserProfilePreference("download.directory_upgrade", 1);
+        }
+
         if (runHeadless) {
             driverOptions.AddArgument("headless");
         }


### PR DESCRIPTION
Ik wil een download directory kunnen opgeven om bestanden die de browser download naar toe te schrijven. Simpelweg uitlezen is geen optie, dus opgeven en een bestaand pad gebruiken is ook een manier om altijd te weten welke download directory we moeten zijn.

Ik wil uiteindelijk een test maken die Exporten -> Exporteren naar <x> doet, 5 seconden wacht en dan assert dat er een bestand in de downloads folder bestaat. Op die manier kunnen we garanderen dat de file download icm `?RawTarget=foo` in pnet t blijft doen.