### PR TITLE
Add DatabaseDefinitionScripter

### DIFF
--- a/src/ProgressOnderwijsUtils/Data/CascadedDelete.cs
+++ b/src/ProgressOnderwijsUtils/Data/CascadedDelete.cs
@@ -46,7 +46,7 @@ public static class CascadedDelete
         var pkColumns = PocoUtils.GetProperties<TId>().Select(pocoProperty => pocoProperty.Name).ToArray();
         var pkColumnsSql = pkColumns.ArraySelect(ParameterizedSql.CreateDynamic);
 
-        var pkColumnsMetaData = initialTableAsEntered.Columns.Select(col => col.ColumnMetaData).Where(col => pkColumns.Contains(col.ColumnName, StringComparer.OrdinalIgnoreCase)).ToArray();
+        var pkColumnsMetaData = initialTableAsEntered.Columns.Where(col => pkColumns.Contains(col.ColumnName, StringComparer.OrdinalIgnoreCase)).ToArray();
         pkColumnsMetaData.CreateNewTableQuery(pksTable).ExecuteNonQuery(conn);
 
         var target = new BulkInsertTarget(
@@ -84,7 +84,7 @@ public static class CascadedDelete
         var pkColumns = pksToDelete.Columns.Cast<DataColumn>().Select(dc => dc.ColumnName).ToArray();
         var pkColumnsSql = pkColumns.ArraySelect(ParameterizedSql.CreateDynamic);
 
-        var pkColumnsMetaData = initialTableAsEntered.Columns.Select(col => col.ColumnMetaData).Where(col => pkColumns.Contains(col.ColumnName, StringComparer.OrdinalIgnoreCase)).ToArray();
+        var pkColumnsMetaData = initialTableAsEntered.Columns.Where(col => pkColumns.Contains(col.ColumnName, StringComparer.OrdinalIgnoreCase)).ToArray();
         pkColumnsMetaData.CreateNewTableQuery(pksTable).ExecuteNonQuery(conn);
         BulkInsertTarget.FromCompleteSetOfColumns(pksTable.CommandText(), pkColumnsMetaData).BulkInsert(conn, pksToDelete);
 
@@ -138,7 +138,7 @@ public static class CascadedDelete
 
         var delTable = SQL($"#del_init");
 
-        var pkColumnsMetaData = initialTableAsEntered.Columns.Select(col => col.ColumnMetaData).Where(col => pkColumns.Contains(col.ColumnName, StringComparer.OrdinalIgnoreCase)).ToArray();
+        var pkColumnsMetaData = initialTableAsEntered.Columns.Where(col => pkColumns.Contains(col.ColumnName, StringComparer.OrdinalIgnoreCase)).ToArray();
         pkColumnsMetaData.CreateNewTableQuery(delTable).ExecuteNonQuery(conn);
 
         var idsToDelete = SQL(
@@ -225,7 +225,7 @@ public static class CascadedDelete
                         return SQL(
                             $@"
                                 declare @output_deleted table(
-                                    {table.Columns.Select(col => col.ColumnMetaData.AsStaticRowVersion().ToSqlColumnDefinitionSql()).ConcatenateSql(SQL($", "))}
+                                    {table.Columns.Select(col => col.AsStaticRowVersion().ToSqlColumnDefinitionSql()).ConcatenateSql(SQL($", "))}
                                 );
                                 {DeletionQuery(SQL($"output deleted.* into @output_deleted"))}
                                 select * from @output_deleted;

--- a/src/ProgressOnderwijsUtils/Data/ColumnDefinition.cs
+++ b/src/ProgressOnderwijsUtils/Data/ColumnDefinition.cs
@@ -40,10 +40,10 @@ public sealed record ColumnDefinition(Type DataType, string Name, int Index, Col
     public override string ToString()
         => $"{DataType.ToCSharpFriendlyTypeName()} {Name}";
 
-    public static ColumnDefinition FromDbColumnMetaData(DbColumnMetaData col, int colIdx)
+    public static ColumnDefinition FromDbColumnMetaData(IDbColumn col, int colIdx)
         => FromSqlSystemTypeId(colIdx, col.ColumnName, col.UserTypeId, DbColumnMetaDataAccessibility(col));
 
-    static ColumnAccessibility DbColumnMetaDataAccessibility(DbColumnMetaData col)
+    static ColumnAccessibility DbColumnMetaDataAccessibility(IDbColumn col)
         => col switch {
             { HasAutoIncrementIdentity : true, } => ColumnAccessibility.AutoIncrementIdentity,
             { IsRowVersion : true, } => ColumnAccessibility.Readonly,

--- a/src/ProgressOnderwijsUtils/Data/ColumnDefinition.cs
+++ b/src/ProgressOnderwijsUtils/Data/ColumnDefinition.cs
@@ -6,7 +6,6 @@ namespace ProgressOnderwijsUtils;
 public enum ColumnAccessibility
 {
     Normal,
-    NormalWithDefaultValue,
     AutoIncrementIdentity,
     Readonly,
 }
@@ -20,8 +19,7 @@ public sealed record ColumnDefinition(Type DataType, string Name, int Index, Col
         => col switch {
             { AutoIncrement: true, } => ColumnAccessibility.AutoIncrementIdentity,
             { ReadOnly: true, } => ColumnAccessibility.Readonly,
-            { DefaultValue : DBNull, } => ColumnAccessibility.Normal,
-            _ => ColumnAccessibility.NormalWithDefaultValue,
+            _ => ColumnAccessibility.Normal,
         };
 
     static Type DataColumnType(DataColumn col)
@@ -50,7 +48,6 @@ public sealed record ColumnDefinition(Type DataType, string Name, int Index, Col
             { HasAutoIncrementIdentity : true, } => ColumnAccessibility.AutoIncrementIdentity,
             { IsRowVersion : true, } => ColumnAccessibility.Readonly,
             { IsComputed : true, } => ColumnAccessibility.Readonly,
-            { HasDefaultValue : true, } => ColumnAccessibility.NormalWithDefaultValue,
             _ => ColumnAccessibility.Normal,
         };
 

--- a/src/ProgressOnderwijsUtils/Data/FieldMapping.cs
+++ b/src/ProgressOnderwijsUtils/Data/FieldMapping.cs
@@ -71,7 +71,7 @@ public struct FieldMappingValidation
                     errors.Add($"Source field {src.Name} of type {src.DataType.ToCSharpFriendlyTypeName()} does not fill any corresponding target field.");
                 }
             } else if (src == null) {
-                if (dst.ColumnAccessibility == ColumnAccessibility.Normal || dst.ColumnAccessibility == ColumnAccessibility.NormalWithDefaultValue) {
+                if (dst.ColumnAccessibility is ColumnAccessibility.Normal) {
                     if (!AllowExtraTargetColumns) {
                         errors.Add($"Target field {dst.Name} of type {dst.DataType.ToCSharpFriendlyTypeName()} is not filled by any corresponding source field.");
                     }
@@ -89,7 +89,7 @@ public struct FieldMappingValidation
                     errors.Add($"Source field {src.Name} of type {src.DataType.ToCSharpFriendlyTypeName()} has a type mismatch with target field {dst.Name} of type {dst.DataType.ToCSharpFriendlyTypeName()}.");
                 } else if (dst.ColumnAccessibility == ColumnAccessibility.Readonly) {
                     errors.Add($"Cannot fill readonly field {dst.Name}.");
-                } else if (dst.ColumnAccessibility == ColumnAccessibility.Normal || dst.ColumnAccessibility == ColumnAccessibility.NormalWithDefaultValue || OverwriteAutoIncrement) {
+                } else if (dst.ColumnAccessibility is ColumnAccessibility.Normal || OverwriteAutoIncrement) {
                     mapped.Add(new(src, dst));
                 }
             }

--- a/src/ProgressOnderwijsUtils/Data/SqlServerUtils.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlServerUtils.cs
@@ -31,4 +31,12 @@ public static class SqlServerUtils
     static bool IsSpidAlreadyDeadException(Exception exception)
         => exception.Message.PretendNullable() != null && exception.Message.Contains("is not an active process ID.", StringComparison.Ordinal)
             || exception.InnerException != null && IsSpidAlreadyDeadException(exception.InnerException);
+
+    public static string PrettifySqlExpression(string sql)
+    {
+        var uncappedKeyWords = Regex.Replace(sql, @"\b(NEXT|VALUE|FOR|IS|NOT|NULL|OR|AND|CONVERT|TRY_CAST|AS)\b", m => m.Value.ToLowerInvariant());
+        var withoutPointlessBrackets = Regex.Replace(uncappedKeyWords, @"\[(\w+)\]", m => m.Value[1..^1]);
+        var withoutPointlessParens = Regex.Replace(withoutPointlessBrackets, @"\((\w+)\)", m => m.Value[1..^1]);
+        return withoutPointlessParens;
+    }
 }

--- a/src/ProgressOnderwijsUtils/Pocos/BulkInsertTarget.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/BulkInsertTarget.cs
@@ -21,7 +21,7 @@ public sealed class BulkInsertTarget
         => (TableName, Columns, Mode, Options) = (tableName, columnDefinition, mode, options);
 
     public static BulkInsertTarget FromDatabaseDescription(DatabaseDescription.Table table)
-        => new(table.QualifiedName, table.Columns.ArraySelect((col, colIdx) => ColumnDefinition.FromDbColumnMetaData(col.ColumnMetaData, colIdx)));
+        => new(table.QualifiedName, table.Columns.ArraySelect(ColumnDefinition.FromDbColumnMetaData));
 
     public static BulkInsertTarget LoadFromTable(SqlConnection conn, ParameterizedSql tableName)
         => LoadFromTable(conn, tableName.CommandText());
@@ -29,7 +29,7 @@ public sealed class BulkInsertTarget
     public static BulkInsertTarget LoadFromTable(SqlConnection conn, string tableName)
         => FromCompleteSetOfColumns(tableName, DbColumnMetaData.ColumnMetaDatas(conn, tableName));
 
-    public static BulkInsertTarget FromCompleteSetOfColumns(string tableName, DbColumnMetaData[] columns)
+    public static BulkInsertTarget FromCompleteSetOfColumns(string tableName, IDbColumn[] columns)
         => new(tableName, columns.ArraySelect(ColumnDefinition.FromDbColumnMetaData));
 
     public BulkInsertTarget With(BulkCopyFieldMappingMode mode)

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>94.2.1</Version>
-    <PackageReleaseNotes>Bump dependencies</PackageReleaseNotes>
+    <Version>95.0.0</Version>
+    <PackageReleaseNotes>Include DatabaseDefinitionScripter</PackageReleaseNotes>
 
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDefinitionScripter.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDefinitionScripter.cs
@@ -1,0 +1,89 @@
+namespace ProgressOnderwijsUtils.SchemaReflection;
+
+public sealed record DatabaseDefinitionScripter(DatabaseDescription db)
+{
+    public void TableDefinitionScript(StringBuilder sb, DatabaseDescription.Table table, bool includeNondeterminisiticObjectIds)
+    {
+        var objectIdLineComment = includeNondeterminisiticObjectIds ? " --objectid:" + table.ObjectId : "";
+        _ = sb.Append($"create table {table.QualifiedName} ({objectIdLineComment}\n");
+        var separatorFromPreviousCol = "";
+        foreach (var colMetaData in table.Columns) {
+            if (colMetaData.ComputedAs is { } computedColumn) {
+                var definition = computedColumn;
+                var persistedClause = !definition.IsPersisted
+                    ? ""
+                    : colMetaData.IsNullable
+                        ? " persisted"
+                        : " persisted not null";
+                var columnTrivia = "--"
+                    + colMetaData.ToSqlTypeNameWithoutNullability()
+                    + ";"
+                    + (colMetaData.IsPrimaryKey ? "PK;" : "")
+                    + "colId:"
+                    + colMetaData.ColumnId;
+                _ = sb.Append("    " + separatorFromPreviousCol + colMetaData.ColumnName + " as " + SqlServerUtils.PrettifySqlExpression(definition.Definition) + persistedClause + columnTrivia + "\n");
+            } else {
+                var identitySpecification = colMetaData.HasAutoIncrementIdentity ? " identity" : "";
+                var columnTrivia = "--"
+                    + (colMetaData.DefaultValueConstraint is not null ? "hasDefault;" : "")
+                    + (colMetaData.IsPrimaryKey ? "PK;" : "")
+                    + "colId:"
+                    + colMetaData.ColumnId;
+                _ = sb.Append("    " + separatorFromPreviousCol + colMetaData.ToSqlColumnDefinition() + identitySpecification + columnTrivia + "\n");
+            }
+            separatorFromPreviousCol = ", ";
+        }
+        _ = sb.Append(")\n");
+        foreach (var index in table.Indexes.OrderByDescending(i => i.IndexType.IsClusteredIndex()).ThenBy(o => o.IndexName)) {
+            _ = sb.Append(index.IndexCreationScript() + "\n");
+        }
+
+        foreach (var fk in table.KeysToReferencedParents.OrderBy(o => o.UnqualifiedName)) {
+            _ = sb.Append(Regex.Replace(fk.ScriptToAddConstraint().CommandText().Trim(), "[\r \t\n]+", " ").Replace(" on delete no action on update no action", "") + "\n");
+        }
+
+        foreach (var ck in table.CheckConstraints.OrderBy(ck => ck.Name)) {
+            _ = sb.Append(ToCreationStatement(table, ck) + "\n");
+        }
+
+        var defaultConstraintsForTable = table.Columns
+            .Where(col => col.DefaultValueConstraint != null)
+            .Select(col => (col, defaultConstraint: col.DefaultValueConstraint.AssertNotNull()))
+            .OrderBy(dvc => dvc.defaultConstraint.Name);
+        foreach (var dfc in defaultConstraintsForTable) {
+            _ = sb.Append($"alter table {table.QualifiedName} add constraint {dfc.defaultConstraint.Name} default {SqlServerUtils.PrettifySqlExpression(dfc.defaultConstraint.Definition)} for {dfc.col.ColumnName}\n");
+        }
+
+        foreach (var dmlTrigger in table.Triggers.OrderBy(tr => tr.Name)) {
+            _ = sb.Append("go\n");
+            _ = sb.Append(dmlTrigger.Definition.Trim() + "\n");
+            _ = sb.Append("go\n");
+        }
+
+        _ = sb.Append($"--end of {table.QualifiedName} definition\n");
+        _ = sb.Append('\n');
+    }
+
+    public static string ToCreationStatement(DatabaseDescription.Table table, CheckConstraintSqlDefinition checkConstraintDefinition)
+    {
+        var creation = checkConstraintDefinition.IsNotTrusted
+            ? $"alter table {table.QualifiedName} with nocheck add constraint {checkConstraintDefinition.Name} check {SqlServerUtils.PrettifySqlExpression(checkConstraintDefinition.Definition)}"
+            : $"alter table {table.QualifiedName} add constraint {checkConstraintDefinition.Name} check {SqlServerUtils.PrettifySqlExpression(checkConstraintDefinition.Definition)}";
+        var disabled = checkConstraintDefinition.IsDisabled ? $"\nalter table {table.QualifiedName} nocheck constraint {checkConstraintDefinition.Name}" : "";
+        return creation + disabled;
+    }
+
+    public string StringifySchema(bool includeNondeterminisiticObjectIds)
+    {
+        var sb = new StringBuilder();
+        foreach (var sequence in db.Sequences.Values.OrderBy(s => s.QualifiedName)) {
+            sequence.AppendCreationScript(sb);
+        }
+        _ = sb.Append('\n');
+
+        foreach (var table in db.AllTables.OrderBy(o => o.QualifiedName)) {
+            TableDefinitionScript(sb, table, includeNondeterminisiticObjectIds);
+        }
+        return sb.ToString();
+    }
+}

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -172,7 +172,7 @@ public sealed class DatabaseDescription
 
     public sealed class Table : IDbNamedObject
     {
-        public readonly Column<Table>[] Columns;
+        public Column<Table>[] Columns { get; }
         public readonly DmlTableTriggerSqlDefinition[] Triggers;
         public readonly CheckConstraintSqlDefinition[] CheckConstraints;
         readonly DbNamedObjectId NamedTableId;
@@ -248,7 +248,7 @@ public sealed class DatabaseDescription
     {
         readonly DbNamedObjectId NamedObject;
         public DatabaseDescription Database { get; }
-        public readonly Column<View>[] Columns;
+        public Column<View>[] Columns { get; }
         public readonly Table[] ReferencedTables;
 
         internal View(DbNamedObjectId namedObject, DatabaseDescriptionById rawSchemaById, DatabaseDescription db)

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -109,15 +109,15 @@ public sealed class DatabaseDescription
 
     public sealed class Column<TObject>
     {
-        public readonly TObject Table;
+        public readonly TObject ContainingObject;
         public DbColumnMetaData ColumnMetaData { get; }
         public readonly DefaultValueConstraintSqlDefinition? DefaultValueConstraint;
         public readonly ComputedColumnSqlDefinition? ComputedAs;
 
-        internal Column(TObject table, DbColumnMetaData columnMetaData, DatabaseDescriptionById dataByTableId)
+        internal Column(TObject containingObject, DbColumnMetaData columnMetaData, DatabaseDescriptionById dataByTableId)
         {
             ColumnMetaData = columnMetaData;
-            Table = table;
+            ContainingObject = containingObject;
             DefaultValueConstraint = dataByTableId.DefaultValues.GetValueOrDefault((columnMetaData.DbObjectId, columnMetaData.ColumnId));
             ComputedAs = dataByTableId.ComputedColumns.GetValueOrDefault((columnMetaData.DbObjectId, columnMetaData.ColumnId));
         }

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -19,6 +19,8 @@ public sealed class DatabaseDescription
             Triggers = rawDescription.DmlTableTriggers.ToGroupedDictionary(o => o.TableObjectId, (_, g) => g.ToArray()),
             Columns = rawDescription.Columns.ToGroupedDictionary(col => col.DbObjectId, (_, cols) => cols.Order().ToArray()),
             SqlExpressionDependsOn = rawDescription.Dependencies.ToLookup(dep => dep.referencing_id, dep => dep.referenced_id),
+            Indexes = rawDescription.Indexes.ToLookup(o => o.ObjectId),
+            IndexColumns = rawDescription.IndexColumns.ToLookup(o => (o.ObjectId, o.IndexId)),
         };
 
         Sequences = rawDescription.Sequences.ToDictionary(s => s.QualifiedName, StringComparer.OrdinalIgnoreCase);
@@ -39,6 +41,8 @@ public sealed class DatabaseDescription
         public required IReadOnlyDictionary<DbObjectId, DmlTableTriggerSqlDefinition[]> Triggers { get; init; }
         public required Dictionary<DbObjectId, DbColumnMetaData[]> Columns { get; init; }
         public required ILookup<DbObjectId, DbObjectId> SqlExpressionDependsOn { get; init; }
+        public required ILookup<DbObjectId, DbObjectIndex> Indexes { get; init; }
+        public required ILookup<(DbObjectId ObjectId, DbIndexId IndexId), DbObjectIndexColumn> IndexColumns { get; init; }
     }
 
     public static DatabaseDescription LoadFromSchemaTables(SqlConnection conn)

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -163,6 +163,10 @@ public sealed class DatabaseDescription
             => ColumnMetaData.Scale;
     }
 
+    static Column<TObject> DefineColumn<TObject>(TObject containingObject, DatabaseDescriptionById rawSchemaById, DbColumnMetaData col)
+        where TObject : IDbNamedObject
+        => new(containingObject, col, rawSchemaById);
+
     public sealed class Table : IDbNamedObject
     {
         public readonly Column<Table>[] Columns;
@@ -175,7 +179,7 @@ public sealed class DatabaseDescription
         {
             this.db = db;
             NamedTableId = namedTableId;
-            Columns = rawSchemaById.Columns.GetValueOrDefault(namedTableId.ObjectId).EmptyIfNull().ArraySelect(col => new Column<Table>(this, col, rawSchemaById));
+            Columns = rawSchemaById.Columns.GetValueOrDefault(namedTableId.ObjectId).EmptyIfNull().ArraySelect(col => DefineColumn(this, rawSchemaById, col));
             Triggers = rawSchemaById.Triggers.GetValueOrDefault(ObjectId).EmptyIfNull();
             CheckConstraints = rawSchemaById.CheckConstraints.GetValueOrDefault(ObjectId).EmptyIfNull();
         }

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -229,7 +229,7 @@ public sealed class DatabaseDescription
         public readonly DbColumnMetaData[] Columns;
         public readonly Table[] ReferencedTables;
 
-        public View(DbNamedObjectId view, DatabaseDescriptionById databaseDescriptionById, DatabaseDescription databaseDescription, DbColumnMetaData[] columns, Table[] referencedTables)
+        internal View(DbNamedObjectId view, DatabaseDescriptionById rawSchemaById, DatabaseDescription db, DbColumnMetaData[] columns, Table[] referencedTables)
         {
             this.view = view;
             Columns = columns;

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -241,7 +241,7 @@ public sealed class DatabaseDescription
         }
     }
 
-    public sealed class View
+    public sealed class View : IDbNamedObject
     {
         readonly DbNamedObjectId view;
         public readonly DatabaseDescription db;
@@ -255,6 +255,9 @@ public sealed class DatabaseDescription
             Columns = rawSchemaById.Columns.GetValueOrDefault(view.ObjectId).EmptyIfNull();
             ReferencedTables = rawSchemaById.SqlExpressionDependsOn[view.ObjectId].Select(db.TryGetTableById).WhereNotNull().ToArray();
         }
+
+        public DbObjectId ObjectId
+            => view.ObjectId;
 
         public string QualifiedName
             => view.QualifiedName;

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -32,7 +32,7 @@ public sealed class DatabaseDescription
         ForeignKeyConstraintsByUnqualifiedName = fkObjects.ToLookup(o => o.UnqualifiedName, StringComparer.OrdinalIgnoreCase);
     }
 
-    public sealed record DataByTableId(
+    internal sealed record DataByTableId(
         Dictionary<(DbObjectId ParentObjectId, DbColumnId ParentColumnId), DefaultValueConstraintSqlDefinition> DefaultValues,
         Dictionary<(DbObjectId ObjectId, DbColumnId ColumnId), ComputedColumnSqlDefinition> ComputedColumns,
         Dictionary<DbObjectId, CheckConstraintSqlDefinition[]> CheckContraints,
@@ -107,7 +107,7 @@ public sealed class DatabaseDescription
         public readonly DefaultValueConstraintSqlDefinition? DefaultValueConstraint;
         public readonly ComputedColumnSqlDefinition? ComputedAs;
 
-        public TableColumn(Table table, DbColumnMetaData columnMetaData, DataByTableId dataByTableId)
+        internal TableColumn(Table table, DbColumnMetaData columnMetaData, DataByTableId dataByTableId)
         {
             ColumnMetaData = columnMetaData;
             Table = table;

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -157,13 +157,13 @@ public sealed class DatabaseDescription
         readonly DbNamedObjectId NamedTableId;
         public readonly DatabaseDescription db;
 
-        internal Table(DbNamedObjectId namedTableId, DatabaseDescriptionById dataByTableId, DatabaseDescription db)
+        internal Table(DbNamedObjectId namedTableId, DatabaseDescriptionById rawSchemaById, DatabaseDescription db)
         {
             this.db = db;
             NamedTableId = namedTableId;
-            Columns = dataByTableId.Columns.GetValueOrDefault(namedTableId.ObjectId).EmptyIfNull().ArraySelect(col => new TableColumn(this, col, dataByTableId));
-            Triggers = dataByTableId.Triggers.GetValueOrDefault(ObjectId).EmptyIfNull();
-            CheckConstraints = dataByTableId.CheckConstraints.GetValueOrDefault(ObjectId).EmptyIfNull();
+            Columns = rawSchemaById.Columns.GetValueOrDefault(namedTableId.ObjectId).EmptyIfNull().ArraySelect(col => new TableColumn(this, col, rawSchemaById));
+            Triggers = rawSchemaById.Triggers.GetValueOrDefault(ObjectId).EmptyIfNull();
+            CheckConstraints = rawSchemaById.CheckConstraints.GetValueOrDefault(ObjectId).EmptyIfNull();
         }
 
         public DbObjectId ObjectId

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -106,7 +106,7 @@ public sealed class DatabaseDescription
     public sealed class TableColumn
     {
         public readonly Table Table;
-        public readonly DbColumnMetaData ColumnMetaData;
+        public DbColumnMetaData ColumnMetaData { get; }
         public readonly DefaultValueConstraintSqlDefinition? DefaultValueConstraint;
         public readonly ComputedColumnSqlDefinition? ComputedAs;
 

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -226,12 +226,14 @@ public sealed class DatabaseDescription
     public sealed class View
     {
         readonly DbNamedObjectId view;
+        public readonly DatabaseDescription db;
         public readonly DbColumnMetaData[] Columns;
         public readonly Table[] ReferencedTables;
 
         internal View(DbNamedObjectId view, DatabaseDescriptionById rawSchemaById, DatabaseDescription db)
         {
             this.view = view;
+            this.db = db;
             Columns = rawSchemaById.Columns.GetValueOrDefault(view.ObjectId).EmptyIfNull();
             ReferencedTables = rawSchemaById.SqlExpressionDependsOn[view.ObjectId].Select(db.TryGetTableById).WhereNotNull().ToArray();
         }

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -246,24 +246,24 @@ public sealed class DatabaseDescription
 
     public sealed class View : IDbNamedObject
     {
-        readonly DbNamedObjectId view;
-        public readonly DatabaseDescription db;
+        readonly DbNamedObjectId NamedObject;
+        public DatabaseDescription Database { get; }
         public readonly Column<View>[] Columns;
         public readonly Table[] ReferencedTables;
 
-        internal View(DbNamedObjectId view, DatabaseDescriptionById rawSchemaById, DatabaseDescription db)
+        internal View(DbNamedObjectId namedObject, DatabaseDescriptionById rawSchemaById, DatabaseDescription db)
         {
-            this.view = view;
-            this.db = db;
-            Columns = rawSchemaById.Columns.GetValueOrDefault(view.ObjectId).EmptyIfNull().ArraySelect(col => DefineColumn(this, rawSchemaById, col));
-            ReferencedTables = rawSchemaById.SqlExpressionDependsOn[view.ObjectId].Select(db.TryGetTableById).WhereNotNull().ToArray();
+            NamedObject = namedObject;
+            Database = db;
+            Columns = rawSchemaById.Columns.GetValueOrDefault(namedObject.ObjectId).EmptyIfNull().ArraySelect(col => DefineColumn(this, rawSchemaById, col));
+            ReferencedTables = rawSchemaById.SqlExpressionDependsOn[namedObject.ObjectId].Select(db.TryGetTableById).WhereNotNull().ToArray();
         }
 
         public DbObjectId ObjectId
-            => view.ObjectId;
+            => NamedObject.ObjectId;
 
         public string QualifiedName
-            => view.QualifiedName;
+            => NamedObject.QualifiedName;
 
         public string SchemaName
             => DbQualifiedNameUtils.SchemaFromQualifiedName(QualifiedName);

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -22,6 +22,7 @@ public sealed class DatabaseDescription
             ComputedColumns = rawDescription.ComputedColumnDefinitions.ToDictionary(o => (o.ObjectId, o.ColumnId)),
             CheckConstraints = rawDescription.CheckConstraints.ToGroupedDictionary(o => o.TableObjectId, (_, g) => g.ToArray()),
             Triggers = rawDescription.DmlTableTriggers.ToGroupedDictionary(o => o.TableObjectId, (_, g) => g.ToArray()),
+            Columns = columnsInOrderByObjectId,
         };
 
         tableById = rawDescription.Tables.ToDictionary(o => o.ObjectId, o => new Table(this, o, columnsInOrderByObjectId.GetValueOrDefault(o.ObjectId).EmptyIfNull(), dataByTableId));
@@ -39,6 +40,7 @@ public sealed class DatabaseDescription
         public required IReadOnlyDictionary<(DbObjectId ObjectId, DbColumnId ColumnId), ComputedColumnSqlDefinition> ComputedColumns { get; init; }
         public required IReadOnlyDictionary<DbObjectId, CheckConstraintSqlDefinition[]> CheckConstraints { get; init; }
         public required IReadOnlyDictionary<DbObjectId, DmlTableTriggerSqlDefinition[]> Triggers { get; init; }
+        public required Dictionary<DbObjectId, DbColumnMetaData[]> Columns { get; init; }
     }
 
     public static DatabaseDescription LoadFromSchemaTables(SqlConnection conn)

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -13,7 +13,6 @@ public sealed class DatabaseDescription
     public DatabaseDescription(RawDatabaseDescription rawDescription)
     {
         var referencedIdByReferencingId = rawDescription.Dependencies.ToLookup(dep => dep.referencing_id, dep => dep.referenced_id);
-        var columnsInOrderByObjectId = rawDescription.Columns.ToGroupedDictionary(col => col.DbObjectId, (_, cols) => cols.Order().ToArray());
 
         Sequences = rawDescription.Sequences.ToDictionary(s => s.QualifiedName, StringComparer.OrdinalIgnoreCase);
 
@@ -22,11 +21,11 @@ public sealed class DatabaseDescription
             ComputedColumns = rawDescription.ComputedColumnDefinitions.ToDictionary(o => (o.ObjectId, o.ColumnId)),
             CheckConstraints = rawDescription.CheckConstraints.ToGroupedDictionary(o => o.TableObjectId, (_, g) => g.ToArray()),
             Triggers = rawDescription.DmlTableTriggers.ToGroupedDictionary(o => o.TableObjectId, (_, g) => g.ToArray()),
-            Columns = columnsInOrderByObjectId,
+            Columns = rawDescription.Columns.ToGroupedDictionary(col => col.DbObjectId, (_, cols) => cols.Order().ToArray()),
         };
 
-        tableById = rawDescription.Tables.ToDictionary(o => o.ObjectId, o => new Table(this, o, columnsInOrderByObjectId.GetValueOrDefault(o.ObjectId).EmptyIfNull(), dataByTableId));
-        viewById = rawDescription.Views.ToDictionary(o => o.ObjectId, o => new View(o, columnsInOrderByObjectId.GetValueOrDefault(o.ObjectId).EmptyIfNull(), referencedIdByReferencingId[o.ObjectId].Select(dep => tableById.GetValueOrDefault(dep)).WhereNotNull().ToArray()));
+        tableById = rawDescription.Tables.ToDictionary(o => o.ObjectId, o => new Table(this, o, dataByTableId.Columns.GetValueOrDefault(o.ObjectId).EmptyIfNull(), dataByTableId));
+        viewById = rawDescription.Views.ToDictionary(o => o.ObjectId, o => new View(o, dataByTableId.Columns.GetValueOrDefault(o.ObjectId).EmptyIfNull(), referencedIdByReferencingId[o.ObjectId].Select(dep => tableById.GetValueOrDefault(dep)).WhereNotNull().ToArray()));
         var fkObjects = rawDescription.ForeignKeys.ArraySelect(o => new ForeignKey(o, tableById));
         fksByReferencedParentObjectId = fkObjects.ToLookup(fk => fk.ReferencedParentTable.ObjectId);
         fksByReferencingChildObjectId = fkObjects.ToLookup(fk => fk.ReferencingChildTable.ObjectId);

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -176,11 +176,11 @@ public sealed class DatabaseDescription
         public readonly DmlTableTriggerSqlDefinition[] Triggers;
         public readonly CheckConstraintSqlDefinition[] CheckConstraints;
         readonly DbNamedObjectId NamedTableId;
-        public readonly DatabaseDescription db;
+        public DatabaseDescription Database { get; }
 
-        internal Table(DbNamedObjectId namedTableId, DatabaseDescriptionById rawSchemaById, DatabaseDescription db)
+        internal Table(DbNamedObjectId namedTableId, DatabaseDescriptionById rawSchemaById, DatabaseDescription database)
         {
-            this.db = db;
+            Database = database;
             NamedTableId = namedTableId;
             Columns = rawSchemaById.Columns.GetValueOrDefault(namedTableId.ObjectId).EmptyIfNull().ArraySelect(col => DefineColumn(this, rawSchemaById, col));
             Triggers = rawSchemaById.Triggers.GetValueOrDefault(ObjectId).EmptyIfNull();
@@ -208,14 +208,14 @@ public sealed class DatabaseDescription
         public IEnumerable<Table> AllDependantTables
             => Utils.TransitiveClosure(
                 new[] { ObjectId, },
-                reachable => db.fksByReferencedParentObjectId[reachable].Select(fk => fk.ReferencingChildTable.ObjectId)
-            ).Select(id => db.tableById[id]);
+                reachable => Database.fksByReferencedParentObjectId[reachable].Select(fk => fk.ReferencingChildTable.ObjectId)
+            ).Select(id => Database.tableById[id]);
 
         public IEnumerable<ForeignKey> KeysToReferencedParents
-            => db.fksByReferencingChildObjectId[ObjectId];
+            => Database.fksByReferencingChildObjectId[ObjectId];
 
         public IEnumerable<ForeignKey> KeysFromReferencingChildren
-            => db.fksByReferencedParentObjectId[ObjectId];
+            => Database.fksByReferencedParentObjectId[ObjectId];
 
         public ForeignKeyInfo[] ChildColumnsReferencingColumn(string pkColumn)
             => KeysFromReferencingChildren

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -23,7 +23,7 @@ public sealed class DatabaseDescription
 
         Sequences = rawDescription.Sequences.ToDictionary(s => s.QualifiedName, StringComparer.OrdinalIgnoreCase);
         tableById = rawDescription.Tables.ToDictionary(o => o.ObjectId, o => new Table(o, rawSchemaById, this));
-        viewById = rawDescription.Views.ToDictionary(o => o.ObjectId, o => new View(o,rawSchemaById, rawSchemaById.Columns.GetValueOrDefault(o.ObjectId).EmptyIfNull(), rawSchemaById.SqlExpressionDependsOn[o.ObjectId].Select(dep => tableById.GetValueOrDefault(dep)).WhereNotNull().ToArray()));
+        viewById = rawDescription.Views.ToDictionary(o => o.ObjectId, o => new View(o,rawSchemaById, this, rawSchemaById.Columns.GetValueOrDefault(o.ObjectId).EmptyIfNull(), rawSchemaById.SqlExpressionDependsOn[o.ObjectId].Select(dep => tableById.GetValueOrDefault(dep)).WhereNotNull().ToArray()));
         var fkObjects = rawDescription.ForeignKeys.ArraySelect(o => new ForeignKey(o, tableById));
         fksByReferencedParentObjectId = fkObjects.ToLookup(fk => fk.ReferencedParentTable.ObjectId);
         fksByReferencingChildObjectId = fkObjects.ToLookup(fk => fk.ReferencingChildTable.ObjectId);
@@ -229,7 +229,7 @@ public sealed class DatabaseDescription
         public readonly DbColumnMetaData[] Columns;
         public readonly Table[] ReferencedTables;
 
-        public View(DbNamedObjectId view, DatabaseDescriptionById databaseDescriptionById, DbColumnMetaData[] columns, Table[] referencedTables)
+        public View(DbNamedObjectId view, DatabaseDescriptionById databaseDescriptionById, DatabaseDescription databaseDescription, DbColumnMetaData[] columns, Table[] referencedTables)
         {
             this.view = view;
             Columns = columns;

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -107,7 +107,8 @@ public sealed class DatabaseDescription
             => SQL($"alter table {ReferencingChildTable.QualifiedNameSql} drop constraint {ParameterizedSql.CreateDynamic(UnqualifiedName)};\n");
     }
 
-    public sealed class Column<TObject>
+    public sealed class Column<TObject> : IDbColumn
+        where TObject : IDbNamedObject
     {
         public readonly TObject ContainingObject;
         public DbColumnMetaData ColumnMetaData { get; }
@@ -151,9 +152,18 @@ public sealed class DatabaseDescription
 
         public bool IsUnicode
             => ColumnMetaData.IsUnicode;
+
+        public short MaxLength
+            => ColumnMetaData.MaxLength;
+
+        public byte Precision
+            => ColumnMetaData.Precision;
+
+        public byte Scale
+            => ColumnMetaData.Scale;
     }
 
-    public sealed class Table
+    public sealed class Table : IDbNamedObject
     {
         public readonly Column<Table>[] Columns;
         public readonly DmlTableTriggerSqlDefinition[] Triggers;

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -17,7 +17,7 @@ public sealed class DatabaseDescription
 
         Sequences = rawDescription.Sequences.ToDictionary(s => s.QualifiedName, StringComparer.OrdinalIgnoreCase);
 
-        var dataByTableId = new DataByTableId {
+        var dataByTableId = new DatabaseDescriptionById {
             DefaultValues = rawDescription.DefaultConstraints.ToDictionary(o => (o.ParentObjectId, o.ParentColumnId)),
             ComputedColumns = rawDescription.ComputedColumnDefinitions.ToDictionary(o => (o.ObjectId, o.ColumnId)),
             CheckConstraints = rawDescription.CheckConstraints.ToGroupedDictionary(o => o.TableObjectId, (_, g) => g.ToArray()),
@@ -33,7 +33,7 @@ public sealed class DatabaseDescription
         ForeignKeyConstraintsByUnqualifiedName = fkObjects.ToLookup(o => o.UnqualifiedName, StringComparer.OrdinalIgnoreCase);
     }
 
-    internal sealed record DataByTableId
+    internal sealed record DatabaseDescriptionById
     {
         public required IReadOnlyDictionary<(DbObjectId ParentObjectId, DbColumnId ParentColumnId), DefaultValueConstraintSqlDefinition> DefaultValues { get; init; }
         public required IReadOnlyDictionary<(DbObjectId ObjectId, DbColumnId ColumnId), ComputedColumnSqlDefinition> ComputedColumns { get; init; }
@@ -110,7 +110,7 @@ public sealed class DatabaseDescription
         public readonly DefaultValueConstraintSqlDefinition? DefaultValueConstraint;
         public readonly ComputedColumnSqlDefinition? ComputedAs;
 
-        internal TableColumn(Table table, DbColumnMetaData columnMetaData, DataByTableId dataByTableId)
+        internal TableColumn(Table table, DbColumnMetaData columnMetaData, DatabaseDescriptionById dataByTableId)
         {
             ColumnMetaData = columnMetaData;
             Table = table;
@@ -157,7 +157,7 @@ public sealed class DatabaseDescription
         readonly DbNamedObjectId NamedTableId;
         public readonly DatabaseDescription db;
 
-        internal Table(DatabaseDescription db, DbNamedObjectId namedTableId, DbColumnMetaData[] columns, DataByTableId dataByTableId)
+        internal Table(DatabaseDescription db, DbNamedObjectId namedTableId, DbColumnMetaData[] columns, DatabaseDescriptionById dataByTableId)
         {
             this.db = db;
             NamedTableId = namedTableId;

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -23,7 +23,7 @@ public sealed class DatabaseDescription
 
         Sequences = rawDescription.Sequences.ToDictionary(s => s.QualifiedName, StringComparer.OrdinalIgnoreCase);
         tableById = rawDescription.Tables.ToDictionary(o => o.ObjectId, o => new Table(o, rawSchemaById, this));
-        viewById = rawDescription.Views.ToDictionary(o => o.ObjectId, o => new View(o,rawSchemaById, this));
+        viewById = rawDescription.Views.ToDictionary(o => o.ObjectId, o => new View(o, rawSchemaById, this));
         var fkObjects = rawDescription.ForeignKeys.ArraySelect(o => new ForeignKey(o, tableById));
         fksByReferencedParentObjectId = fkObjects.ToLookup(fk => fk.ReferencedParentTable.ObjectId);
         fksByReferencingChildObjectId = fkObjects.ToLookup(fk => fk.ReferencingChildTable.ObjectId);

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -115,12 +115,12 @@ public sealed class DatabaseDescription
         public readonly DefaultValueConstraintSqlDefinition? DefaultValueConstraint;
         public readonly ComputedColumnSqlDefinition? ComputedAs;
 
-        internal Column(TObject containingObject, DbColumnMetaData columnMetaData, DatabaseDescriptionById dataByTableId)
+        internal Column(TObject containingObject, DbColumnMetaData columnMetaData, DatabaseDescriptionById rawSchemaById)
         {
             ColumnMetaData = columnMetaData;
             ContainingObject = containingObject;
-            DefaultValueConstraint = dataByTableId.DefaultValues.GetValueOrDefault((columnMetaData.DbObjectId, columnMetaData.ColumnId));
-            ComputedAs = dataByTableId.ComputedColumns.GetValueOrDefault((columnMetaData.DbObjectId, columnMetaData.ColumnId));
+            DefaultValueConstraint = rawSchemaById.DefaultValues.GetValueOrDefault((columnMetaData.DbObjectId, columnMetaData.ColumnId));
+            ComputedAs = rawSchemaById.ComputedColumns.GetValueOrDefault((columnMetaData.DbObjectId, columnMetaData.ColumnId));
         }
 
         public DbColumnId ColumnId

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -2,6 +2,7 @@ namespace ProgressOnderwijsUtils.SchemaReflection;
 
 public sealed class DatabaseDescription
 {
+    public RawDatabaseDescription RawDescription { get; }
     public readonly IReadOnlyDictionary<string, SequenceSqlDefinition> Sequences;
     readonly IReadOnlyDictionary<DbObjectId, Table> tableById;
     readonly IReadOnlyDictionary<DbObjectId, View> viewById;
@@ -12,6 +13,7 @@ public sealed class DatabaseDescription
 
     public DatabaseDescription(RawDatabaseDescription rawDescription)
     {
+        RawDescription = rawDescription;
         var rawSchemaById = rawDescription.IndexById();
 
         Sequences = rawDescription.Sequences.ToDictionary(s => s.QualifiedName, StringComparer.OrdinalIgnoreCase);

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -108,7 +108,7 @@ public sealed class DatabaseDescription
     }
 
     public sealed class Index<TObject>
-        where TObject : IObjectWithColumns<TObject>
+        where TObject : ObjectWithColumns<TObject>
     {
         public readonly TObject ContainingObject;
         readonly DbObjectIndex IndexMetaData;
@@ -136,7 +136,6 @@ public sealed class DatabaseDescription
         {
             public Column<TObject> Column
                 => Index.ContainingObject.ColumnsById[UnderlyingMetaData.ColumnId];
-
 
             public bool IsDescending
                 => UnderlyingMetaData.IsDescending;
@@ -255,14 +254,7 @@ public sealed class DatabaseDescription
         where TObject : ObjectWithColumns<TObject>
         => new((TObject)containingObject, col, rawSchemaById);
 
-    public interface IObjectWithColumns<TObject> : IDbNamedObject
-        where TObject : IObjectWithColumns<TObject>
-    {
-        Column<TObject>[] Columns { get; }
-        IReadOnlyDictionary<DbColumnId, Column<TObject>> ColumnsById { get; }
-    }
-
-    public abstract class ObjectWithColumns<TObject> : IObjectWithColumns<TObject>
+    public abstract class ObjectWithColumns<TObject> : IDbNamedObject
         where TObject : ObjectWithColumns<TObject>
     {
         private protected ObjectWithColumns(DbNamedObjectId namedObjectId, DatabaseDescriptionById rawSchemaById, DatabaseDescription database)

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -12,7 +12,7 @@ public sealed class DatabaseDescription
 
     public DatabaseDescription(RawDatabaseDescription rawDescription)
     {
-        var rawSchemaById = RawDatabaseDescription.IndexById(rawDescription);
+        var rawSchemaById = rawDescription.IndexById();
 
         Sequences = rawDescription.Sequences.ToDictionary(s => s.QualifiedName, StringComparer.OrdinalIgnoreCase);
         tableById = rawDescription.Tables.ToDictionary(o => o.ObjectId, o => new Table(o, rawSchemaById, this));

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -245,14 +245,14 @@ public sealed class DatabaseDescription
     {
         readonly DbNamedObjectId view;
         public readonly DatabaseDescription db;
-        public readonly DbColumnMetaData[] Columns;
+        public readonly Column<View>[] Columns;
         public readonly Table[] ReferencedTables;
 
         internal View(DbNamedObjectId view, DatabaseDescriptionById rawSchemaById, DatabaseDescription db)
         {
             this.view = view;
             this.db = db;
-            Columns = rawSchemaById.Columns.GetValueOrDefault(view.ObjectId).EmptyIfNull();
+            Columns = rawSchemaById.Columns.GetValueOrDefault(view.ObjectId).EmptyIfNull().ArraySelect(col => DefineColumn(this, rawSchemaById, col));
             ReferencedTables = rawSchemaById.SqlExpressionDependsOn[view.ObjectId].Select(db.TryGetTableById).WhereNotNull().ToArray();
         }
 

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -23,7 +23,7 @@ public sealed class DatabaseDescription
 
         Sequences = rawDescription.Sequences.ToDictionary(s => s.QualifiedName, StringComparer.OrdinalIgnoreCase);
         tableById = rawDescription.Tables.ToDictionary(o => o.ObjectId, o => new Table(o, dataByTableId, this));
-        viewById = rawDescription.Views.ToDictionary(o => o.ObjectId, o => new View(o, dataByTableId.Columns.GetValueOrDefault(o.ObjectId).EmptyIfNull(), dataByTableId.SqlExpressionDependsOn[o.ObjectId].Select(dep => tableById.GetValueOrDefault(dep)).WhereNotNull().ToArray()));
+        viewById = rawDescription.Views.ToDictionary(o => o.ObjectId, o => new View(o,dataByTableId, dataByTableId.Columns.GetValueOrDefault(o.ObjectId).EmptyIfNull(), dataByTableId.SqlExpressionDependsOn[o.ObjectId].Select(dep => tableById.GetValueOrDefault(dep)).WhereNotNull().ToArray()));
         var fkObjects = rawDescription.ForeignKeys.ArraySelect(o => new ForeignKey(o, tableById));
         fksByReferencedParentObjectId = fkObjects.ToLookup(fk => fk.ReferencedParentTable.ObjectId);
         fksByReferencingChildObjectId = fkObjects.ToLookup(fk => fk.ReferencingChildTable.ObjectId);
@@ -229,7 +229,7 @@ public sealed class DatabaseDescription
         public readonly DbColumnMetaData[] Columns;
         public readonly Table[] ReferencedTables;
 
-        public View(DbNamedObjectId view, DbColumnMetaData[] columns, Table[] referencedTables)
+        public View(DbNamedObjectId view, DatabaseDescriptionById databaseDescriptionById, DbColumnMetaData[] columns, Table[] referencedTables)
         {
             this.view = view;
             Columns = columns;

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -161,6 +161,9 @@ public sealed class DatabaseDescription
 
         public byte Scale
             => ColumnMetaData.Scale;
+
+        public bool HasAutoIncrementIdentity
+            => ColumnMetaData.HasAutoIncrementIdentity;
     }
 
     static Column<TObject> DefineColumn<TObject>(TObject containingObject, DatabaseDescriptionById rawSchemaById, DbColumnMetaData col)

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -12,7 +12,7 @@ public sealed class DatabaseDescription
 
     public DatabaseDescription(RawDatabaseDescription rawDescription)
     {
-        var rawSchemaById = DatabaseDescriptionById.Create(rawDescription);
+        var rawSchemaById = RawDatabaseDescription.IndexById(rawDescription);
 
         Sequences = rawDescription.Sequences.ToDictionary(s => s.QualifiedName, StringComparer.OrdinalIgnoreCase);
         tableById = rawDescription.Tables.ToDictionary(o => o.ObjectId, o => new Table(o, rawSchemaById, this));

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
@@ -52,12 +52,6 @@ public sealed record DbColumnMetaData(
         set => columnFlags[3] = value;
     }
 
-    public bool HasDefaultValue
-    {
-        get => columnFlags[4];
-        set => columnFlags[4] = value;
-    }
-
     public static DbColumnMetaData Create(string name, Type dataType, bool isKey, int? maxLength)
     {
         var typeId = SqlSystemTypeIdExtensions.DotnetTypeToSqlType(dataType);
@@ -145,7 +139,6 @@ public sealed record DbColumnMetaData(
                         + 2*c.is_computed
                         + 4*iif(pk.column_id is not null, convert(bit, 1), convert(bit, 0))
                         + 8*c.is_identity
-                        + 16*iif(c.default_object_id <> 0, convert(bit, 1), convert(bit, 0))
                         )
                 from {fromTempDb && SQL($"tempdb.")}sys.columns c
                 left join pks pk on pk.object_id = c.object_id and pk.column_id = c.column_id

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
@@ -12,8 +12,11 @@ public sealed record DbColumnMetaData(
     short MaxLength,
     byte Precision,
     byte Scale
-) : IWrittenImplicitly, IComparable<DbColumnMetaData>
+) : IWrittenImplicitly, IComparable<DbColumnMetaData>, IDbColumn
 {
+    DbColumnMetaData IDbColumn.ColumnMetaData
+        => this;
+
     public DbObjectId DbObjectId { get; init; }
     public DbColumnId ColumnId { get; init; }
 
@@ -92,46 +95,6 @@ public sealed record DbColumnMetaData(
     public override string ToString()
         => ToStringByMembers.ToStringByPublicMembers(this);
 
-    public string ToSqlColumnDefinition()
-        => $"{ColumnName} {ToSqlTypeName()}";
-
-    string ColumnPrecisionSpecifier()
-        => UserTypeId switch {
-            _ when SemanticMaxLength(out var supportMaxLen, out var hasMaxLen) is var maxLen && supportMaxLen => hasMaxLen ? $"({maxLen})" : "(max)",
-            SqlSystemTypeId.Decimal or SqlSystemTypeId.Numeric => $"({Precision},{Scale})",
-            SqlSystemTypeId.DateTime2 or SqlSystemTypeId.DateTimeOffset or SqlSystemTypeId.Time when Scale != 7 => $"({Scale})",
-            _ => "",
-        };
-
-    public short SemanticMaxLength(out bool typeSupportsMaxLength, out bool hasMaxLength)
-    {
-        if (UserTypeId is SqlSystemTypeId.NVarChar or SqlSystemTypeId.NChar) {
-            typeSupportsMaxLength = true;
-            hasMaxLength = MaxLength > 0;
-            return (short)(MaxLength >> 1);
-        } else if (UserTypeId is SqlSystemTypeId.VarChar or SqlSystemTypeId.Char or SqlSystemTypeId.VarBinary or SqlSystemTypeId.Binary) {
-            typeSupportsMaxLength = true;
-            hasMaxLength = MaxLength > 0;
-            return MaxLength;
-        } else {
-            typeSupportsMaxLength = false;
-            hasMaxLength = false;
-            return 0;
-        }
-    }
-
-    public string ToSqlTypeName()
-        => ToSqlTypeNameWithoutNullability() + NullabilityAnnotation();
-
-    public string ToSqlTypeNameWithoutNullability()
-        => UserTypeId.SqlUnderlyingTypeInfo().SqlTypeName + ColumnPrecisionSpecifier();
-
-    string NullabilityAnnotation()
-        => IsNullable ? " null" : " not null";
-
-    public ParameterizedSql ToSqlColumnDefinitionSql()
-        => ParameterizedSql.CreateDynamic($"{ColumnName} {ToSqlTypeName()}");
-
     public DataColumn ToDataColumn()
         => new(ColumnName, UserTypeId.SqlUnderlyingTypeInfo().ClrType);
 
@@ -147,10 +110,6 @@ public sealed record DbColumnMetaData(
         }
     }
 
-    [Pure]
-    public ParameterizedSql SqlColumnName()
-        => ParameterizedSql.CreateDynamic(isSafeForSql.IsMatch(ColumnName) ? ColumnName : throw new NotSupportedException("this isn't safe!"));
-
     static readonly ParameterizedSql tempDb = SQL($"tempdb");
 
     public static DbColumnMetaData[] ColumnMetaDatas(SqlConnection conn, ParameterizedSql objectName)
@@ -164,7 +123,6 @@ public sealed record DbColumnMetaData(
     public static DbColumnMetaData[] LoadAll(SqlConnection conn)
         => RunQuery(conn, false, new());
 
-    static readonly Regex isSafeForSql = new("^[a-zA-Z0-9_]+$", RegexOptions.ECMAScript | RegexOptions.Compiled);
 
     public static ParameterizedSql BaseQuery(bool fromTempDb)
         => SQL(

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
@@ -89,20 +89,6 @@ public sealed record DbColumnMetaData(
     public override string ToString()
         => ToStringByMembers.ToStringByPublicMembers(this);
 
-    public DataColumn ToDataColumn()
-        => new(ColumnName, UserTypeId.SqlUnderlyingTypeInfo().ClrType);
-
-    public DbColumnMetaData AsStaticRowVersion()
-    {
-        if (IsRowVersion) {
-            return this with {
-                UserTypeId = SqlSystemTypeId.Binary,
-                MaxLength = 8,
-            };
-        } else {
-            return this;
-        }
-    }
 
     static readonly ParameterizedSql tempDb = SQL($"tempdb");
 
@@ -164,7 +150,7 @@ public sealed record DbColumnMetaData(
 public static class DbColumnMetaDataExtensions
 {
     [Pure]
-    public static ParameterizedSql CreateNewTableQuery(this IReadOnlyCollection<DbColumnMetaData> columns, ParameterizedSql tableName)
+    public static ParameterizedSql CreateNewTableQuery(this IReadOnlyCollection<IDbColumn> columns, ParameterizedSql tableName)
     {
         var keyColumns = columns
             .Where(md => md.IsPrimaryKey)

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DbNamedObjectId.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DbNamedObjectId.cs
@@ -3,7 +3,13 @@ namespace ProgressOnderwijsUtils.SchemaReflection;
 [DbIdEnum]
 public enum DbObjectId { }
 
-public struct DbNamedObjectId : IWrittenImplicitly
+public interface IDbNamedObject
+{
+    DbObjectId ObjectId { get; }
+    string QualifiedName { get; }
+}
+
+public struct DbNamedObjectId : IWrittenImplicitly, IDbNamedObject
 {
     public DbObjectId ObjectId { get; init; }
     public string QualifiedName { get; init; }

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DbObjectIndex.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DbObjectIndex.cs
@@ -7,7 +7,7 @@ public sealed record DbObjectIndex : IWrittenImplicitly
 {
     public DbObjectId ObjectId { get; init; }
     public DbIndexId IndexId { get; init; }
-    public string? IndexNaam { get; init; }
+    public string? IndexName { get; init; }
     public SqlIndexType IndexType { get; init; }
     public bool IsPrimaryKey { get; init; }
     public bool IsUniqueConstraint { get; init; }
@@ -21,7 +21,7 @@ public sealed record DbObjectIndex : IWrittenImplicitly
             select
                 ObjectId = i.object_id
                 , IndexId = i.index_id
-                , IndexNaam = i.name
+                , IndexName = i.name
                 , IndexType =  i.type
                 , IsUniqueConstraint = i.is_unique_constraint
                 , IsUnique =  i.is_unique

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DbObjectIndex.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DbObjectIndex.cs
@@ -35,11 +35,15 @@ public sealed record DbObjectIndex : IWrittenImplicitly
         ).ReadPocos<DbObjectIndex>(conn);
 }
 
+[DbIdEnum]
+public enum DbIndexColumnId { }
+
 public sealed record DbObjectIndexColumn : IWrittenImplicitly
 {
     public DbObjectId ObjectId { get; init; }
     public DbIndexId IndexId { get; init; }
     public DbColumnId ColumnId { get; init; }
+    public DbIndexColumnId IndexColumnId { get; init; }
     public byte KeyOrdinal { get; init; }
     public bool IsDescending { get; init; }
     public bool IsIncluded { get; init; }
@@ -51,6 +55,7 @@ public sealed record DbObjectIndexColumn : IWrittenImplicitly
                 ObjectId = sic.object_id
                 , IndexId = sic.index_id
                 , ColumnId = sic.column_id
+                , IndexColumnId = sic.index_column_id
                 , KeyOrdinal = sic.key_ordinal
                 , IsDescending = sic.is_descending_key
                 , IsIncluded = sic.is_included_column

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DefaultValueConstraintSqlDefinition.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DefaultValueConstraintSqlDefinition.cs
@@ -11,7 +11,6 @@ public sealed record DefaultValueConstraintSqlDefinition(DbObjectId ParentObject
                         , d.name
                         , d.definition
                     from sys.default_constraints d
-                    join sys.columns c on d.parent_object_id = c.object_id and d.parent_column_id = c.column_id
                 "
         ).ReadPocos<DefaultValueConstraintSqlDefinition>(conn);
 }

--- a/src/ProgressOnderwijsUtils/SchemaReflection/IDbColumn.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/IDbColumn.cs
@@ -49,6 +49,21 @@ public static class DbColumnExtensions
             _ => "",
         };
 
+    public static DataColumn ToDataColumn(this IDbColumn column)
+        => new(column.ColumnName, column.UserTypeId.SqlUnderlyingTypeInfo().ClrType);
+
+    public static IDbColumn AsStaticRowVersion(this IDbColumn column)
+    {
+        if (column.IsRowVersion) {
+            return column.ColumnMetaData with {
+                UserTypeId = SqlSystemTypeId.Binary,
+                MaxLength = 8,
+            };
+        } else {
+            return column;
+        }
+    }
+
     public static bool IsReadOnly(this IDbColumn sqlColumn)
         => sqlColumn.HasAutoIncrementIdentity || sqlColumn.IsComputed || sqlColumn.IsRowVersion;
 

--- a/src/ProgressOnderwijsUtils/SchemaReflection/IDbColumn.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/IDbColumn.cs
@@ -15,6 +15,7 @@ public interface IDbColumn
     short MaxLength { get; }
     byte Precision { get; }
     byte Scale { get; }
+    bool HasAutoIncrementIdentity { get; }
 }
 
 public static class DbColumnExtensions
@@ -47,6 +48,9 @@ public static class DbColumnExtensions
             SqlSystemTypeId.DateTime2 or SqlSystemTypeId.DateTimeOffset or SqlSystemTypeId.Time when column.Scale != 7 => $"({column.Scale})",
             _ => "",
         };
+
+    public static bool IsReadOnly(this IDbColumn sqlColumn)
+        => sqlColumn.HasAutoIncrementIdentity || sqlColumn.IsComputed || sqlColumn.IsRowVersion;
 
     public static short SemanticMaxLength(this IDbColumn column, out bool typeSupportsMaxLength, out bool hasMaxLength)
     {

--- a/src/ProgressOnderwijsUtils/SchemaReflection/IDbColumn.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/IDbColumn.cs
@@ -1,0 +1,67 @@
+namespace ProgressOnderwijsUtils.SchemaReflection;
+
+public interface IDbColumn
+{
+    DbColumnMetaData ColumnMetaData { get; }
+    DbColumnId ColumnId { get; }
+    string ColumnName { get; }
+    bool IsPrimaryKey { get; }
+    bool IsRowVersion { get; }
+    bool IsComputed { get; }
+    bool IsNullable { get; }
+    SqlSystemTypeId UserTypeId { get; }
+    bool IsString { get; }
+    bool IsUnicode { get; }
+    short MaxLength { get; }
+    byte Precision { get; }
+    byte Scale { get; }
+}
+
+public static class DbColumnExtensions
+{
+    static readonly Regex isSafeForSql = new("^[a-zA-Z0-9_]+$", RegexOptions.ECMAScript | RegexOptions.Compiled);
+
+    [Pure]
+    public static ParameterizedSql SqlColumnName(this IDbColumn column)
+        => ParameterizedSql.CreateDynamic(isSafeForSql.IsMatch(column.ColumnName) ? column.ColumnName : throw new NotSupportedException("this isn't safe!"));
+
+    public static string ToSqlColumnDefinition(this IDbColumn column)
+        => $"{column.ColumnName} {column.ToSqlTypeName()}";
+
+    public static ParameterizedSql ToSqlColumnDefinitionSql(this IDbColumn column)
+        => ParameterizedSql.CreateDynamic($"{column.ColumnName} {column.ToSqlTypeName()}");
+
+    public static string ToSqlTypeName(this IDbColumn column)
+        => column.ToSqlTypeNameWithoutNullability() + column.NullabilityAnnotation();
+
+    public static string ToSqlTypeNameWithoutNullability(this IDbColumn column)
+        => column.UserTypeId.SqlUnderlyingTypeInfo().SqlTypeName + column.ColumnPrecisionSpecifier();
+
+    static string NullabilityAnnotation(this IDbColumn column)
+        => column.IsNullable ? " null" : " not null";
+
+    static string ColumnPrecisionSpecifier(this IDbColumn column)
+        => column.UserTypeId switch {
+            _ when column.SemanticMaxLength(out var supportMaxLen, out var hasMaxLen) is var maxLen && supportMaxLen => hasMaxLen ? $"({maxLen})" : "(max)",
+            SqlSystemTypeId.Decimal or SqlSystemTypeId.Numeric => $"({column.Precision},{column.Scale})",
+            SqlSystemTypeId.DateTime2 or SqlSystemTypeId.DateTimeOffset or SqlSystemTypeId.Time when column.Scale != 7 => $"({column.Scale})",
+            _ => "",
+        };
+
+    public static short SemanticMaxLength(this IDbColumn column, out bool typeSupportsMaxLength, out bool hasMaxLength)
+    {
+        if (column.UserTypeId is SqlSystemTypeId.NVarChar or SqlSystemTypeId.NChar) {
+            typeSupportsMaxLength = true;
+            hasMaxLength = column.MaxLength > 0;
+            return (short)(column.MaxLength >> 1);
+        } else if (column.UserTypeId is SqlSystemTypeId.VarChar or SqlSystemTypeId.Char or SqlSystemTypeId.VarBinary or SqlSystemTypeId.Binary) {
+            typeSupportsMaxLength = true;
+            hasMaxLength = column.MaxLength > 0;
+            return column.MaxLength;
+        } else {
+            typeSupportsMaxLength = false;
+            hasMaxLength = false;
+            return 0;
+        }
+    }
+}

--- a/src/ProgressOnderwijsUtils/SchemaReflection/RawDatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/RawDatabaseDescription.cs
@@ -35,13 +35,13 @@ public sealed record RawDatabaseDescription
 
     static ObjectDependency[] Load_sql_expression_dependencies(SqlConnection conn)
         => SQL(
-            $@"
-                select
-                    sed.referencing_id
-                    , sed.referenced_id
-                from sys.sql_expression_dependencies sed
-                where 1=1
-                    and sed.referenced_id is not null
-            "
+            $"""
+            select
+                sed.referencing_id
+                , sed.referenced_id
+            from sys.sql_expression_dependencies sed
+            where 1=1
+                and sed.referenced_id is not null
+            """
         ).ReadPocos<ObjectDependency>(conn);
 }

--- a/src/ProgressOnderwijsUtils/SchemaReflection/RawDatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/RawDatabaseDescription.cs
@@ -45,3 +45,27 @@ public sealed record RawDatabaseDescription
             """
         ).ReadPocos<ObjectDependency>(conn);
 }
+
+sealed record DatabaseDescriptionById
+{
+    public required IReadOnlyDictionary<(DbObjectId ParentObjectId, DbColumnId ParentColumnId), DefaultValueConstraintSqlDefinition> DefaultValues { get; init; }
+    public required IReadOnlyDictionary<(DbObjectId ObjectId, DbColumnId ColumnId), ComputedColumnSqlDefinition> ComputedColumns { get; init; }
+    public required IReadOnlyDictionary<DbObjectId, CheckConstraintSqlDefinition[]> CheckConstraints { get; init; }
+    public required IReadOnlyDictionary<DbObjectId, DmlTableTriggerSqlDefinition[]> Triggers { get; init; }
+    public required Dictionary<DbObjectId, DbColumnMetaData[]> Columns { get; init; }
+    public required ILookup<DbObjectId, DbObjectId> SqlExpressionDependsOn { get; init; }
+    public required ILookup<DbObjectId, DbObjectIndex> Indexes { get; init; }
+    public required ILookup<(DbObjectId ObjectId, DbIndexId IndexId), DbObjectIndexColumn> IndexColumns { get; init; }
+
+    internal static DatabaseDescriptionById Create(RawDatabaseDescription rawDescription)
+        => new() {
+            DefaultValues = rawDescription.DefaultConstraints.ToDictionary(o => (o.ParentObjectId, o.ParentColumnId)),
+            ComputedColumns = rawDescription.ComputedColumnDefinitions.ToDictionary(o => (o.ObjectId, o.ColumnId)),
+            CheckConstraints = rawDescription.CheckConstraints.ToGroupedDictionary(o => o.TableObjectId, (_, g) => g.ToArray()),
+            Triggers = rawDescription.DmlTableTriggers.ToGroupedDictionary(o => o.TableObjectId, (_, g) => g.ToArray()),
+            Columns = rawDescription.Columns.ToGroupedDictionary(col => col.DbObjectId, (_, cols) => cols.Order().ToArray()),
+            SqlExpressionDependsOn = rawDescription.Dependencies.ToLookup(dep => dep.referencing_id, dep => dep.referenced_id),
+            Indexes = rawDescription.Indexes.ToLookup(o => o.ObjectId),
+            IndexColumns = rawDescription.IndexColumns.ToLookup(o => (o.ObjectId, o.IndexId)),
+        };
+}

--- a/src/ProgressOnderwijsUtils/SchemaReflection/RawDatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/RawDatabaseDescription.cs
@@ -45,16 +45,16 @@ public sealed record RawDatabaseDescription
             """
         ).ReadPocos<ObjectDependency>(conn);
 
-    internal static DatabaseDescriptionById IndexById(RawDatabaseDescription rawDescription)
+    internal DatabaseDescriptionById IndexById()
         => new() {
-            DefaultValues = rawDescription.DefaultConstraints.ToDictionary(o => (o.ParentObjectId, o.ParentColumnId)),
-            ComputedColumns = rawDescription.ComputedColumnDefinitions.ToDictionary(o => (o.ObjectId, o.ColumnId)),
-            CheckConstraints = rawDescription.CheckConstraints.ToGroupedDictionary(o => o.TableObjectId, (_, g) => g.ToArray()),
-            Triggers = rawDescription.DmlTableTriggers.ToGroupedDictionary(o => o.TableObjectId, (_, g) => g.ToArray()),
-            Columns = rawDescription.Columns.ToGroupedDictionary(col => col.DbObjectId, (_, cols) => cols.Order().ToArray()),
-            SqlExpressionDependsOn = rawDescription.Dependencies.ToLookup(dep => dep.referencing_id, dep => dep.referenced_id),
-            Indexes = rawDescription.Indexes.ToLookup(o => o.ObjectId),
-            IndexColumns = rawDescription.IndexColumns.ToLookup(o => (o.ObjectId, o.IndexId)),
+            DefaultValues = DefaultConstraints.ToDictionary(o => (o.ParentObjectId, o.ParentColumnId)),
+            ComputedColumns = ComputedColumnDefinitions.ToDictionary(o => (o.ObjectId, o.ColumnId)),
+            CheckConstraints = CheckConstraints.ToGroupedDictionary(o => o.TableObjectId, (_, g) => g.ToArray()),
+            Triggers = DmlTableTriggers.ToGroupedDictionary(o => o.TableObjectId, (_, g) => g.ToArray()),
+            Columns = Columns.ToGroupedDictionary(col => col.DbObjectId, (_, cols) => cols.Order().ToArray()),
+            SqlExpressionDependsOn = Dependencies.ToLookup(dep => dep.referencing_id, dep => dep.referenced_id),
+            Indexes = Indexes.ToLookup(o => o.ObjectId),
+            IndexColumns = IndexColumns.ToLookup(o => (o.ObjectId, o.IndexId)),
         };
 }
 

--- a/src/ProgressOnderwijsUtils/SchemaReflection/SchemaReflectionExtensions.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/SchemaReflectionExtensions.cs
@@ -3,9 +3,9 @@ namespace ProgressOnderwijsUtils.SchemaReflection;
 public static class SchemaReflectionExtensions
 {
     public static DataTable ToEmptyDataTable(this DatabaseDescription.Table tableDescription)
-        => tableDescription.Columns.Select(col => col.ColumnMetaData).ToEmptyDataTable(tableDescription.QualifiedName);
+        => tableDescription.Columns.ToEmptyDataTable(tableDescription.QualifiedName);
 
-    public static DataTable ToEmptyDataTable(this IEnumerable<DbColumnMetaData> columns, string qualifiedTableName)
+    public static DataTable ToEmptyDataTable(this IEnumerable<IDbColumn> columns, string qualifiedTableName)
     {
         var table = new DataTable(DbQualifiedNameUtils.UnqualifiedTableName(qualifiedTableName), DbQualifiedNameUtils.SchemaFromQualifiedName(qualifiedTableName));
         table.Columns.AddRange(columns.Select(col => col.ToDataColumn()).ToArray());

--- a/test/ProgressOnderwijsUtils.Tests/Data/DatabaseDescriptionTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/DatabaseDescriptionTest.cs
@@ -7,11 +7,11 @@ public sealed class DatabaseDescriptionTest : TransactedLocalConnection
     {
         var db = CreateSampleData();
 
-        var SomeDataWithDefault_metadata = db.GetTableByName("dbo.ForeignKeyLookupLevel").Columns.Single(c => c.ColumnName == "SomeDataWithDefault").ColumnMetaData;
-        var SomeDataWithoutDefault_metadata = db.GetTableByName("dbo.ForeignKeyLookupLevel").Columns.Single(c => c.ColumnName == "SomeDataWithoutDefault").ColumnMetaData;
+        var SomeDataWithDefault_metadata = db.GetTableByName("dbo.ForeignKeyLookupLevel").Columns.Single(c => c.ColumnName == "SomeDataWithDefault");
+        var SomeDataWithoutDefault_metadata = db.GetTableByName("dbo.ForeignKeyLookupLevel").Columns.Single(c => c.ColumnName == "SomeDataWithoutDefault");
 
-        PAssert.That(() => SomeDataWithDefault_metadata.HasDefaultValue);
-        PAssert.That(() => !SomeDataWithoutDefault_metadata.HasDefaultValue);
+        PAssert.That(() => SomeDataWithDefault_metadata.DefaultValueConstraint != null);
+        PAssert.That(() => SomeDataWithoutDefault_metadata.DefaultValueConstraint == null);
     }
 
     DatabaseDescription CreateSampleData()


### PR DESCRIPTION
Immediate motivation is to reduce the number of times schema information is read (https://github.com/progressonderwijs/progress/issues/53103); but it's also just a lot simpler to centralize this in one file rather than read half from `DatabaseDescription` and half from schema-tables directly.

