### PR TITLE
CascadeDelete: Extra parameter to accommodate foreign key specifications like `on delete set null`

### DIFF
--- a/src/ProgressOnderwijsUtils/Data/CascadedDelete.cs
+++ b/src/ProgressOnderwijsUtils/Data/CascadedDelete.cs
@@ -21,6 +21,7 @@ public static class CascadedDelete
             initialTableAsEntered,
             outputAllDeletedRows,
             logger,
+            o => o.DeleteReferentialAction != FkReferentialAction.SetNull,
             stopCascading,
             new[] { pkColumn, },
             SQL(
@@ -59,6 +60,7 @@ public static class CascadedDelete
             initialTableAsEntered,
             outputAllDeletedRows,
             logger,
+            o => o.DeleteReferentialAction != FkReferentialAction.SetNull,
             stopCascading,
             pkColumns,
             SQL(
@@ -93,6 +95,7 @@ public static class CascadedDelete
             initialTableAsEntered,
             outputAllDeletedRows,
             logger,
+            o => o.DeleteReferentialAction != FkReferentialAction.SetNull,
             stopCascading,
             pkColumns,
             SQL(
@@ -124,6 +127,7 @@ public static class CascadedDelete
         DatabaseDescription.Table initialTableAsEntered,
         bool outputAllDeletedRows,
         Action<string>? logger,
+        Func<DatabaseDescription.ForeignKey, bool> foreignKeyPredicate,
         Func<string, bool>? stopCascading,
         string[] pkColumns,
         ParameterizedSql pksTVParameter)
@@ -248,7 +252,7 @@ public static class CascadedDelete
                 }
             );
 
-            foreach (var fk in table.KeysFromReferencingChildren.Where(o => o.DeleteReferentialAction != FkReferentialAction.SetNull)) {
+            foreach (var fk in table.KeysFromReferencingChildren.Where(foreignKeyPredicate)) {
                 var childTable = fk.ReferencingChildTable;
                 var pkFkJoin = fk.Columns.Select(col => SQL($"fk.{col.ReferencingChildColumn.SqlColumnName()}=pk.{col.ReferencedParentColumn.SqlColumnName()}")).ConcatenateSql(SQL($" and "));
                 var newDelTable = ParameterizedSql.RawSql_PotentialForSqlInjection($"[#del_{delBatch}]");

--- a/src/ProgressOnderwijsUtils/Data/CascadedDelete.cs
+++ b/src/ProgressOnderwijsUtils/Data/CascadedDelete.cs
@@ -103,7 +103,7 @@ public static class CascadedDelete
             initialTableAsEntered,
             outputAllDeletedRows,
             logger,
-            null,
+            foreignKeyPredicate,
             stopCascading,
             pkColumns,
             SQL(

--- a/src/ProgressOnderwijsUtils/Data/CascadedDelete.cs
+++ b/src/ProgressOnderwijsUtils/Data/CascadedDelete.cs
@@ -248,7 +248,7 @@ public static class CascadedDelete
                 }
             );
 
-            foreach (var fk in table.KeysFromReferencingChildren) {
+            foreach (var fk in table.KeysFromReferencingChildren.Where(o => o.DeleteReferentialAction != FkReferentialAction.SetNull)) {
                 var childTable = fk.ReferencingChildTable;
                 var pkFkJoin = fk.Columns.Select(col => SQL($"fk.{col.ReferencingChildColumn.SqlColumnName()}=pk.{col.ReferencedParentColumn.SqlColumnName()}")).ConcatenateSql(SQL($" and "));
                 var newDelTable = ParameterizedSql.RawSql_PotentialForSqlInjection($"[#del_{delBatch}]");

--- a/src/ProgressOnderwijsUtils/Data/CascadedDelete.cs
+++ b/src/ProgressOnderwijsUtils/Data/CascadedDelete.cs
@@ -127,7 +127,7 @@ public static class CascadedDelete
         DatabaseDescription.Table initialTableAsEntered,
         bool outputAllDeletedRows,
         Action<string>? logger,
-        Func<DatabaseDescription.ForeignKey, bool> foreignKeyPredicate,
+        Func<DatabaseDescription.ForeignKey, bool>? foreignKeyPredicate,
         Func<string, bool>? stopCascading,
         string[] pkColumns,
         ParameterizedSql pksTVParameter)
@@ -252,7 +252,7 @@ public static class CascadedDelete
                 }
             );
 
