### PR TITLE
Prep potential use of InterpolatedStringHandler

### DIFF
--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDefinitionScripter.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDefinitionScripter.cs
@@ -98,7 +98,7 @@ public sealed record DatabaseDefinitionScripter(DatabaseDescription db)
         }
         return sb;
     }
-    
+
     static StringBuilder DatabaseTriggersScript(TriggerSqlDefinition dbTrigger)
     {
         var sb = new StringBuilder();
@@ -120,7 +120,7 @@ public sealed record DatabaseDefinitionScripter(DatabaseDescription db)
     public string StringifySchema(bool includeNondeterminisiticObjectIds)
     {
         var sb = new StringBuilder();
-        foreach(var schema in db.RawDescription.Schemas.Order()) {
+        foreach (var schema in db.RawDescription.Schemas.Order()) {
             _ = sb.Append(SchemaScript(schema.AssertNotNull()));
         }
         foreach (var sequence in db.Sequences.Values.OrderBy(s => s.QualifiedName)) {
@@ -140,10 +140,10 @@ public sealed record DatabaseDefinitionScripter(DatabaseDescription db)
     public string StringifySchemaForDbCreation()
     {
         var sb = new StringBuilder();
-        foreach(var schema in db.RawDescription.Schemas.Order()) {
+        foreach (var schema in db.RawDescription.Schemas.Order()) {
             _ = sb.Append(SchemaScript(schema.AssertNotNull()));
         }
-        
+
         foreach (var sequence in db.Sequences.Values.OrderBy(s => s.QualifiedName)) {
             sequence.AppendCreationScript(sb);
         }

--- a/test/ProgressOnderwijsUtils.Tests/Data/AsSqlInExpressionTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/AsSqlInExpressionTest.cs
@@ -4,15 +4,24 @@ public sealed class AsSqlInExpressionTest : TransactedLocalConnection
 {
     [Fact]
     public void In_helper_generates_for_empty_set()
-        => PAssert.That(() => SQL($"x.y in {Array.Empty<int>().AsUnrolledSqlInExpression()}").CommandText() == "x.y in (null)");
+    {
+        var xyInEmptySql = SQL($"x.y in {Array.Empty<int>().AsUnrolledSqlInExpression()}");
+        PAssert.That(() => xyInEmptySql.CommandText() == "x.y in (null)");
+    }
 
     [Fact]
     public void In_helper_generates_for_single_item()
-        => PAssert.That(() => SQL($"x.y in {new[] { 7, }.AsUnrolledSqlInExpression()}").CommandText() == "x.y in ( @par0 )");
+    {
+        var sql = SQL($"x.y in {new[] { 7, }.AsUnrolledSqlInExpression()}");
+        PAssert.That(() => sql.CommandText() == "x.y in ( @par0 )");
+    }
 
     [Fact]
     public void In_helper_generates_for_multiple_items()
-        => PAssert.That(() => SQL($"x.y in {new[] { 7, 11, 13, }.AsUnrolledSqlInExpression()}").CommandText() == "x.y in ( @par0 , @par1 , @par2 )");
+    {
+        var sql = SQL($"x.y in {new[] { 7, 11, 13, }.AsUnrolledSqlInExpression()}");
+        PAssert.That(() => sql.CommandText() == "x.y in ( @par0 , @par1 , @par2 )");
+    }
 
     [Fact]
     public void In_helper_works_on_actual_query()
@@ -24,12 +33,19 @@ public sealed class AsSqlInExpressionTest : TransactedLocalConnection
             "
         ).ExecuteNonQuery(Connection);
 
-        PAssert.That(() => SQL($"select t.x from Tin t where t.x in {Array.Empty<int>().AsUnrolledSqlInExpression()}").ReadPlain<int?>(Connection).None());
-        PAssert.That(() => SQL($"select t.y from Tin t where t.y in {Array.Empty<int>().AsUnrolledSqlInExpression()}").ReadPlain<int?>(Connection).None());
+        var xQueriedInEmpty = SQL($"select t.x from Tin t where t.x in {Array.Empty<int>().AsUnrolledSqlInExpression()}").ReadPlain<int?>(Connection);
+        PAssert.That(() => xQueriedInEmpty.None());
 
-        PAssert.That(() => SQL($"select t.x from Tin t where t.x in {new[] { 3, }.AsUnrolledSqlInExpression()}").ReadPlain<int?>(Connection).Single() == 3);
-        PAssert.That(() => SQL($"select t.x from Tin t where t.x in {new[] { 999, }.AsUnrolledSqlInExpression()}").ReadPlain<int?>(Connection).None());
+        var yQueriedInEmpty = SQL($"select t.y from Tin t where t.y in {Array.Empty<int>().AsUnrolledSqlInExpression()}").ReadPlain<int?>(Connection);
+        PAssert.That(() => yQueriedInEmpty.None());
 
-        PAssert.That(() => SQL($"select t.y from Tin t where t.y in {new[] { 7, 999, }.AsUnrolledSqlInExpression()}").ReadPlain<int?>(Connection).Single() == 7);
+        var xQueriedInExistingSet = SQL($"select t.x from Tin t where t.x in {new[] { 3, }.AsUnrolledSqlInExpression()}").ReadPlain<int?>(Connection);
+        PAssert.That(() => xQueriedInExistingSet.Single() == 3);
+
+        var xQueriedInNonExistingSet = SQL($"select t.x from Tin t where t.x in {new[] { 999, }.AsUnrolledSqlInExpression()}").ReadPlain<int?>(Connection);
+        PAssert.That(() => xQueriedInNonExistingSet.None());
+
+        var yQueriedPartialOverlap = SQL($"select t.y from Tin t where t.y in {new[] { 7, 999, }.AsUnrolledSqlInExpression()}").ReadPlain<int?>(Connection);
+        PAssert.That(() => yQueriedPartialOverlap.Single() == 7);
     }
 }

--- a/test/ProgressOnderwijsUtils.Tests/Data/ConcatenateSqlTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/ConcatenateSqlTest.cs
@@ -6,16 +6,30 @@ public sealed class ConcatenateSqlTest
     public void ConcatenatationOfEmptySequenceIsEmpty()
     {
         PAssert.That(() => Array.Empty<ParameterizedSql>().ConcatenateSql() == ParameterizedSql.Empty);
-        PAssert.That(() => Array.Empty<ParameterizedSql>().ConcatenateSql(SQL($"bla")) == ParameterizedSql.Empty);
+        var bla = SQL($"bla");
+        PAssert.That(() => Array.Empty<ParameterizedSql>().ConcatenateSql(bla) == ParameterizedSql.Empty);
     }
 
     [Fact]
     public void ConcatenateWithEmptySeparatorIsStillSpaced()
-        => PAssert.That(() => new[] { SQL($"een"), SQL($"twee"), SQL($"drie"), }.ConcatenateSql() == SQL($"een twee drie"));
+    {
+        var een = SQL($"een");
+        var twee = SQL($"twee");
+        var drie = SQL($"drie");
+        var expected = SQL($"een twee drie");
+        PAssert.That(() => new[] { een, twee, drie, }.ConcatenateSql() == expected);
+    }
 
     [Fact]
     public void ConcatenateWithSeparatorUsesSeparatorSpaced()
-        => PAssert.That(() => new[] { SQL($"een"), SQL($"twee"), SQL($"drie"), }.ConcatenateSql(SQL($"!")) == SQL($"een ! twee ! drie"));
+    {
+        var een = SQL($"een");
+        var twee = SQL($"twee");
+        var drie = SQL($"drie");
+        var separator = SQL($"!");
+        var expected = SQL($"een ! twee ! drie");
+        PAssert.That(() => new[] { een, twee, drie, }.ConcatenateSql(separator) == expected);
+    }
 
     [Fact]
     public void ConcatenateIsFastEnoughForLargeSequences()

--- a/test/ProgressOnderwijsUtils.Tests/Data/DatabaseDescriptionTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/DatabaseDescriptionTest.cs
@@ -106,7 +106,7 @@ end;";
     [Fact]
     public void CheckDatabaseTriggers_works()
     {
-        var definition = 
+        var definition =
             """
             create trigger EenTrigger on database for create_table, alter_table as
             begin

--- a/test/ProgressOnderwijsUtils.Tests/Data/ParameterValuesForDebuggingExtensionTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/ParameterValuesForDebuggingExtensionTest.cs
@@ -4,20 +4,31 @@ public static class ParameterValuesForDebuggingExtensionTest
 {
     [Fact]
     public static void ParameterlessSqlHasNoParameters()
-        => PAssert.That(() => SQL($"Hello").ParameterValuesForDebugging().None());
+    {
+        var sql = SQL($"Hello");
+        PAssert.That(() => sql.ParameterValuesForDebugging().None());
+    }
 
     [Fact]
     public static void IntParametersCanBeRetrieved()
     {
-        PAssert.That(() => SQL($"Hello{1}").ParameterValuesForDebugging().SequenceEqual(new object[] { 1, }));
-        PAssert.That(() => SQL($"Hello{3}, {2}, {1}").ParameterValuesForDebugging().SequenceEqual(new object[] { 3, 2, 1, }));
+        var sqlA = SQL($"Hello{1}");
+        PAssert.That(() => sqlA.ParameterValuesForDebugging().SequenceEqual(new object[] { 1, }));
+        var sqlB = SQL($"Hello{3}, {2}, {1}");
+        PAssert.That(() => sqlB.ParameterValuesForDebugging().SequenceEqual(new object[] { 3, 2, 1, }));
     }
 
     [Fact]
     public static void DateTimeParametersCanBeRetrieved()
-        => PAssert.That(() => SQL($"Hello{new DateTime(2000, 1, 1)}").ParameterValuesForDebugging().SequenceEqual(new object[] { new DateTime(2000, 1, 1), }));
+    {
+        var sql = SQL($"Hello{new DateTime(2000, 1, 1)}");
+        PAssert.That(() => sql.ParameterValuesForDebugging().SequenceEqual(new object[] { new DateTime(2000, 1, 1), }));
+    }
 
     [Fact]
     public static void CurrentTimeTokenIsNotReplaced()
-        => PAssert.That(() => SQL($"Hello{CurrentTimeToken.Instance}").ParameterValuesForDebugging().SequenceEqual(new object[] { CurrentTimeToken.Instance, }));
+    {
+        var sql = SQL($"Hello{CurrentTimeToken.Instance}");
+        PAssert.That(() => sql.ParameterValuesForDebugging().SequenceEqual(new object[] { CurrentTimeToken.Instance, }));
+    }
 }

--- a/test/ProgressOnderwijsUtils.Tests/Data/TableValuedParameterTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/TableValuedParameterTest.cs
@@ -83,7 +83,6 @@ public sealed class TableValuedParameterTest : TransactedLocalConnection
         PAssert.That(() => sum == (100 * 100 + 100) / 2);
     }
 
-
     [Fact]
     public void ParameterizedSqlTvpsCanCountDaysOfWeek()
     {
@@ -126,14 +125,15 @@ public sealed class TableValuedParameterTest : TransactedLocalConnection
 
     [Fact]
     public void Binary_columns_can_be_used_in_tvps()
-        => PAssert.That(
-            () => SQL(
-                $@"
+    {
+        var dataLengthSumQuery = SQL(
+            $@"
                 select sum(datalength(hashes.QueryTableValue))
                 from {new[] { Encoding.ASCII.GetBytes("0123456789"), Encoding.ASCII.GetBytes("abcdef"), }} hashes
             "
-            ).ReadPlain<long>(Connection).Single() == 16
         );
+        PAssert.That(() => dataLengthSumQuery.ReadPlain<long>(Connection).Single() == 16);
+    }
 
     public sealed class TestDataPoco : IReadImplicitly
     {

--- a/test/ProgressOnderwijsUtils.Tests/Data/TestSqlParameterComponent.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/TestSqlParameterComponent.cs
@@ -53,11 +53,16 @@ public sealed class TestSqlParameterComponent : TransactedLocalConnection
     [Fact]
     public void DeDuplication_of_convertable_parameters()
     {
-        PAssert.That(() => SQL($"select {3}, {3}").CommandText() == "select @par0, @par0");
-        PAssert.That(() => SQL($"select {Wrap(3)}, {Wrap(3)}").CommandText() == "select @par0, @par0");
-        PAssert.That(() => SQL($"select {3}, {Wrap(3)}").CommandText() == "select @par0, @par0", "TODO: We would like this to be conceptually different parameters");
-        PAssert.That(() => SQL($"select {3}, {TrivialConvertibleValue.Create(3)}").CommandText() == "select @par0, @par0", "TODO: We would like this to be conceptually different parameters");
-        PAssert.That(() => SQL($"select {Wrap(3)}, {TrivialConvertibleValue.Create(3)}").CommandText() == "select @par0, @par0");
+        var sql_double_3 = SQL($"select {3}, {3}");
+        PAssert.That(() => sql_double_3.CommandText() == "select @par0, @par0");
+        var sql_double_wrap_3 = SQL($"select {Wrap(3)}, {Wrap(3)}");
+        PAssert.That(() => sql_double_wrap_3.CommandText() == "select @par0, @par0");
+        var sql_3_wrap_3 = SQL($"select {3}, {Wrap(3)}");
+        PAssert.That(() => sql_3_wrap_3.CommandText() == "select @par0, @par0", "TODO: We would like this to be conceptually different parameters");
+        var sql_3_convertible_3 = SQL($"select {3}, {TrivialConvertibleValue.Create(3)}");
+        PAssert.That(() => sql_3_convertible_3.CommandText() == "select @par0, @par0", "TODO: We would like this to be conceptually different parameters");
+        var sql_wrap_3_convertible_3 = SQL($"select {Wrap(3)}, {TrivialConvertibleValue.Create(3)}");
+        PAssert.That(() => sql_wrap_3_convertible_3.CommandText() == "select @par0, @par0");
     }
 
     [Fact]
@@ -65,7 +70,8 @@ public sealed class TestSqlParameterComponent : TransactedLocalConnection
     {
         var asString = Wrap("Aap");
         using var transactedLocalConnection = new TransactedLocalConnection();
-        PAssert.That(() => SQL($"select {asString}").ReadScalar<string>(transactedLocalConnection.Connection) == "Aap");
+        var sql = SQL($"select {asString}");
+        PAssert.That(() => sql.ReadScalar<string>(transactedLocalConnection.Connection) == "Aap");
     }
 
     static ParameterizedSql Wrap<T>(T value)

--- a/test/ProgressOnderwijsUtils.Tests/PocoUtilsTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/PocoUtilsTest.cs
@@ -36,7 +36,7 @@ public sealed record SimpleObject : IWrittenImplicitly, ISimpleInterface
 }
 #pragma warning restore CS0169 // field unused
 #pragma warning restore IDE0044 // Add readonly modifier
-#pragma warning restore IDE0051 // Remove unused private members    
+#pragma warning restore IDE0051 // Remove unused private members
 
 struct SetterTestStruct : IWrittenImplicitly
 {


### PR DESCRIPTION
 - https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/interpolated-string-handler
 - https://github.com/progressonderwijs/progress/issues/43386
 - Motivation: string interpolations using `InterpolatedStringHandler` aren't supported in expression trees.
 - i.e. just don't use those in PAssert tests, which is something specifically common in tests of SQL($...) syntax, of course.
 - should purely be a refactor; this just updates the tests so they _can_ compile using InterpolatedStringHandler, it doesn't actually use one.