### PR TITLE
Give explicit error when bulk inserting computed columns; error can be suppressed though

### DIFF
--- a/src/ProgressOnderwijsUtils/Data/ColumnDefinition.cs
+++ b/src/ProgressOnderwijsUtils/Data/ColumnDefinition.cs
@@ -52,5 +52,5 @@ public sealed record ColumnDefinition(Type DataType, string Name, int Index, Col
         };
 
     public static bool ShouldIncludePropertyInSqlInsert(IPocoProperty o)
-        => o.CanRead && o.PropertyInfo.Attr<DatabaseGeneratedAttribute>() is not { DatabaseGeneratedOption: not DatabaseGeneratedOption.None, };
+        => o.CanRead && o.PropertyInfo.Attr<DatabaseGeneratedAttribute>() is not { DatabaseGeneratedOption: DatabaseGeneratedOption.Identity, };
 }

--- a/src/ProgressOnderwijsUtils/Data/FieldMapping.cs
+++ b/src/ProgressOnderwijsUtils/Data/FieldMapping.cs
@@ -55,6 +55,7 @@ public struct FieldMappingValidation
     public bool AllowExtraSourceColumns;
     public bool AllowExtraTargetColumns;
     public bool OverwriteAutoIncrement;
+    public bool AllowReadOnlyTarget;
 
     public Maybe<BulkInsertFieldMapping[], string> ValidateAndFilter(BulkInsertFieldMapping.Suggestion[] mapping)
     {
@@ -88,7 +89,9 @@ public struct FieldMappingValidation
                 if (src.DataType.GetNonNullableUnderlyingType() != dst.DataType.GetNonNullableUnderlyingType()) {
                     errors.Add($"Source field {src.Name} of type {src.DataType.ToCSharpFriendlyTypeName()} has a type mismatch with target field {dst.Name} of type {dst.DataType.ToCSharpFriendlyTypeName()}.");
                 } else if (dst.ColumnAccessibility == ColumnAccessibility.Readonly) {
-                    errors.Add($"Cannot fill readonly field {dst.Name}.");
+                    if (!AllowReadOnlyTarget) {
+                        errors.Add($"Cannot fill readonly field {dst.Name}.");
+                    }
                 } else if (dst.ColumnAccessibility is ColumnAccessibility.Normal || OverwriteAutoIncrement) {
                     mapped.Add(new(src, dst));
                 }

--- a/src/ProgressOnderwijsUtils/Data/FieldMapping.cs
+++ b/src/ProgressOnderwijsUtils/Data/FieldMapping.cs
@@ -89,7 +89,7 @@ public struct FieldMappingValidation
                 if (src.DataType.GetNonNullableUnderlyingType() != dst.DataType.GetNonNullableUnderlyingType()) {
                     errors.Add($"Source field {src.Name} of type {src.DataType.ToCSharpFriendlyTypeName()} has a type mismatch with target field {dst.Name} of type {dst.DataType.ToCSharpFriendlyTypeName()}.");
                 } else if (dst.ColumnAccessibility == ColumnAccessibility.Readonly) {
-                    if (!AllowReadOnlyTarget) {
+                    if (!SilentlySkipReadonlyTargetColumns) {
                         errors.Add($"Cannot fill readonly field {dst.Name}.");
                     }
                 } else if (dst.ColumnAccessibility is ColumnAccessibility.Normal || OverwriteAutoIncrement) {

--- a/src/ProgressOnderwijsUtils/Data/FieldMapping.cs
+++ b/src/ProgressOnderwijsUtils/Data/FieldMapping.cs
@@ -55,7 +55,7 @@ public struct FieldMappingValidation
     public bool AllowExtraSourceColumns;
     public bool AllowExtraTargetColumns;
     public bool OverwriteAutoIncrement;
-    public bool AllowReadOnlyTarget;
+    public bool SilentlySkipReadonlyTargetColumns;
 
     public Maybe<BulkInsertFieldMapping[], string> ValidateAndFilter(BulkInsertFieldMapping.Suggestion[] mapping)
     {

--- a/src/ProgressOnderwijsUtils/Pocos/BulkInsertTarget.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/BulkInsertTarget.cs
@@ -6,8 +6,8 @@ namespace ProgressOnderwijsUtils;
 public sealed record BulkInsertTarget
 {
     public const SqlBulkCopyOptions DefaultOptionsCorrespondingToInsertIntoBehavior = SqlBulkCopyOptions.CheckConstraints | SqlBulkCopyOptions.FireTriggers | SqlBulkCopyOptions.KeepNulls;
-    public string TableName { get; init; }
-    public ColumnDefinition[] Columns { get; init; }
+    public string TableName { get; }
+    public ColumnDefinition[] Columns { get; }
     public BulkCopyFieldMappingMode Mode { get; init; }
     public SqlBulkCopyOptions Options { get; init; }
     public bool SilentlySkipReadonlyTargetColumns { get; init; }

--- a/src/ProgressOnderwijsUtils/Pocos/BulkInsertTarget.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/BulkInsertTarget.cs
@@ -8,11 +8,11 @@ public sealed record BulkInsertTarget
     public enum ReadOnlyTargetError { Given, Suppressed, }
 
     public const SqlBulkCopyOptions DefaultOptionsCorrespondingToInsertIntoBehavior = SqlBulkCopyOptions.CheckConstraints | SqlBulkCopyOptions.FireTriggers | SqlBulkCopyOptions.KeepNulls;
-    public readonly string TableName;
-    public readonly ColumnDefinition[] Columns;
-    public readonly BulkCopyFieldMappingMode Mode;
-    public readonly SqlBulkCopyOptions Options;
-    public readonly ReadOnlyTargetError ReadOnlyTarget;
+    public string TableName { get; init; }
+    public ColumnDefinition[] Columns { get; init; }
+    public BulkCopyFieldMappingMode Mode { get; init; }
+    public SqlBulkCopyOptions Options { get; init; }
+    public ReadOnlyTargetError ReadOnlyTarget { get; init; }
 
     public ParameterizedSql TableNameSql
         => ParameterizedSql.RawSql_PotentialForSqlInjection(TableName);

--- a/src/ProgressOnderwijsUtils/Pocos/BulkInsertTarget.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/BulkInsertTarget.cs
@@ -67,6 +67,6 @@ public sealed class BulkInsertTarget
             AllowExtraSourceColumns = Mode == BulkCopyFieldMappingMode.AllowExtraPocoProperties,
             AllowExtraTargetColumns = Mode == BulkCopyFieldMappingMode.AllowExtraDatabaseColumns,
             OverwriteAutoIncrement = Options.HasFlag(SqlBulkCopyOptions.KeepIdentity),
-            AllowReadOnlyTarget = ReadOnlyTarget == ReadOnlyTargetMode.Allowed,
+            SilentlySkipReadonlyTargetColumns = ReadOnlyTarget == ReadOnlyTargetMode.Allowed,
         }.ValidateAndFilter(BulkInsertFieldMapping.Create(sourceFields, Columns));
 }

--- a/src/ProgressOnderwijsUtils/Pocos/BulkInsertTarget.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/BulkInsertTarget.cs
@@ -35,9 +35,6 @@ public sealed record BulkInsertTarget
     public static BulkInsertTarget FromCompleteSetOfColumns(string tableName, IDbColumn[] columns)
         => new(tableName, columns.ArraySelect(ColumnDefinition.FromDbColumnMetaData));
 
-    public BulkInsertTarget With(SqlBulkCopyOptions options)
-        => new(TableName, Columns, Mode, options, ReadOnlyTarget);
-
     public BulkInsertTarget With(ReadOnlyTargetError error)
         => new(TableName, Columns, Mode, Options, error);
 

--- a/src/ProgressOnderwijsUtils/Pocos/BulkInsertTarget.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/BulkInsertTarget.cs
@@ -12,7 +12,7 @@ public sealed record BulkInsertTarget
     public ColumnDefinition[] Columns { get; init; }
     public BulkCopyFieldMappingMode Mode { get; init; }
     public SqlBulkCopyOptions Options { get; init; }
-    public ReadOnlyTargetError ReadOnlyTarget { get; init; }
+    public ReadOnlyTargetError SilentlySkipReadonlyTargetColumns { get; init; }
 
     public ParameterizedSql TableNameSql
         => ParameterizedSql.RawSql_PotentialForSqlInjection(TableName);
@@ -21,7 +21,7 @@ public sealed record BulkInsertTarget
         : this(tableName, columnDefinition, BulkCopyFieldMappingMode.ExactMatch, DefaultOptionsCorrespondingToInsertIntoBehavior, ReadOnlyTargetError.Given) { }
 
     BulkInsertTarget(string tableName, ColumnDefinition[] columnDefinition, BulkCopyFieldMappingMode mode, SqlBulkCopyOptions options, ReadOnlyTargetError readOnlyTarget)
-        => (TableName, Columns, Mode, Options, ReadOnlyTarget) = (tableName, columnDefinition, mode, options, readOnlyTarget);
+        => (TableName, Columns, Mode, Options, SilentlySkipReadonlyTargetColumns) = (tableName, columnDefinition, mode, options, readOnlyTarget);
 
     public static BulkInsertTarget FromDatabaseDescription(DatabaseDescription.Table table)
         => new(table.QualifiedName, table.Columns.ArraySelect(ColumnDefinition.FromDbColumnMetaData));
@@ -58,6 +58,6 @@ public sealed record BulkInsertTarget
             AllowExtraSourceColumns = Mode == BulkCopyFieldMappingMode.AllowExtraPocoProperties,
             AllowExtraTargetColumns = Mode == BulkCopyFieldMappingMode.AllowExtraDatabaseColumns,
             OverwriteAutoIncrement = Options.HasFlag(SqlBulkCopyOptions.KeepIdentity),
-            SilentlySkipReadonlyTargetColumns = ReadOnlyTarget == ReadOnlyTargetError.Suppressed,
+            SilentlySkipReadonlyTargetColumns = SilentlySkipReadonlyTargetColumns == ReadOnlyTargetError.Suppressed,
         }.ValidateAndFilter(BulkInsertFieldMapping.Create(sourceFields, Columns));
 }

--- a/src/ProgressOnderwijsUtils/Pocos/BulkInsertTarget.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/BulkInsertTarget.cs
@@ -35,9 +35,6 @@ public sealed record BulkInsertTarget
     public static BulkInsertTarget FromCompleteSetOfColumns(string tableName, IDbColumn[] columns)
         => new(tableName, columns.ArraySelect(ColumnDefinition.FromDbColumnMetaData));
 
-    public BulkInsertTarget With(BulkCopyFieldMappingMode mode)
-        => new(TableName, Columns, mode, Options, ReadOnlyTarget);
-
     public BulkInsertTarget With(SqlBulkCopyOptions options)
         => new(TableName, Columns, Mode, options, ReadOnlyTarget);
 

--- a/src/ProgressOnderwijsUtils/Pocos/BulkInsertTarget.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/BulkInsertTarget.cs
@@ -3,7 +3,7 @@ using ProgressOnderwijsUtils.SchemaReflection;
 
 namespace ProgressOnderwijsUtils;
 
-public sealed class BulkInsertTarget
+public sealed record BulkInsertTarget
 {
     public enum ReadOnlyTargetError { Given, Suppressed, }
 

--- a/src/ProgressOnderwijsUtils/Pocos/BulkInsertTarget.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/BulkInsertTarget.cs
@@ -35,9 +35,6 @@ public sealed record BulkInsertTarget
     public static BulkInsertTarget FromCompleteSetOfColumns(string tableName, IDbColumn[] columns)
         => new(tableName, columns.ArraySelect(ColumnDefinition.FromDbColumnMetaData));
 
-    public BulkInsertTarget With(ReadOnlyTargetError error)
-        => new(TableName, Columns, Mode, Options, error);
-
     public void BulkInsert<[MeansImplicitUse(ImplicitUseKindFlags.Access, ImplicitUseTargetFlags.WithMembers)] T>(SqlConnection sqlConn, IEnumerable<T> pocos, CommandTimeout timeout = new(), CancellationToken cancellationToken = new())
         where T : IReadImplicitly
     {

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>100.3.0</Version>
-    <PackageReleaseNotes>Add IsSubsetOf and MergeWith to SortedSet</PackageReleaseNotes>
+    <Version>101.0.0</Version>
+    <PackageReleaseNotes>Give explicit error when bulk inserting computed columns; error can be suppressed though</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>

--- a/test/ProgressOnderwijsUtils.Tests/Data/BulkInsertTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/BulkInsertTest.cs
@@ -265,7 +265,7 @@ public sealed class BulkInsertTest : TransactedLocalConnection
         PAssert.That(() => notAllowed.ErrorOrNull().AssertNotNull().Message.Contains("Cannot fill readonly field ReadOnly", StringComparison.InvariantCulture));
 
         // but we can allow it
-        target.With(BulkInsertTarget.ReadOnlyTargetError.Suppressed).BulkInsert(Connection, new[] { record, });
+        (target with { ReadOnlyTarget = BulkInsertTarget.ReadOnlyTargetError.Suppressed, }).BulkInsert(Connection, new[] { record, });
 
         var allowed = SQL($"select * from {tableName}").ReadPocos<TableWithReadOnlyColumn>(Connection).Single();
         PAssert.That(() => !allowed.ReadOnly.SequenceEqual(record.ReadOnly));

--- a/test/ProgressOnderwijsUtils.Tests/Data/BulkInsertTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/BulkInsertTest.cs
@@ -265,7 +265,7 @@ public sealed class BulkInsertTest : TransactedLocalConnection
         PAssert.That(() => notAllowed.ErrorOrNull().AssertNotNull().Message.Contains("Cannot fill readonly field ReadOnly", StringComparison.InvariantCulture));
 
         // but we can allow it
-        target.With(BulkInsertTarget.ReadOnlyTargetMode.Allowed).BulkInsert(Connection, new[] { record, });
+        target.With(BulkInsertTarget.ReadOnlyTargetError.Suppressed).BulkInsert(Connection, new[] { record, });
 
         var allowed = SQL($"select * from {tableName}").ReadPocos<TableWithReadOnlyColumn>(Connection).Single();
         PAssert.That(() => !allowed.ReadOnly.SequenceEqual(record.ReadOnly));

--- a/test/ProgressOnderwijsUtils.Tests/Data/BulkInsertTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/BulkInsertTest.cs
@@ -265,7 +265,7 @@ public sealed class BulkInsertTest : TransactedLocalConnection
         PAssert.That(() => notAllowed.AssertError().Message.Contains("Cannot fill readonly field ReadOnly", StringComparison.InvariantCulture));
 
         // but we can allow it
-        (target with { ReadOnlyTarget = BulkInsertTarget.ReadOnlyTargetError.Suppressed, }).BulkInsert(Connection, new[] { record, });
+        (target with { SilentlySkipReadonlyTargetColumns = BulkInsertTarget.ReadOnlyTargetError.Suppressed, }).BulkInsert(Connection, new[] { record, });
 
         var allowed = SQL($"select * from {tableName}").ReadPocos<TableWithReadOnlyColumn>(Connection).Single();
         PAssert.That(() => !allowed.ReadOnly.SequenceEqual(record.ReadOnly));

--- a/test/ProgressOnderwijsUtils.Tests/Data/BulkInsertTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/BulkInsertTest.cs
@@ -247,4 +247,27 @@ public sealed class BulkInsertTest : TransactedLocalConnection
         );
         PAssert.That(() => pocoProperties.Count == dbProps.Count());
     }
+
+    sealed record TableWithReadOnlyColumn(int X, byte[] ReadOnly) : IReadImplicitly, IWrittenImplicitly;
+
+    [Fact]
+    public void Writing_to_read_only_column_error_can_be_disabled()
+    {
+        var tableName = SQL($"#TableWithReadOnlyColumn");
+        SQL($"create table {tableName} (X int not null, ReadOnly rowversion not null);").ExecuteNonQuery(Connection);
+        var record = new TableWithReadOnlyColumn(1, [1, 2, 3, 4, 5, 6, 7, 8,]);
+        var target = BulkInsertTarget.LoadFromTable(Connection, tableName);
+
+        // by default, writing to read-only column is not allowed
+        var notAllowed = Maybe.Try(() => target.BulkInsert(Connection, new[] { record, }))
+            .Catch<InvalidOperationException>();
+
+        PAssert.That(() => notAllowed.ErrorOrNull().AssertNotNull().Message.Contains("Cannot fill readonly field ReadOnly", StringComparison.InvariantCulture));
+
+        // but we can allow it
+        target.With(BulkInsertTarget.ReadOnlyTargetMode.Allowed).BulkInsert(Connection, new[] { record, });
+
+        var allowed = SQL($"select * from {tableName}").ReadPocos<TableWithReadOnlyColumn>(Connection).Single();
+        PAssert.That(() => !allowed.ReadOnly.SequenceEqual(record.ReadOnly));
+    }
 }