-            foreach (var fk in table.KeysFromReferencingChildren.Where(foreignKeyPredicate)) {
+            foreach (var fk in table.KeysFromReferencingChildren.Where(foreignKeyPredicate ?? (_ => true))) {
                 var childTable = fk.ReferencingChildTable;
                 var pkFkJoin = fk.Columns.Select(col => SQL($"fk.{col.ReferencingChildColumn.SqlColumnName()}=pk.{col.ReferencedParentColumn.SqlColumnName()}")).ConcatenateSql(SQL($" and "));
                 var newDelTable = ParameterizedSql.RawSql_PotentialForSqlInjection($"[#del_{delBatch}]");

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>102.2.3</Version>
-    <PackageReleaseNotes>Bump dependencies</PackageReleaseNotes>
+    <Version>102.2.4</Version>
+    <PackageReleaseNotes>Replace RecursivelyDelete parameter</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>

--- a/test/ProgressOnderwijsUtils.Tests/Data/CascadedDeleteTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/CascadedDeleteTest.cs
@@ -22,7 +22,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         PAssert.That(() => initialDependentValues.SetEqual(new[] { 111, 333, }));
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, null, null, "A", AId.One, AId.Two);
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, null, "A", AId.One, AId.Two);
 
         var finalDependentValues = SQL($"select C from T2").ReadPlain<int>(Connection);
         PAssert.That(() => finalDependentValues.SetEqual(new[] { 333, }));
@@ -47,7 +47,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         PAssert.That(() => initialDependentValues.SetEqual(new[] { 111, 333, }));
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, null, null, "A", AId.One, AId.Two);
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, null, "A", AId.One, AId.Two);
 
         var finalDependentValues = SQL($"select C from T2").ReadPlain<int>(Connection);
         PAssert.That(() => finalDependentValues.SetEqual(new[] { 333, }));
@@ -77,7 +77,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         PAssert.That(() => initialDependentValues.SetEqual(new[] { 111, 333, }));
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var ex = Assert.ThrowsAny<Exception>(() => CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, null, null, "A", AId.One, AId.Two));
+        var ex = Assert.ThrowsAny<Exception>(() => CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, null, "A", AId.One, AId.Two));
         PAssert.That(() => ex.Message.Contains("dbo.T2->dbo.T1->dbo.T2->dbo.T1"));
     }
 
@@ -103,7 +103,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         ).ExecuteNonQuery(Connection);
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, null, null, PksToDelete("A", 1, 2));
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, null, PksToDelete("A", 1, 2));
         var finalValues = SQL($"select B from T1").ReadPlain<int>(Connection);
 
         PAssert.That(() => deletionReport.Select(t => t.Table).SequenceEqual(new[] { "dbo.T1", }));
@@ -142,7 +142,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         PAssert.That(() => initialTLeafKeys.SetEqual(new[] { 1, 2, 3, 4, }));
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.TRoot"), true, null, null, null, new RootId { Root = 1, }, new RootId { Root = 2, });
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.TRoot"), true, null, null, new RootId { Root = 1, }, new RootId { Root = 2, });
 
         var finalT2 = SQL($"select D from T2").ReadPlain<int>(Connection);
         PAssert.That(() => finalT2.SetEqual(new[] { 5, }));
@@ -175,7 +175,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         ).ExecuteNonQuery(Connection);
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.TRoot"), true, null, null, null, new RootId { Root = 1, });
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.TRoot"), true, null, null, new RootId { Root = 1, });
 
         var rowsFromTRoot = deletionReport.Single(t => t.Table == "dbo.TRoot");
         PAssert.That(() => rowsFromTRoot.DeletedAtMostRowCount == 1);
@@ -201,7 +201,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         ).ExecuteNonQuery(Connection);
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, fk => fk.ReferencedParentTable.QualifiedName != "dbo.T2", null, "A", AId.One);
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, fk => fk.ReferencedParentTable.QualifiedName != "dbo.T2", "A", AId.One);
 
         PAssert.That(() => deletionReport.Select(t => t.Table).SequenceEqual(new[] { "dbo.T3", "dbo.T1", }));
     }
