### PR TITLE
For analysis purposes, also provide the first diff when an approval is changed.

### DIFF
--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>96.0.3</Version>
-    <PackageReleaseNotes>Crash when "short" strings exceed 1GB instead of thrashing the garbage collector indefinitely</PackageReleaseNotes>
+    <Version>97.0.0</Version>
+    <PackageReleaseNotes>For analysis purposes, also provide the first diff when an approval is changed.</PackageReleaseNotes>
 
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>

--- a/test/ProgressOnderwijsUtils.Tests/ApprovalTestTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/ApprovalTestTest.cs
@@ -57,4 +57,19 @@ public sealed class ApprovalTestTest
             () => File.Delete(approval.ApprovalPath)
         );
     }
+
+    [Fact]
+    public void Approval_failure_gives_correct_diff()
+    {
+        var approval = ApprovalTest.CreateHere();
+        File.WriteAllText(approval.ApprovalPath, "Hello world!");
+        Utils.TryWithCleanup(
+            () => {
+                var changed = approval.IsChangedFrom("Hello astronauts ...", out var diff);
+                PAssert.That(() => changed);
+                PAssert.That(() => diff == "'world!' »» 'astron'");
+            },
+            () => File.Delete(approval.ApprovalPath)
+        );
+    }
 }

--- a/test/ProgressOnderwijsUtils.Tests/ApprovalTestTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/ApprovalTestTest.cs
@@ -72,4 +72,19 @@ public sealed class ApprovalTestTest
             () => File.Delete(approval.ApprovalPath)
         );
     }
+
+    [Fact]
+    public void Approval_success_gives_no_diff()
+    {
+        var approval = ApprovalTest.CreateHere();
+        File.WriteAllText(approval.ApprovalPath, "Hello world!");
+        Utils.TryWithCleanup(
+            () => {
+                var changed = approval.IsChangedFrom("Hello world!", out var diff);
+                PAssert.That(() => !changed);
+                PAssert.That(() => diff == "");
+            },
+            () => File.Delete(approval.ApprovalPath)
+        );
+    }
 }


### PR DESCRIPTION
For example, I've got an approval that locally succeeds, but fails on the CI. With this extra diff logging, I can analyse the failure on the CI itself.