--- a/test/ProgressOnderwijsUtils.Tests/Data/BulkInsertTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/BulkInsertTest.cs
@@ -194,7 +194,7 @@ public sealed class BulkInsertTest : TransactedLocalConnection
         new[] { new SampleRow2 { intNonNull = 1, intNull = null, stringNull = "test", stringNonNull = "test", }, }
             .BulkCopyToSqlServer(Connection, target);
         new[] { new SampleRow2 { intNonNull = 2, intNull = null, stringNull = "test", stringNonNull = "test", }, }
-            .BulkCopyToSqlServer(Connection, target.With(target.Options ^ SqlBulkCopyOptions.KeepNulls));
+            .BulkCopyToSqlServer(Connection, target with { Options = target.Options ^ SqlBulkCopyOptions.KeepNulls, });
 
         var fromDb = SQL($"select * from #tmp").ReadPocos<SampleRow2>(Connection);
 

--- a/test/ProgressOnderwijsUtils.Tests/Data/BulkInsertTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/BulkInsertTest.cs
@@ -265,7 +265,7 @@ public sealed class BulkInsertTest : TransactedLocalConnection
         PAssert.That(() => notAllowed.AssertError().Message.Contains("Cannot fill readonly field ReadOnly", StringComparison.InvariantCulture));
 
         // but we can allow it