@@ -221,7 +221,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         ).ExecuteNonQuery(Connection);
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), true, null, null, null, "A", AId.One)
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), true, null, null, "A", AId.One)
             .Select(StringifyDeletionReportRow).JoinStrings("\n");
 
         Assert.Equal(
@@ -269,7 +269,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         ).ExecuteNonQuery(Connection);
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.C"), true, null, null, null, new C_rec(4))
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.C"), true, null, null, new C_rec(4))
             .Select(StringifyDeletionReportRow).JoinStrings("\n");
 
         PAssert.That(
@@ -302,7 +302,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         ).ExecuteNonQuery(Connection);
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, null, null, "A", AId.One);
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, null, "A", AId.One);
 
         PAssert.That(() => deletionReport.Select(t => t.Table).SequenceEqual(new[] { "dbo.T2", "dbo.T1", }));
     }
@@ -316,7 +316,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         var version = SQL($"select t.V from T1 t").ReadScalar<byte[]>(Connection).AssertNotNull();
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), true, null, null, null, "A", AId.One).Single();
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), true, null, null, "A", AId.One).Single();
         var deletedRow = deletionReport.DeletedRows.AssertNotNull().Rows.Cast<DataRow>().Single();
 
         PAssert.That(() => deletionReport.Table == "dbo.T1");
@@ -333,7 +333,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         var version = SQL($"select t.V from T1 t").ReadScalar<byte[]>(Connection).AssertNotNull();
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), true, null, null, null, "A", AId.One).Single();
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), true, null, null, "A", AId.One).Single();
         var deletedRow = deletionReport.DeletedRows.AssertNotNull().Rows.Cast<DataRow>().Single();
 
         PAssert.That(() => deletionReport.Table == "dbo.T1");

--- a/test/ProgressOnderwijsUtils.Tests/Data/CascadedDeleteTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/CascadedDeleteTest.cs
@@ -201,7 +201,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         ).ExecuteNonQuery(Connection);
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, fk => fk.ReferencedParentTable.QualifiedName != "dbo.T2", "A", AId.One);
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, fk => fk.ReferencingChildTable.QualifiedName != "dbo.T2", "A", AId.One);
 
         PAssert.That(() => deletionReport.Select(t => t.Table).SequenceEqual(new[] { "dbo.T3", "dbo.T1", }));
     }

--- a/test/ProgressOnderwijsUtils.Tests/Data/CascadedDeleteTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/CascadedDeleteTest.cs
@@ -22,7 +22,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         PAssert.That(() => initialDependentValues.SetEqual(new[] { 111, 333, }));
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, null, "A", AId.One, AId.Two);
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, null, null, "A", AId.One, AId.Two);
 
         var finalDependentValues = SQL($"select C from T2").ReadPlain<int>(Connection);
         PAssert.That(() => finalDependentValues.SetEqual(new[] { 333, }));
@@ -47,7 +47,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         PAssert.That(() => initialDependentValues.SetEqual(new[] { 111, 333, }));
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, null, "A", AId.One, AId.Two);
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, null, null, "A", AId.One, AId.Two);
 
         var finalDependentValues = SQL($"select C from T2").ReadPlain<int>(Connection);
         PAssert.That(() => finalDependentValues.SetEqual(new[] { 333, }));
@@ -77,7 +77,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         PAssert.That(() => initialDependentValues.SetEqual(new[] { 111, 333, }));
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var ex = Assert.ThrowsAny<Exception>(() => CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, null, "A", AId.One, AId.Two));
+        var ex = Assert.ThrowsAny<Exception>(() => CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, null, null, "A", AId.One, AId.Two));
         PAssert.That(() => ex.Message.Contains("dbo.T2->dbo.T1->dbo.T2->dbo.T1"));
     }
 
@@ -103,7 +103,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         ).ExecuteNonQuery(Connection);
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, null, PksToDelete("A", 1, 2));
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, null, null, PksToDelete("A", 1, 2));
         var finalValues = SQL($"select B from T1").ReadPlain<int>(Connection);
 
         PAssert.That(() => deletionReport.Select(t => t.Table).SequenceEqual(new[] { "dbo.T1", }));
