### PR TITLE
Baseline for html->pipe (memory) benchmark

### DIFF
--- a/src/ProgressOnderwijsUtils/Extensions/StringUtils.cs
+++ b/src/ProgressOnderwijsUtils/Extensions/StringUtils.cs
@@ -2,6 +2,8 @@ namespace ProgressOnderwijsUtils;
 
 public static class StringUtils
 {
+    public static readonly Encoding Utf8WithoutBom = new UTF8Encoding(false);
+
     /// <summary>
     /// Removes all 'diakriet' from the string.
     /// </summary>

--- a/tools/ProgressOnderwijsUtilsBenchmarks/BenchmarkProgram.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/BenchmarkProgram.cs
@@ -7,11 +7,11 @@ public static class BenchmarkProgram
 {
     static void Main()
         // => RunTreeBenchmarks();
-        //=> BenchmarkRunner.Run<HtmlFragmentBenchmark>();
         //=> MicroOrmBenchmarkProgram.RunBenchmarks();
         //=> RunArrayBuilderBenchmarks();
         //=> BenchmarkRunner.Run<SmallBatchInsertBench>();
-        => BenchmarkRunner.Run<NullabilityBenchmark>();
+        //=> BenchmarkRunner.Run<NullabilityBenchmark>();
+        => BenchmarkRunner.Run<HtmlFragmentBenchmark>();
 
     [UsedImplicitly]
     static void RunArrayBuilderBenchmarks()


### PR DESCRIPTION
Baseline results:

<div>
<pre><code>BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1848/22H2/2022Update/SunValley2)
AMD Ryzen 9 7950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=7.0.400-preview.23274.1
  [Host] : .NET 7.0.7 (7.0.723.27404), X64 RyuJIT AVX2
</code></pre>
<pre><code>Job=Server  Force=False  Server=True  
Toolchain=InProcessEmitToolchain  InvocationCount=256  IterationCount=100  
LaunchCount=1  UnrollFactor=16  WarmupCount=1  
</code></pre>

<table>
<thead><tr><th> Method</th><th>Mean</th><th>Error</th><th>StdDev</th><th>Gen0</th><th>Gen1</th><th>Gen2</th><th>Allocated</th>
</tr>
</thead><tbody><tr><td>WriteToString</td><td>446.1 μs</td><td>2.61 μs</td><td>6.97 μs</td><td>109.3750</td><td>109.3750</td><td>109.3750</td><td>452.63 KB</td>
</tr><tr><td>WriteToStream</td><td>690.6 μs</td><td>2.83 μs</td><td>8.21 μs</td><td>285.1563</td><td>285.1563</td><td>285.1563</td><td>1047.21 KB</td>
</tr></tbody></table>
</div>