-        (target with { SilentlySkipReadonlyTargetColumns = BulkInsertTarget.ReadOnlyTargetError.Suppressed, }).BulkInsert(Connection, new[] { record, });
+        (target with { SilentlySkipReadonlyTargetColumns = true, }).BulkInsert(Connection, new[] { record, });
 
         var allowed = SQL($"select * from {tableName}").ReadPocos<TableWithReadOnlyColumn>(Connection).Single();
         PAssert.That(() => !allowed.ReadOnly.SequenceEqual(record.ReadOnly));

--- a/test/ProgressOnderwijsUtils.Tests/Data/PocoBulkCopyFieldMappingTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/PocoBulkCopyFieldMappingTest.cs
@@ -31,21 +31,16 @@ public sealed class PocoBulkCopyFieldMappingTest : TransactedLocalConnection
     [Fact]
     public void Exact_mapping_gives_exception_on_less_columns()
     {
-        var bulkInsertTarget = CreateTargetTable();
-        _ = Assert.Throws<InvalidOperationException>(
-            () => {
-                bulkInsertTarget.With(BulkCopyFieldMappingMode.ExactMatch).BulkInsert(Connection, new[] { new LessColumns { Id = 37, SomeColumn = 42, }, });
-            }
-        );
+        var bulkInsertTarget = CreateTargetTable() with { Mode = BulkCopyFieldMappingMode.ExactMatch, };
+        _ = Assert.Throws<InvalidOperationException>(() => bulkInsertTarget.BulkInsert(Connection, new[] { new LessColumns { Id = 37, SomeColumn = 42, }, }));
     }
 
     [Fact]
     public void Exact_mapping_gives_exception_on_more_columns()