@@ -142,7 +142,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         PAssert.That(() => initialTLeafKeys.SetEqual(new[] { 1, 2, 3, 4, }));
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.TRoot"), true, null, null, new RootId { Root = 1, }, new RootId { Root = 2, });
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.TRoot"), true, null, null, null, new RootId { Root = 1, }, new RootId { Root = 2, });
 
         var finalT2 = SQL($"select D from T2").ReadPlain<int>(Connection);
         PAssert.That(() => finalT2.SetEqual(new[] { 5, }));
@@ -175,7 +175,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         ).ExecuteNonQuery(Connection);
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.TRoot"), true, null, null, new RootId { Root = 1, });
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.TRoot"), true, null, null, null, new RootId { Root = 1, });
 
         var rowsFromTRoot = deletionReport.Single(t => t.Table == "dbo.TRoot");
         PAssert.That(() => rowsFromTRoot.DeletedAtMostRowCount == 1);
@@ -204,7 +204,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
             => onTable == "dbo.T2";
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, StopCascading, "A", AId.One);
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, null, StopCascading, "A", AId.One);
 
         PAssert.That(() => deletionReport.Select(t => t.Table).SequenceEqual(new[] { "dbo.T3", "dbo.T1", }));
     }
@@ -224,7 +224,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         ).ExecuteNonQuery(Connection);
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), true, null, null, "A", AId.One)
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), true, null, null, null, "A", AId.One)
             .Select(StringifyDeletionReportRow).JoinStrings("\n");
 
         Assert.Equal(
@@ -272,7 +272,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         ).ExecuteNonQuery(Connection);
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.C"), true, null, null, new C_rec(4))
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.C"), true, null, null, null, new C_rec(4))
             .Select(StringifyDeletionReportRow).JoinStrings("\n");
 
         PAssert.That(
@@ -305,7 +305,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         ).ExecuteNonQuery(Connection);
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, null, "A", AId.One);
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, null, null, "A", AId.One);
 
         PAssert.That(() => deletionReport.Select(t => t.Table).SequenceEqual(new[] { "dbo.T2", "dbo.T1", }));
     }
@@ -319,7 +319,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         var version = SQL($"select t.V from T1 t").ReadScalar<byte[]>(Connection).AssertNotNull();
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), true, null, null, "A", AId.One).Single();
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), true, null, null, null, "A", AId.One).Single();
         var deletedRow = deletionReport.DeletedRows.AssertNotNull().Rows.Cast<DataRow>().Single();
 
         PAssert.That(() => deletionReport.Table == "dbo.T1");
@@ -336,7 +336,7 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         var version = SQL($"select t.V from T1 t").ReadScalar<byte[]>(Connection).AssertNotNull();
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), true, null, null, "A", AId.One).Single();
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), true, null, null, null, "A", AId.One).Single();
         var deletedRow = deletionReport.DeletedRows.AssertNotNull().Rows.Cast<DataRow>().Single();
 
         PAssert.That(() => deletionReport.Table == "dbo.T1");

--- a/test/ProgressOnderwijsUtils.Tests/Data/CascadedDeleteTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/CascadedDeleteTest.cs
@@ -200,11 +200,8 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
             "
         ).ExecuteNonQuery(Connection);
 
-        bool StopCascading(string onTable)
-            => onTable == "dbo.T2";
-
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
-        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, null, StopCascading, "A", AId.One);
+        var deletionReport = CascadedDelete.RecursivelyDelete(Connection, db.GetTableByName("dbo.T1"), false, null, fk => fk.ReferencedParentTable.QualifiedName != "dbo.T2", null, "A", AId.One);
 
         PAssert.That(() => deletionReport.Select(t => t.Table).SequenceEqual(new[] { "dbo.T3", "dbo.T1", }));
     }


### PR DESCRIPTION
- https://github.com/progressonderwijs/progress/issues/61738

Furthermore replacing the `StopCascading` parameter with this more advanced parameter.

By example:
If the foreign key has a delete specification `on delete set null` then do not delete, but let the FK specification set the value to null, you can use the predicate to accomodate this in the CascadeDelete.