### PR TITLE
Fix database scripts

### DIFF
--- a/src/ProgressOnderwijsUtils/Data/SqlServerUtils.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlServerUtils.cs
@@ -34,9 +34,14 @@ public static class SqlServerUtils
 
     public static string PrettifySqlExpression(string sql)
     {
+        var withoutPointlessParens = Regex.Replace(sql, @"\((\w+)\)", m => m.Value[1..^1]);
+        return withoutPointlessParens;
+    }
+
+    public static string PrettifySqlExpressionLeaveParens(string sql)
+    {
         var uncappedKeyWords = Regex.Replace(sql, @"\b(NEXT|VALUE|FOR|IS|NOT|NULL|OR|AND|CONVERT|TRY_CAST|AS)\b", m => m.Value.ToLowerInvariant());
         var withoutPointlessBrackets = Regex.Replace(uncappedKeyWords, @"\[(\w+)\]", m => m.Value[1..^1]);
-        var withoutPointlessParens = Regex.Replace(withoutPointlessBrackets, @"\((\w+)\)", m => m.Value[1..^1]);
-        return withoutPointlessParens;
+        return withoutPointlessBrackets;
     }
 }

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>97.5.0</Version>
-    <PackageReleaseNotes>Bump dependencies</PackageReleaseNotes>
+    <Version>97.5.1</Version>
+    <PackageReleaseNotes>Small fixes in database scripting</PackageReleaseNotes>
 
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDefinitionScripter.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDefinitionScripter.cs
@@ -10,9 +10,6 @@ public sealed record DatabaseDefinitionScripter(DatabaseDescription db)
         foreach (var colMetaData in table.Columns) {
             if (colMetaData.ComputedAs is { } computedColumn) {
                 var definition = computedColumn;
-                var collationClause = colMetaData.CollationName == null
-                    ? ""
-                    : " collate " + colMetaData.CollationName;
                 var persistedClause = !definition.IsPersisted
                     ? ""
                     : colMetaData.IsNullable
@@ -24,7 +21,7 @@ public sealed record DatabaseDefinitionScripter(DatabaseDescription db)
                     + (colMetaData.IsPrimaryKey ? "PK;" : "")
                     + "colId:"
                     + colMetaData.ColumnId;
-                _ = sb.Append("    " + separatorFromPreviousCol + colMetaData.ColumnName + " as " + SqlServerUtils.PrettifySqlExpressionLeaveParens(definition.Definition) + collationClause + persistedClause + columnTrivia + "\n");
+                _ = sb.Append("    " + separatorFromPreviousCol + colMetaData.ColumnName + " as " + SqlServerUtils.PrettifySqlExpressionLeaveParens(definition.Definition) + persistedClause + columnTrivia + "\n");
             } else {
                 var identitySpecification = colMetaData.HasAutoIncrementIdentity ? " identity" : "";
                 var columnTrivia = "--"

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDefinitionScripter.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDefinitionScripter.cs
@@ -24,7 +24,7 @@ public sealed record DatabaseDefinitionScripter(DatabaseDescription db)
                     + (colMetaData.IsPrimaryKey ? "PK;" : "")
                     + "colId:"
                     + colMetaData.ColumnId;
-                _ = sb.Append("    " + separatorFromPreviousCol + colMetaData.ColumnName + " as " + SqlServerUtils.PrettifySqlExpression(definition.Definition) + collationClause + persistedClause + columnTrivia + "\n");
+                _ = sb.Append("    " + separatorFromPreviousCol + colMetaData.ColumnName + " as " + SqlServerUtils.PrettifySqlExpressionLeaveParens(definition.Definition) + collationClause + persistedClause + columnTrivia + "\n");
             } else {
                 var identitySpecification = colMetaData.HasAutoIncrementIdentity ? " identity" : "";
                 var columnTrivia = "--"

--- a/src/ProgressOnderwijsUtils/SchemaReflection/IDbColumn.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/IDbColumn.cs
@@ -37,7 +37,7 @@ public static class DbColumnExtensions
         => column.ToSqlTypeNameWithoutNullability() + CollationForStringColumn(column) + column.NullabilityAnnotation();
 
     static string CollationForStringColumn(IDbColumn column)
-        => column.IsString ? $" collate {column.ColumnMetaData.CollationName ?? DefaultDbCollation}" : "";
+        => column.IsString && column.UserTypeId != SqlSystemTypeId.Xml ? $" collate {column.ColumnMetaData.CollationName ?? DefaultDbCollation}" : "";
 
     public static string ToSqlTypeNameWithoutNullability(this IDbColumn column)
         => column.UserTypeId.SqlUnderlyingTypeInfo().SqlTypeName + column.ColumnPrecisionSpecifier();


### PR DESCRIPTION
- https://github.com/progressonderwijs/Academica/issues/80

Paar kleine aanpassingen in het maken van databasescripts. Hierna zal de approval van de databasedefinitie ook afgaan. Deze aanpassingen zijn nodig om de scripts te gebruiken om een nieuwe database aan te maken. Voor de approvals maakt het niet echt uit dat de sql niet helemaal valide is maar bij het maken van een nieuwe database is dat wel nodig.