-        => Assert.Throws<InvalidOperationException>(
-            () => {
-                CreateTargetTable().With(BulkCopyFieldMappingMode.ExactMatch).BulkInsert(Connection, new[] { new MoreColumns(), });
-            }
-        );
+    {
+        var bulkInsertTarget = CreateTargetTable() with { Mode = BulkCopyFieldMappingMode.ExactMatch, };
+        _ = Assert.Throws<InvalidOperationException>(() => bulkInsertTarget.BulkInsert(Connection, new[] { new MoreColumns(), }));
+    }
 
     BulkInsertTarget CreateTargetTable()
     {
@@ -65,51 +60,43 @@ public sealed class PocoBulkCopyFieldMappingTest : TransactedLocalConnection
     [Fact]
     public void Exact_mapping_works_when_mapping_is_exact()
     {
-        CreateTargetTable().With(BulkCopyFieldMappingMode.ExactMatch).BulkInsert(Connection, new[] { new ExactMapping(), });
+        (CreateTargetTable() with { Mode = BulkCopyFieldMappingMode.ExactMatch, }).BulkInsert(Connection, new[] { new ExactMapping(), });
         PAssert.That(() => ExactMapping.Load(Connection).Any());
     }
 
     [Fact]
     public void AllowExtraDatabaseColumns_mapping_gives_exception_on_more_columns()
-        => Assert.Throws<InvalidOperationException>(
-            () => {
-                CreateTargetTable().With(BulkCopyFieldMappingMode.AllowExtraDatabaseColumns).BulkInsert(Connection, new[] { new MoreColumns(), });
-            }
-        );
+        => Assert.Throws<InvalidOperationException>(() => (CreateTargetTable() with { Mode = BulkCopyFieldMappingMode.AllowExtraDatabaseColumns, }).BulkInsert(Connection, new[] { new MoreColumns(), }));
 
     [Fact]
     public void AllowExtraDatabaseColumns_mapping_works_on_less_columns()
     {
-        CreateTargetTable().With(BulkCopyFieldMappingMode.AllowExtraDatabaseColumns).BulkInsert(Connection, new[] { new LessColumns(), });
+        (CreateTargetTable() with { Mode = BulkCopyFieldMappingMode.AllowExtraDatabaseColumns, }).BulkInsert(Connection, new[] { new LessColumns(), });
         PAssert.That(() => ExactMapping.Load(Connection).Any());
     }
 
     [Fact]
     public void AllowExtraDatabaseColumns_mapping_works_when_mapping_is_exact()
     {
-        CreateTargetTable().With(BulkCopyFieldMappingMode.AllowExtraDatabaseColumns).BulkInsert(Connection, new[] { new ExactMapping(), });
+        (CreateTargetTable() with { Mode = BulkCopyFieldMappingMode.AllowExtraDatabaseColumns, }).BulkInsert(Connection, new[] { new ExactMapping(), });
         PAssert.That(() => ExactMapping.Load(Connection).Any());
     }
 
     [Fact]
     public void AllowExtraPocoProperties_mapping_gives_exception_on_less_columns()
-        => Assert.Throws<InvalidOperationException>(
-            () => {
-                CreateTargetTable().With(BulkCopyFieldMappingMode.AllowExtraPocoProperties).BulkInsert(Connection, new[] { new LessColumns(), });
-            }
-        );
+        => Assert.Throws<InvalidOperationException>(() => (CreateTargetTable() with { Mode = BulkCopyFieldMappingMode.AllowExtraPocoProperties, }).BulkInsert(Connection, new[] { new LessColumns(), }));
 
     [Fact]
     public void AllowExtraPocoProperties_mapping_works_on_more_columns()
     {
-        CreateTargetTable().With(BulkCopyFieldMappingMode.AllowExtraPocoProperties).BulkInsert(Connection, new[] { new MoreColumns(), });
+        (CreateTargetTable() with { Mode = BulkCopyFieldMappingMode.AllowExtraPocoProperties, }).BulkInsert(Connection, new[] { new MoreColumns(), });
         PAssert.That(() => ExactMapping.Load(Connection).Any());
     }
 
     [Fact]
     public void AllowExtraPocoProperties_mapping_works_when_mapping_is_exact()
     {
-        CreateTargetTable().With(BulkCopyFieldMappingMode.AllowExtraPocoProperties).BulkInsert(Connection, new[] { new ExactMapping(), });
+        (CreateTargetTable() with { Mode = BulkCopyFieldMappingMode.AllowExtraPocoProperties, }).BulkInsert(Connection, new[] { new ExactMapping(), });
         PAssert.That(() => ExactMapping.Load(Connection).Any());
     }
 }

