### PR TITLE
Fix bitlocker detection issue in which INPLACE_S_TRUNCATED was incorr…

### DIFF
--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>99.2.0</Version>
-    <PackageReleaseNotes>Always specify datetime-offset when serializing SQL-column value to JSON.</PackageReleaseNotes>
+    <Version>99.2.1</Version>
+    <PackageReleaseNotes>Fix bitlocker detection issue in which INPLACE_S_TRUNCATED was incorrectly interpreted as an error.</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>

--- a/src/ProgressOnderwijsUtils/Win32/Win32Extentions.cs
+++ b/src/ProgressOnderwijsUtils/Win32/Win32Extentions.cs
@@ -9,7 +9,7 @@ public static class Win32Extentions
     internal static void AssertResultOk(this HRESULT result, string attemptingAction, string context)
     {
         if (result.Value is not (0 or INPLACE_S_TRUNCATED)) {
-            throw new($"HRESULT failure ({result.Value}) while attempting {attemptingAction}\nContext:{context}");
+            throw new($"HRESULT failure (0x{result.Value:x}) while attempting {attemptingAction}\nContext:{context}");
         }
     }
 }

--- a/src/ProgressOnderwijsUtils/Win32/Win32Extentions.cs
+++ b/src/ProgressOnderwijsUtils/Win32/Win32Extentions.cs
@@ -4,9 +4,11 @@ namespace ProgressOnderwijsUtils.Win32;
 
 public static class Win32Extentions
 {
+    const int INPLACE_S_TRUNCATED = 0x401a0;
+
     internal static void AssertResultOk(this HRESULT result, string attemptingAction, string context)
     {
-        if (result.Value != 0) {
+        if (result.Value is not (0 or INPLACE_S_TRUNCATED)) {
             throw new($"HRESULT failure ({result.Value}) while attempting {attemptingAction}\nContext:{context}");
         }
     }


### PR DESCRIPTION
…ectly interpreted as an error.


Avoids this log-spam: https://progressonderwijs.slack.com/archives/C01E6JUSG2X/p1700544408166689

I believe this isn't an error because of docs like https://learn.microsoft.com/en-us/windows/win32/api/propsys/nf-propsys-ipropertystore-getvalue