### PR TITLE
Improve usability of API

### DIFF
--- a/src/ProgressOnderwijsUtils/Data/SqlBatch.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlBatch.cs
@@ -146,7 +146,7 @@ public readonly record struct PocosSqlCommand<
             throw cmd.CreateExceptionWithTextAndArguments(ex, this, "DataReaderToSingleRowUnpacker failed");
         }
         var rows = ParameterizedSqlObjectMapper.ReaderToArray(this, reader, unpacker, cmd);
-        var nullableVerifier = NonNullableFieldVerifier.MissingRequiredProperties_FuncFactory<T>();
+        var nullableVerifier = NonNullableFieldVerifier.VerificationDelegate<T>();
         foreach (var row in rows) {
             var nullablityError = nullableVerifier(row);
             if (nullablityError != null) {
@@ -206,7 +206,7 @@ public readonly record struct EnumeratedObjectsSqlCommand<T>(ParameterizedSql Sq
             } catch (Exception e) {
                 throw cmd.CreateExceptionWithTextAndArguments(e, this, ParameterizedSqlObjectMapper.UnpackingErrorMessage<T>(reader, lastColumnRead));
             }
-            var nullableVerifier = NonNullableFieldVerifier.MissingRequiredProperties_FuncFactory<T>();
+            var nullableVerifier = NonNullableFieldVerifier.VerificationDelegate<T>();
             var nullablityError = nullableVerifier(nextRow);
             if (nullablityError != null) {
                 throw new(nullablityError.JoinStrings("\n"));

--- a/src/ProgressOnderwijsUtils/Pocos/NonNullableFieldVerifier.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/NonNullableFieldVerifier.cs
@@ -1,6 +1,6 @@
 using static ProgressOnderwijsUtils.BackingFieldDetector;
 
-namespace ProgressOnderwijsUtils.RequiredFields;
+namespace ProgressOnderwijsUtils;
 
 public static class NonNullableFieldVerifier
 {

--- a/src/ProgressOnderwijsUtils/RequiredFields/NonNullableFieldVerifier.cs
+++ b/src/ProgressOnderwijsUtils/RequiredFields/NonNullableFieldVerifier.cs
@@ -72,6 +72,6 @@ public static class NonNullableFieldVerifier
             => AutoPropertyOfFieldOrNull(field) is { } autoProp ? autoProp.Name : field.Name;
     }
 
-    public static Func<T, string[]?> MissingRequiredProperties_FuncFactory<T>()
+    public static Func<T, string[]?> VerificationDelegate<T>()
         => Cache<T>.checker ?? throw new("Failed to construct nullability verifier", Cache<T>.exception);
 }

--- a/src/ProgressOnderwijsUtils/RequiredFields/NonNullableFieldVerifier.cs
+++ b/src/ProgressOnderwijsUtils/RequiredFields/NonNullableFieldVerifier.cs
@@ -74,4 +74,7 @@ public static class NonNullableFieldVerifier
 
     public static Func<T, string[]?> VerificationDelegate<T>()
         => Cache<T>.checker ?? throw new("Failed to construct nullability verifier", Cache<T>.exception);
+
+    public static string[]? Verify<T>(T obj)
+        => VerificationDelegate<T>()(obj);
 }

--- a/test/ProgressOnderwijsUtils.Tests/NonNullableNullabilityCheck.cs
+++ b/test/ProgressOnderwijsUtils.Tests/NonNullableNullabilityCheck.cs
@@ -39,19 +39,19 @@ public sealed class NonNullableNullabilityCheck
 
     [Fact]
     public void AssertOneNullFieldIsDetected()
-        => PAssert.That(() => NonNullableFieldVerifier.MissingRequiredProperties_FuncFactory<NullablityTestClass>()(OneContainingNull).EmptyIfNull().SequenceEqual(new[] { getVerifierMessage(nameof(NullablityTestClass.SomeNullString)), }));
+        => PAssert.That(() => NonNullableFieldVerifier.VerificationDelegate<NullablityTestClass>()(OneContainingNull).EmptyIfNull().SequenceEqual(new[] { getVerifierMessage(nameof(NullablityTestClass.SomeNullString)), }));
 
     [Fact]
     public void AssertAllNullFieldsAreDetected()
-        => PAssert.That(() => NonNullableFieldVerifier.MissingRequiredProperties_FuncFactory<NullablityTestClass>()(AllContainingNull).EmptyIfNull().SequenceEqual(new[] { getVerifierMessage(nameof(NullablityTestClass.SomeNullString)), getVerifierMessage(nameof(NullablityTestClass.SomeObject)), getVerifierMessage(nameof(NullablityTestClass.SomeObjectArray)), }));
+        => PAssert.That(() => NonNullableFieldVerifier.VerificationDelegate<NullablityTestClass>()(AllContainingNull).EmptyIfNull().SequenceEqual(new[] { getVerifierMessage(nameof(NullablityTestClass.SomeNullString)), getVerifierMessage(nameof(NullablityTestClass.SomeObject)), getVerifierMessage(nameof(NullablityTestClass.SomeObjectArray)), }));
 
     [Fact]
     public void AssertAllNullFieldsAreDetected_SubClass()
-        => PAssert.That(() => NonNullableFieldVerifier.MissingRequiredProperties_FuncFactory<NullabilityTestSubClass>()(ContainingAllNullSubClass).EmptyIfNull().SequenceEqual(new[] { getVerifierMessage(nameof(NullablityTestClass.SomeNullString)), getVerifierMessage(nameof(NullablityTestClass.SomeObject)), getVerifierMessage(nameof(NullablityTestClass.SomeObjectArray)), }));
+        => PAssert.That(() => NonNullableFieldVerifier.VerificationDelegate<NullabilityTestSubClass>()(ContainingAllNullSubClass).EmptyIfNull().SequenceEqual(new[] { getVerifierMessage(nameof(NullablityTestClass.SomeNullString)), getVerifierMessage(nameof(NullablityTestClass.SomeObject)), getVerifierMessage(nameof(NullablityTestClass.SomeObjectArray)), }));
 
     [Fact]
     public void AssertNoNullFieldsReturnsNull()
-        => PAssert.That(() => NonNullableFieldVerifier.MissingRequiredProperties_FuncFactory<NullablityTestClass>()(NotContainingNull) == null);
+        => PAssert.That(() => NonNullableFieldVerifier.VerificationDelegate<NullablityTestClass>()(NotContainingNull) == null);
 
     [Fact]
     public void AssertWithReflectionOfField()

--- a/test/ProgressOnderwijsUtils.Tests/NonNullableNullabilityCheck.cs
+++ b/test/ProgressOnderwijsUtils.Tests/NonNullableNullabilityCheck.cs
@@ -39,19 +39,19 @@ public sealed class NonNullableNullabilityCheck
 
     [Fact]
     public void AssertOneNullFieldIsDetected()
-        => PAssert.That(() => NonNullableFieldVerifier.VerificationDelegate<NullablityTestClass>()(OneContainingNull).EmptyIfNull().SequenceEqual(new[] { getVerifierMessage(nameof(NullablityTestClass.SomeNullString)), }));
+        => PAssert.That(() => NonNullableFieldVerifier.Verify(OneContainingNull).EmptyIfNull().SequenceEqual(new[] { getVerifierMessage(nameof(NullablityTestClass.SomeNullString)), }));
 
     [Fact]
     public void AssertAllNullFieldsAreDetected()
-        => PAssert.That(() => NonNullableFieldVerifier.VerificationDelegate<NullablityTestClass>()(AllContainingNull).EmptyIfNull().SequenceEqual(new[] { getVerifierMessage(nameof(NullablityTestClass.SomeNullString)), getVerifierMessage(nameof(NullablityTestClass.SomeObject)), getVerifierMessage(nameof(NullablityTestClass.SomeObjectArray)), }));
+        => PAssert.That(() => NonNullableFieldVerifier.Verify(AllContainingNull).EmptyIfNull().SequenceEqual(new[] { getVerifierMessage(nameof(NullablityTestClass.SomeNullString)), getVerifierMessage(nameof(NullablityTestClass.SomeObject)), getVerifierMessage(nameof(NullablityTestClass.SomeObjectArray)), }));
 
     [Fact]
     public void AssertAllNullFieldsAreDetected_SubClass()
-        => PAssert.That(() => NonNullableFieldVerifier.VerificationDelegate<NullabilityTestSubClass>()(ContainingAllNullSubClass).EmptyIfNull().SequenceEqual(new[] { getVerifierMessage(nameof(NullablityTestClass.SomeNullString)), getVerifierMessage(nameof(NullablityTestClass.SomeObject)), getVerifierMessage(nameof(NullablityTestClass.SomeObjectArray)), }));
+        => PAssert.That(() => NonNullableFieldVerifier.Verify(ContainingAllNullSubClass).EmptyIfNull().SequenceEqual(new[] { getVerifierMessage(nameof(NullablityTestClass.SomeNullString)), getVerifierMessage(nameof(NullablityTestClass.SomeObject)), getVerifierMessage(nameof(NullablityTestClass.SomeObjectArray)), }));
 
     [Fact]
     public void AssertNoNullFieldsReturnsNull()
-        => PAssert.That(() => NonNullableFieldVerifier.VerificationDelegate<NullablityTestClass>()(NotContainingNull) == null);
+        => PAssert.That(() => NonNullableFieldVerifier.Verify(NotContainingNull) == null);
 
     [Fact]
     public void AssertWithReflectionOfField()

--- a/tools/ProgressOnderwijsUtilsBenchmarks/NullabilityVerifierBenchmark/NullabilityBenchmark.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/NullabilityVerifierBenchmark/NullabilityBenchmark.cs
@@ -111,7 +111,7 @@ public sealed class NullabilityBenchmark
         }
     }
 
-    static readonly Func<NullablityTestClass, string[]?> Verifier = NonNullableFieldVerifier.MissingRequiredProperties_FuncFactory<NullablityTestClass>();
+    static readonly Func<NullablityTestClass, string[]?> Verifier = NonNullableFieldVerifier.VerificationDelegate<NullablityTestClass>();
 
     [Benchmark]
     public void Compiled()


### PR DESCRIPTION
 - depends on #841 
 - issue #773 
 - allow type inference
 - don't use the word "required" because there's a keyword by that name which means something different.
 - avoid namespace with just this one class.