--- a/test/ProgressOnderwijsUtils.Tests/Data/PocoBulkCopyTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/PocoBulkCopyTest.cs
@@ -110,7 +110,7 @@ public sealed class PocoBulkCopyTest : TransactedLocalConnection
                 )
             "
             ).ExecuteNonQuery(conn);
-            return BulkInsertTarget.LoadFromTable(conn, tableName);
+            return BulkInsertTarget.LoadFromTable(conn, tableName).With(BulkInsertTarget.ReadOnlyTargetMode.Allowed);
         }
     }
 
@@ -149,7 +149,7 @@ public sealed class PocoBulkCopyTest : TransactedLocalConnection
     [Fact]
     public void BulkCopyWontInsertComputedColumns()
     {
-        var target = ComputedColumnExample.CreateTargetTable(Connection, SQL($"#tmp"));
+        var target = ComputedColumnExample.CreateTargetTable(Connection, SQL($"#tmp")).With(BulkInsertTarget.ReadOnlyTargetMode.NotAllowed);
 
         _ = Assert.ThrowsAny<Exception>(() => new ComputedColumnExample_LackingAnnotation[] { new() { Bla = "ja", Computed = true, Id = 13, }, }.BulkCopyToSqlServer(Connection, target));
     }
@@ -359,7 +359,7 @@ public sealed class PocoBulkCopyTest : TransactedLocalConnection
             "
         ).ExecuteNonQuery(Connection);
 
-        var bulkInsertTarget = BulkInsertTarget.LoadFromTable(Connection, tableName);
+        var bulkInsertTarget = BulkInsertTarget.LoadFromTable(Connection, tableName).With(BulkInsertTarget.ReadOnlyTargetMode.Allowed);
 
         new[] {
             new ComputedColumnExample {

--- a/test/ProgressOnderwijsUtils.Tests/Data/PocoBulkCopyTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/PocoBulkCopyTest.cs
@@ -110,7 +110,7 @@ public sealed class PocoBulkCopyTest : TransactedLocalConnection
                 )
             "
             ).ExecuteNonQuery(conn);
-            return BulkInsertTarget.LoadFromTable(conn, tableName).With(BulkInsertTarget.ReadOnlyTargetMode.Allowed);
+            return BulkInsertTarget.LoadFromTable(conn, tableName).With(BulkInsertTarget.ReadOnlyTargetError.Suppressed);
         }
     }
 
@@ -149,7 +149,7 @@ public sealed class PocoBulkCopyTest : TransactedLocalConnection
     [Fact]
     public void BulkCopyWontInsertComputedColumns()
     {
-        var target = ComputedColumnExample.CreateTargetTable(Connection, SQL($"#tmp")).With(BulkInsertTarget.ReadOnlyTargetMode.NotAllowed);
+        var target = ComputedColumnExample.CreateTargetTable(Connection, SQL($"#tmp")).With(BulkInsertTarget.ReadOnlyTargetError.Given);
 
         _ = Assert.ThrowsAny<Exception>(() => new ComputedColumnExample_LackingAnnotation[] { new() { Bla = "ja", Computed = true, Id = 13, }, }.BulkCopyToSqlServer(Connection, target));
     }
