### PR TITLE
Bump CsWin32 (breaking changes)

### DIFF
--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.11.3" /> <!-- PV 20231218: Package installed, cause Microsoft.Data.SqlClient used an old vunerable version 1.7.0 -->
-    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.1.378-beta">
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.106">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/ProgressOnderwijsUtils/Win32/Bitlocker.cs
+++ b/src/ProgressOnderwijsUtils/Win32/Bitlocker.cs
@@ -1,37 +1,30 @@
 using System.Runtime.InteropServices;
-using Microsoft.Windows.Sdk;
+using Windows.Win32;
+using Windows.Win32.UI.Shell;
 
 namespace ProgressOnderwijsUtils.Win32;
 
 public static class BitLocker
 {
-    public static unsafe int BitlockerStatusOfDriveLetter(char driveLetter)
+    public static int BitlockerStatusOfDriveLetter(char driveLetter)
     {
-        IShellItem2* ppv = null;
+        var pszPath = $"{driveLetter}:";
+        PInvoke.SHCreateItemFromParsingName(
+            pszPath,
+            null,
+            Guid.Parse(typeof(IShellItem2).GetCustomAttribute<GuidAttribute>().AssertNotNull().Value),
+            out var ppv_Void
+        ).AssertResultOk(nameof(PInvoke.SHCreateItemFromParsingName), pszPath);
+        var ppv = (IShellItem2)ppv_Void;
 
-        try {
-            var pszPath = $"{driveLetter}:";
-            PInvoke.SHCreateItemFromParsingName(
-                pszPath,
-                null,
-                Guid.Parse(typeof(IShellItem2).GetCustomAttribute<GuidAttribute>().AssertNotNull().Value),
-                out var ppv_Void
-            ).AssertResultOk(nameof(PInvoke.SHCreateItemFromParsingName), pszPath);
-            ppv = (IShellItem2*)ppv_Void;
+        const string pszName = "System.Volume.BitLockerProtection";
+        var driveDebugSuffix = "\nfor:" + pszPath;
+        PInvoke.PSGetPropertyKeyFromName(pszName, out var key).AssertResultOk(nameof(PInvoke.SHCreateItemFromParsingName), pszName + driveDebugSuffix);
 
-            const string pszName = "System.Volume.BitLockerProtection";
-            var driveDebugSuffix = "\nfor:" + pszPath;
-            PInvoke.PSGetPropertyKeyFromName(pszName, out var key).AssertResultOk(nameof(PInvoke.SHCreateItemFromParsingName), pszName + driveDebugSuffix);
+        ppv.GetProperty(key, out var val);
 
-            ppv->GetProperty(key, out var val).AssertResultOk(nameof(IShellItem2) + "." + nameof(IShellItem2.GetProperty), $"fmtid={key.fmtid};pid:{key.pid};{driveDebugSuffix}");
+        PInvoke.PropVariantToInt32(val, out var bitLockerStatus).AssertResultOk(nameof(PInvoke.PropVariantToInt32), $"vt={val.Anonymous.Anonymous.vt};{driveDebugSuffix}");
 
-            PInvoke.PropVariantToInt32(val, out var bitLockerStatus).AssertResultOk(nameof(PInvoke.PropVariantToInt32), $"vt={val.Anonymous.Anonymous.vt};{driveDebugSuffix}");
-
-            return bitLockerStatus;
-        } finally {
-            if (ppv != null) {
-                _ = ppv->Release();
-            }
-        }
+        return bitLockerStatus;
     }
 }

--- a/src/ProgressOnderwijsUtils/Win32/Win32Extentions.cs
+++ b/src/ProgressOnderwijsUtils/Win32/Win32Extentions.cs
@@ -1,4 +1,4 @@
-using Microsoft.Windows.Sdk;
+using Windows.Win32.Foundation;
 
 namespace ProgressOnderwijsUtils.Win32;
 

--- a/test/ProgressOnderwijsUtils.Tests/Win32/VirusScanTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Win32/VirusScanTest.cs
@@ -1,3 +1,4 @@
+using System.Runtime.Versioning;
 using ProgressOnderwijsUtils.Win32;
 
 namespace ProgressOnderwijsUtils.Tests.Win32;
@@ -8,10 +9,12 @@ public sealed class VirusScanTest
     const string schoneString = "Dit is geen virus";
 
     [FactIgnoreOnAppVeyor]
+    [SupportedOSPlatform("windows10.0.10240")]
     public void VirusAlsByte_wordt_herkend()
         => PAssert.That(() => VirusScan.IsMalware(Encoding.ASCII.GetBytes(virusString), "EICAR", "Utils test"));
 
     [FactIgnoreOnAppVeyor]
+    [SupportedOSPlatform("windows10.0.10240")]
     public void SchoneString_als_byte_wordt_niet_als_virus_herkend()
         => PAssert.That(() => !VirusScan.IsMalware(Encoding.ASCII.GetBytes(schoneString), "Progress.Net", "Utils test"));
 }


### PR DESCRIPTION
Package includes various breaking changes, but dependent code is simple enough that this isn't all that tricky.

 - Replaces https://github.com/progressonderwijs/ProgressOnderwijsUtils/pull/1030