### PR TITLE
Remove feature policy header

### DIFF
--- a/src/ProgressOnderwijsUtils.AspNetCore/ProgressOnderwijsUtils.AspNetCore.csproj
+++ b/src/ProgressOnderwijsUtils.AspNetCore/ProgressOnderwijsUtils.AspNetCore.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup>
-    <Version>8.0.0</Version>
+    <Version>8.1.0</Version>
     <Title>ProgressOnderwijsUtils.AspNetCore</Title>
     <Description>Add Cross-Origin-Embedder-Policy and Cross-Origin-Opener-Policy to the default set of headers set.</Description>
-    <PackageReleaseNotes>Bump dependency version to .net 7; add Permissions-Policy</PackageReleaseNotes>
+    <PackageReleaseNotes>Remove support for the deprecated Feature-Policy header (but retain Permissions-Policy)</PackageReleaseNotes>
     <PackageTags>ProgressOnderwijs</PackageTags>
     <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>

--- a/src/ProgressOnderwijsUtils.AspNetCore/SecurityHeadersMiddleware.cs
+++ b/src/ProgressOnderwijsUtils.AspNetCore/SecurityHeadersMiddleware.cs
@@ -22,9 +22,9 @@ public sealed class SecurityHeadersMiddleware
         }
         if (options.PermissionsPolicy != null) {
             context.Response.Headers["Permissions-Policy"] = options.PermissionsPolicy;
-            if (options.AlsoSetFeaturePolicy) {
-                context.Response.Headers["Feature-Policy"] = options.PermissionsPolicy;
-            }
+        }
+        if (options.FeaturePolicy != null) {
+            context.Response.Headers["Feature-Policy"] = options.FeaturePolicy;
         }
         if (options.ReferrerPolicy != null) {
             context.Response.Headers["Referrer-Policy"] = options.ReferrerPolicy;

--- a/src/ProgressOnderwijsUtils.AspNetCore/SecurityHeadersMiddleware.cs
+++ b/src/ProgressOnderwijsUtils.AspNetCore/SecurityHeadersMiddleware.cs
@@ -23,9 +23,6 @@ public sealed class SecurityHeadersMiddleware
         if (options.PermissionsPolicy != null) {
             context.Response.Headers["Permissions-Policy"] = options.PermissionsPolicy;
         }
-        if (options.FeaturePolicy != null) {
-            context.Response.Headers["Feature-Policy"] = options.FeaturePolicy;
-        }
         if (options.ReferrerPolicy != null) {
             context.Response.Headers["Referrer-Policy"] = options.ReferrerPolicy;
         }

--- a/src/ProgressOnderwijsUtils.AspNetCore/SecurityHeadersMiddlewareOptions.cs
+++ b/src/ProgressOnderwijsUtils.AspNetCore/SecurityHeadersMiddlewareOptions.cs
@@ -4,10 +4,10 @@ public sealed record SecurityHeadersMiddlewareOptions
 {
     public string? ContentSecurityPolicy { get; init; } = "object-src 'self'; script-src 'self';";
     public string? PermissionsPolicy { get; init; } = "microphone=(), camera=(), fullscreen=(), geolocation=(), display-capture=()";
+    public string? FeaturePolicy { get; init; } = "microphone 'none'; camera 'none'; fullscreen 'none'; geolocation 'none'; display-capture 'none'";
     /// <summary>
     /// Legacy header name for Permissions-Policy used in safari 11.1+ and firefox 74+
     /// </summary>
-    public bool AlsoSetFeaturePolicy = true;
     public string? ReferrerPolicy { get; init; } = "same-origin";
     public string? XContentTypeOptions { get; init; } = "nosniff";
     public string? CrossOriginEmbedderPolicy { get; init; } = "require-corp";

--- a/src/ProgressOnderwijsUtils.AspNetCore/SecurityHeadersMiddlewareOptions.cs
+++ b/src/ProgressOnderwijsUtils.AspNetCore/SecurityHeadersMiddlewareOptions.cs
@@ -4,7 +4,6 @@ public sealed record SecurityHeadersMiddlewareOptions
 {
     public string? ContentSecurityPolicy { get; init; } = "object-src 'self'; script-src 'self';";
     public string? PermissionsPolicy { get; init; } = "microphone=(), camera=(), fullscreen=(), geolocation=(), display-capture=()";
-    public string? FeaturePolicy { get; init; } = "microphone 'none'; camera 'none'; fullscreen 'none'; geolocation 'none'; display-capture 'none'";
     /// <summary>
     /// Legacy header name for Permissions-Policy used in safari 11.1+ and firefox 74+
     /// </summary>


### PR DESCRIPTION
caniuse claims it doesn't work anyhow, and at least on FF I can verify that.

Sticking to the chrome-only but hopefully more future-proof Permissions-Policy therefore.