@@ -359,7 +359,7 @@ public sealed class PocoBulkCopyTest : TransactedLocalConnection
             "
         ).ExecuteNonQuery(Connection);
 
-        var bulkInsertTarget = BulkInsertTarget.LoadFromTable(Connection, tableName).With(BulkInsertTarget.ReadOnlyTargetMode.Allowed);
+        var bulkInsertTarget = BulkInsertTarget.LoadFromTable(Connection, tableName).With(BulkInsertTarget.ReadOnlyTargetError.Suppressed);
 
         new[] {
             new ComputedColumnExample {

--- a/test/ProgressOnderwijsUtils.Tests/Data/PocoBulkCopyTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/PocoBulkCopyTest.cs
@@ -110,7 +110,7 @@ public sealed class PocoBulkCopyTest : TransactedLocalConnection
                 )
             "
             ).ExecuteNonQuery(conn);
-            return BulkInsertTarget.LoadFromTable(conn, tableName) with { ReadOnlyTarget = BulkInsertTarget.ReadOnlyTargetError.Suppressed, };
+            return BulkInsertTarget.LoadFromTable(conn, tableName) with { SilentlySkipReadonlyTargetColumns = BulkInsertTarget.ReadOnlyTargetError.Suppressed, };
         }
     }
 
@@ -149,7 +149,7 @@ public sealed class PocoBulkCopyTest : TransactedLocalConnection
     [Fact]
     public void BulkCopyWontInsertComputedColumns()
     {
-        var target = ComputedColumnExample.CreateTargetTable(Connection, SQL($"#tmp")) with { ReadOnlyTarget = BulkInsertTarget.ReadOnlyTargetError.Given, };
+        var target = ComputedColumnExample.CreateTargetTable(Connection, SQL($"#tmp")) with { SilentlySkipReadonlyTargetColumns = BulkInsertTarget.ReadOnlyTargetError.Given, };
 
         _ = Assert.ThrowsAny<Exception>(() => new ComputedColumnExample_LackingAnnotation[] { new() { Bla = "ja", Computed = true, Id = 13, }, }.BulkCopyToSqlServer(Connection, target));
     }
@@ -359,7 +359,7 @@ public sealed class PocoBulkCopyTest : TransactedLocalConnection
             "
         ).ExecuteNonQuery(Connection);
 
-        var bulkInsertTarget = BulkInsertTarget.LoadFromTable(Connection, tableName) with { ReadOnlyTarget = BulkInsertTarget.ReadOnlyTargetError.Suppressed, };
+        var bulkInsertTarget = BulkInsertTarget.LoadFromTable(Connection, tableName) with { SilentlySkipReadonlyTargetColumns = BulkInsertTarget.ReadOnlyTargetError.Suppressed, };
 
         new[] {
             new ComputedColumnExample {

--- a/test/ProgressOnderwijsUtils.Tests/Data/PocoBulkCopyTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/PocoBulkCopyTest.cs
@@ -326,7 +326,7 @@ public sealed class PocoBulkCopyTest : TransactedLocalConnection
                 Id = 11,
                 Bla = "Something",
             },
-        }.BulkCopyToSqlServer(Connection, bulkInsertTarget.With(SqlBulkCopyOptions.KeepIdentity | SqlBulkCopyOptions.CheckConstraints));
+        }.BulkCopyToSqlServer(Connection, bulkInsertTarget with { Options = SqlBulkCopyOptions.KeepIdentity | SqlBulkCopyOptions.CheckConstraints, });
 
         var fromDb = SQL(
             $@"

--- a/test/ProgressOnderwijsUtils.Tests/Data/PocoBulkCopyTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/PocoBulkCopyTest.cs
@@ -110,7 +110,7 @@ public sealed class PocoBulkCopyTest : TransactedLocalConnection
                 )
             "
             ).ExecuteNonQuery(conn);
-            return BulkInsertTarget.LoadFromTable(conn, tableName).With(BulkInsertTarget.ReadOnlyTargetError.Suppressed);
+            return BulkInsertTarget.LoadFromTable(conn, tableName) with { ReadOnlyTarget = BulkInsertTarget.ReadOnlyTargetError.Suppressed, };
         }
     }
 
@@ -149,7 +149,7 @@ public sealed class PocoBulkCopyTest : TransactedLocalConnection
     [Fact]
     public void BulkCopyWontInsertComputedColumns()
     {
-        var target = ComputedColumnExample.CreateTargetTable(Connection, SQL($"#tmp")).With(BulkInsertTarget.ReadOnlyTargetError.Given);
+        var target = ComputedColumnExample.CreateTargetTable(Connection, SQL($"#tmp")) with { ReadOnlyTarget = BulkInsertTarget.ReadOnlyTargetError.Given, };
 
         _ = Assert.ThrowsAny<Exception>(() => new ComputedColumnExample_LackingAnnotation[] { new() { Bla = "ja", Computed = true, Id = 13, }, }.BulkCopyToSqlServer(Connection, target));
     }
@@ -359,7 +359,7 @@ public sealed class PocoBulkCopyTest : TransactedLocalConnection
             "
         ).ExecuteNonQuery(Connection);
 
-        var bulkInsertTarget = BulkInsertTarget.LoadFromTable(Connection, tableName).With(BulkInsertTarget.ReadOnlyTargetError.Suppressed);
+        var bulkInsertTarget = BulkInsertTarget.LoadFromTable(Connection, tableName) with { ReadOnlyTarget = BulkInsertTarget.ReadOnlyTargetError.Suppressed, };
 
         new[] {
             new ComputedColumnExample {

--- a/test/ProgressOnderwijsUtils.Tests/Data/PocoBulkCopyTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/PocoBulkCopyTest.cs
@@ -110,7 +110,7 @@ public sealed class PocoBulkCopyTest : TransactedLocalConnection
                 )
             "
             ).ExecuteNonQuery(conn);
-            return BulkInsertTarget.LoadFromTable(conn, tableName) with { SilentlySkipReadonlyTargetColumns = BulkInsertTarget.ReadOnlyTargetError.Suppressed, };
+            return BulkInsertTarget.LoadFromTable(conn, tableName) with { SilentlySkipReadonlyTargetColumns = true, };
         }
     }
 
@@ -149,7 +149,7 @@ public sealed class PocoBulkCopyTest : TransactedLocalConnection
     [Fact]
     public void BulkCopyWontInsertComputedColumns()
     {
-        var target = ComputedColumnExample.CreateTargetTable(Connection, SQL($"#tmp")) with { SilentlySkipReadonlyTargetColumns = BulkInsertTarget.ReadOnlyTargetError.Given, };
+        var target = ComputedColumnExample.CreateTargetTable(Connection, SQL($"#tmp")) with { SilentlySkipReadonlyTargetColumns = false, };
 
         _ = Assert.ThrowsAny<Exception>(() => new ComputedColumnExample_LackingAnnotation[] { new() { Bla = "ja", Computed = true, Id = 13, }, }.BulkCopyToSqlServer(Connection, target));
     }
@@ -359,7 +359,7 @@ public sealed class PocoBulkCopyTest : TransactedLocalConnection
             "
         ).ExecuteNonQuery(Connection);
 
-        var bulkInsertTarget = BulkInsertTarget.LoadFromTable(Connection, tableName) with { SilentlySkipReadonlyTargetColumns = BulkInsertTarget.ReadOnlyTargetError.Suppressed, };
+        var bulkInsertTarget = BulkInsertTarget.LoadFromTable(Connection, tableName) with { SilentlySkipReadonlyTargetColumns = true, };
 
         new[] {
             new ComputedColumnExample {

--- a/test/ProgressOnderwijsUtils.Tests/Data/PocoObjectMapperTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/PocoObjectMapperTest.cs
@@ -345,7 +345,7 @@ public sealed class PocoObjectMapperTest : TransactedLocalConnection
 
         var target = BulkInsertTarget.LoadFromTable(Connection, tableName) with {
             Mode = BulkCopyFieldMappingMode.AllowExtraPocoProperties,
-            SilentlySkipReadonlyTargetColumns = BulkInsertTarget.ReadOnlyTargetError.Suppressed,
+            SilentlySkipReadonlyTargetColumns = true,
         };
         initialPocos.BulkCopyToSqlServer(Connection, target);
 
@@ -385,7 +385,7 @@ public sealed class PocoObjectMapperTest : TransactedLocalConnection
 
         var target = BulkInsertTarget.LoadFromTable(Connection, tableName) with {
             Mode = BulkCopyFieldMappingMode.AllowExtraPocoProperties,
-            SilentlySkipReadonlyTargetColumns = BulkInsertTarget.ReadOnlyTargetError.Suppressed,
+            SilentlySkipReadonlyTargetColumns = true,
         };
         srcData.BulkCopyToSqlServer(Connection, target);
 

--- a/test/ProgressOnderwijsUtils.Tests/Data/PocoObjectMapperTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/PocoObjectMapperTest.cs
@@ -345,7 +345,7 @@ public sealed class PocoObjectMapperTest : TransactedLocalConnection
 
         var target = BulkInsertTarget.LoadFromTable(Connection, tableName) with {
             Mode = BulkCopyFieldMappingMode.AllowExtraPocoProperties,
-            ReadOnlyTarget = BulkInsertTarget.ReadOnlyTargetError.Suppressed,
+            SilentlySkipReadonlyTargetColumns = BulkInsertTarget.ReadOnlyTargetError.Suppressed,
         };
         initialPocos.BulkCopyToSqlServer(Connection, target);
 
@@ -385,7 +385,7 @@ public sealed class PocoObjectMapperTest : TransactedLocalConnection
 
         var target = BulkInsertTarget.LoadFromTable(Connection, tableName) with {
             Mode = BulkCopyFieldMappingMode.AllowExtraPocoProperties,
-            ReadOnlyTarget = BulkInsertTarget.ReadOnlyTargetError.Suppressed,
+            SilentlySkipReadonlyTargetColumns = BulkInsertTarget.ReadOnlyTargetError.Suppressed,
         };
         srcData.BulkCopyToSqlServer(Connection, target);
 

--- a/test/ProgressOnderwijsUtils.Tests/Data/PocoObjectMapperTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/PocoObjectMapperTest.cs
@@ -343,7 +343,11 @@ public sealed class PocoObjectMapperTest : TransactedLocalConnection
         var rowsAfterDelete = SQL($"select * from {tableName} order by Counter").ReadPocos<PocoWithRowVersions>(Connection);
         PAssert.That(() => rowsAfterDelete.None());
 
-        initialPocos.BulkCopyToSqlServer(Connection, BulkInsertTarget.LoadFromTable(Connection, tableName).With(BulkCopyFieldMappingMode.AllowExtraPocoProperties).With(BulkInsertTarget.ReadOnlyTargetError.Suppressed));
+        var target = BulkInsertTarget.LoadFromTable(Connection, tableName) with {
+            Mode = BulkCopyFieldMappingMode.AllowExtraPocoProperties,
+            ReadOnlyTarget = BulkInsertTarget.ReadOnlyTargetError.Suppressed,
+        };
+        initialPocos.BulkCopyToSqlServer(Connection, target);
 
         var rowsAfterBulkInsert = SQL($"select * from {tableName} order by Counter").ReadPocos<PocoWithRowVersions>(Connection);
 
@@ -379,7 +383,11 @@ public sealed class PocoObjectMapperTest : TransactedLocalConnection
             )
             .ToArray();
 
-        srcData.BulkCopyToSqlServer(Connection, BulkInsertTarget.LoadFromTable(Connection, tableName).With(BulkCopyFieldMappingMode.AllowExtraPocoProperties).With(BulkInsertTarget.ReadOnlyTargetError.Suppressed));
+        var target = BulkInsertTarget.LoadFromTable(Connection, tableName) with {
+            Mode = BulkCopyFieldMappingMode.AllowExtraPocoProperties,
+            ReadOnlyTarget = BulkInsertTarget.ReadOnlyTargetError.Suppressed,
+        };
+        srcData.BulkCopyToSqlServer(Connection, target);
 
         var rowsAfterBulkInsert = SQL($"select * from {tableName} order by Counter").ReadPocos<PocoWithRowVersions>(Connection);
         var expected = srcData.Select((o, i) => o with { Counter = i + 6, });

--- a/test/ProgressOnderwijsUtils.Tests/Data/PocoObjectMapperTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/PocoObjectMapperTest.cs
@@ -343,7 +343,7 @@ public sealed class PocoObjectMapperTest : TransactedLocalConnection
         var rowsAfterDelete = SQL($"select * from {tableName} order by Counter").ReadPocos<PocoWithRowVersions>(Connection);
         PAssert.That(() => rowsAfterDelete.None());
 
-        initialPocos.BulkCopyToSqlServer(Connection, BulkInsertTarget.LoadFromTable(Connection, tableName).With(BulkCopyFieldMappingMode.AllowExtraPocoProperties));
+        initialPocos.BulkCopyToSqlServer(Connection, BulkInsertTarget.LoadFromTable(Connection, tableName).With(BulkCopyFieldMappingMode.AllowExtraPocoProperties).With(BulkInsertTarget.ReadOnlyTargetMode.Allowed));
 
         var rowsAfterBulkInsert = SQL($"select * from {tableName} order by Counter").ReadPocos<PocoWithRowVersions>(Connection);
 
@@ -379,7 +379,7 @@ public sealed class PocoObjectMapperTest : TransactedLocalConnection
             )
             .ToArray();
 
-        srcData.BulkCopyToSqlServer(Connection, BulkInsertTarget.LoadFromTable(Connection, tableName).With(BulkCopyFieldMappingMode.AllowExtraPocoProperties));
+        srcData.BulkCopyToSqlServer(Connection, BulkInsertTarget.LoadFromTable(Connection, tableName).With(BulkCopyFieldMappingMode.AllowExtraPocoProperties).With(BulkInsertTarget.ReadOnlyTargetMode.Allowed));
 
         var rowsAfterBulkInsert = SQL($"select * from {tableName} order by Counter").ReadPocos<PocoWithRowVersions>(Connection);
         var expected = srcData.Select((o, i) => o with { Counter = i + 6, });

--- a/test/ProgressOnderwijsUtils.Tests/Data/PocoObjectMapperTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/PocoObjectMapperTest.cs
@@ -343,7 +343,7 @@ public sealed class PocoObjectMapperTest : TransactedLocalConnection
         var rowsAfterDelete = SQL($"select * from {tableName} order by Counter").ReadPocos<PocoWithRowVersions>(Connection);
         PAssert.That(() => rowsAfterDelete.None());
 
-        initialPocos.BulkCopyToSqlServer(Connection, BulkInsertTarget.LoadFromTable(Connection, tableName).With(BulkCopyFieldMappingMode.AllowExtraPocoProperties).With(BulkInsertTarget.ReadOnlyTargetMode.Allowed));
+        initialPocos.BulkCopyToSqlServer(Connection, BulkInsertTarget.LoadFromTable(Connection, tableName).With(BulkCopyFieldMappingMode.AllowExtraPocoProperties).With(BulkInsertTarget.ReadOnlyTargetError.Suppressed));
 
         var rowsAfterBulkInsert = SQL($"select * from {tableName} order by Counter").ReadPocos<PocoWithRowVersions>(Connection);
 
@@ -379,7 +379,7 @@ public sealed class PocoObjectMapperTest : TransactedLocalConnection
             )
             .ToArray();
 
-        srcData.BulkCopyToSqlServer(Connection, BulkInsertTarget.LoadFromTable(Connection, tableName).With(BulkCopyFieldMappingMode.AllowExtraPocoProperties).With(BulkInsertTarget.ReadOnlyTargetMode.Allowed));
+        srcData.BulkCopyToSqlServer(Connection, BulkInsertTarget.LoadFromTable(Connection, tableName).With(BulkCopyFieldMappingMode.AllowExtraPocoProperties).With(BulkInsertTarget.ReadOnlyTargetError.Suppressed));
 
         var rowsAfterBulkInsert = SQL($"select * from {tableName} order by Counter").ReadPocos<PocoWithRowVersions>(Connection);
         var expected = srcData.Select((o, i) => o with { Counter = i + 6, });


### PR DESCRIPTION
Do not exclude computed columns anymore from the to inserted columns
By default, give an error when writing to such computed columns. It can be configured to suppress this sanlity error check though. For example needed for writing a rowversion property to a static byte[8] column.