### PR TITLE
Various code-cleanups and unit tests for untested code

### DIFF
--- a/ProgressOnderwijsUtils.sln.DotSettings
+++ b/ProgressOnderwijsUtils.sln.DotSettings
@@ -143,6 +143,7 @@ $EXPR$.AssertNotNull();</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertToConstant_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertToConstant_002ELocal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertToNullCoalescingCompoundAssignment/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertToPrimaryConstructor/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertToStaticClass/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CoVariantArrayConversion/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CSharpWarnings_003A_003ACS0078/@EntryIndexedValue">ERROR</s:String>

--- a/ProgressOnderwijsUtils.sln.DotSettings
+++ b/ProgressOnderwijsUtils.sln.DotSettings
@@ -470,6 +470,7 @@ $EXPR$.AssertNotNull();</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=TryCastAndCheckForNull_002E0/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=TryCastAndCheckForNull_002E1/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=TryStatementsCanBeMerged/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=TypeWithSuspiciousEqualityIsUsedInRecord_002ELocal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnassignedField_002ECompiler/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnassignedField_002ELocal/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnassignedGetOnlyAutoProperty/@EntryIndexedValue">ERROR</s:String>

--- a/src/ProgressOnderwijsUtils/Collections/SequenceEqualityComparer.cs
+++ b/src/ProgressOnderwijsUtils/Collections/SequenceEqualityComparer.cs
@@ -1,12 +1,12 @@
 namespace ProgressOnderwijsUtils.Collections;
 
-public sealed record SequenceEqualityComparer<T>(IEqualityComparer<T> UnderlyingElementComparer, bool NullCountsAsEmpty) : IEqualityComparer<T[]?>, IEqualityComparer<IEnumerable<T>?>
+public sealed record SequenceEqualityComparer<T>(IEqualityComparer<T> UnderlyingElementComparer, bool NullCountsAsEmpty) : IEqualityComparer<T?[]?>, IEqualityComparer<IEnumerable<T?>?>
 {
     public static readonly SequenceEqualityComparer<T> Default = new(EqualityComparer<T>.Default, false);
     const int NullHashCode = 0x1d45_7af3;
 
     [Pure]
-    public bool Equals(T[]? x, T[]? y)
+    public bool Equals(T?[]? x, T?[]? y)
     {
         if (NullCountsAsEmpty) {
             x ??= [];
@@ -31,7 +31,7 @@ public sealed record SequenceEqualityComparer<T>(IEqualityComparer<T> Underlying
     }
 
     [Pure]
-    public int GetHashCode(T[]? arr)
+    public int GetHashCode(T?[]? arr)
     {
         if (arr == null) {
             if (NullCountsAsEmpty) {
@@ -41,14 +41,14 @@ public sealed record SequenceEqualityComparer<T>(IEqualityComparer<T> Underlying
             }
         }
         var buffer = new HashCode();
-        foreach (var obj in arr) {
-            buffer.Add(obj, UnderlyingElementComparer);
+        foreach (var value in arr) {
+            buffer.Add(value is null ? 0 : UnderlyingElementComparer.GetHashCode(value));
         }
         return buffer.ToHashCode();
     }
 
     [Pure]
-    public bool Equals(IEnumerable<T>? x, IEnumerable<T>? y)
+    public bool Equals(IEnumerable<T?>? x, IEnumerable<T?>? y)
     {
         if (NullCountsAsEmpty) {
             x ??= Array.Empty<T>();
@@ -78,7 +78,7 @@ public sealed record SequenceEqualityComparer<T>(IEqualityComparer<T> Underlying
     }
 
     [Pure]
-    public int GetHashCode(IEnumerable<T>? seq)
+    public int GetHashCode(IEnumerable<T?>? seq)
     {
         if (seq == null) {
             if (NullCountsAsEmpty) {
@@ -88,8 +88,8 @@ public sealed record SequenceEqualityComparer<T>(IEqualityComparer<T> Underlying
             }
         }
         var buffer = new HashCode();
-        foreach (var obj in seq) {
-            buffer.Add(obj, UnderlyingElementComparer);
+        foreach (var value in seq) {
+            buffer.Add(value is null ? 0 : UnderlyingElementComparer.GetHashCode(value));
         }
         return buffer.ToHashCode();
     }

--- a/src/ProgressOnderwijsUtils/Collections/SequenceEqualityComparer.cs
+++ b/src/ProgressOnderwijsUtils/Collections/SequenceEqualityComparer.cs
@@ -9,8 +9,8 @@ public sealed record SequenceEqualityComparer<T>(IEqualityComparer<T> Underlying
     public bool Equals(T[]? x, T[]? y)
     {
         if (NullCountsAsEmpty) {
-            x ??= Array.Empty<T>();
-            y ??= Array.Empty<T>();
+            x ??= [];
+            y ??= [];
         } else {
             if (x == null) {
                 return y == null;
@@ -35,7 +35,7 @@ public sealed record SequenceEqualityComparer<T>(IEqualityComparer<T> Underlying
     {
         if (arr == null) {
             if (NullCountsAsEmpty) {
-                arr = Array.Empty<T>();
+                arr = [];
             } else {
                 return NullHashCode;
             }

--- a/src/ProgressOnderwijsUtils/Data/ColumnDefinition.cs
+++ b/src/ProgressOnderwijsUtils/Data/ColumnDefinition.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations.Schema;
 using ProgressOnderwijsUtils.SchemaReflection;
 
 namespace ProgressOnderwijsUtils;

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSql.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSql.cs
@@ -5,7 +5,7 @@ namespace ProgressOnderwijsUtils;
 /// Represents a string of SQL including parameter values.
 /// </summary>
 [DebuggerDisplay("{DebugText()}")]
-public readonly struct ParameterizedSql
+public readonly struct ParameterizedSql : IEquatable<ParameterizedSql>
 {
     internal readonly ISqlComponent? impl;
 

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSql.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSql.cs
@@ -5,7 +5,7 @@ namespace ProgressOnderwijsUtils;
 /// Represents a string of SQL including parameter values.
 /// </summary>
 [DebuggerDisplay("{DebugText()}")]
-public struct ParameterizedSql
+public readonly struct ParameterizedSql
 {
     internal readonly ISqlComponent? impl;
 

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSqlObjectMapper.cs
@@ -1,7 +1,6 @@
 using System.Buffers;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Text.Json;
-using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Query;
 
 // ReSharper disable ConvertToUsingDeclaration

--- a/src/ProgressOnderwijsUtils/Data/SqlParameterComponent.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlParameterComponent.cs
@@ -1,136 +1,136 @@
-namespace ProgressOnderwijsUtils
-{
-    static class SqlParameterComponent
-    {
-        static readonly Dictionary<long, string> empty = new();
-        static readonly ConcurrentDictionary<Type, Dictionary<long, string>> enumStringRepresentations = new();
+namespace ProgressOnderwijsUtils;
 
-        static readonly Func<Type, Dictionary<long, string>> enumStringRepresentationValueFactory =
-            type => {
-                var enumAttributes = type.GetCustomAttributes(true);
-                foreach (var customAttribute in enumAttributes) {
-                    if (customAttribute is IEnumShouldBeParameterizedInSqlAttribute) {
-                        return empty;
-                    }
-                }
-                var enumValues = Enum.GetValues(type);
-                if (enumValues.Length == 0) {
+static class SqlParameterComponent
+{
+    static readonly Dictionary<long, string> empty = new();
+    static readonly ConcurrentDictionary<Type, Dictionary<long, string>> enumStringRepresentations = new();
+
+    static readonly Func<Type, Dictionary<long, string>> enumStringRepresentationValueFactory =
+        type => {
+            var enumAttributes = type.GetCustomAttributes(true);
+            foreach (var customAttribute in enumAttributes) {
+                if (customAttribute is IEnumShouldBeParameterizedInSqlAttribute) {
                     return empty;
                 }
-                var literalSqlByEnumValue = new Dictionary<long, string>();
-                foreach (var v in enumValues) {
-                    var valueAsLong = ((IConvertible)v).ToInt64(null);
-                    literalSqlByEnumValue.Add(valueAsLong, $"{valueAsLong.ToStringInvariant()}/*{ObjectToCode.PlainObjectToCode(v)}*/");
-                }
-                return literalSqlByEnumValue;
-            };
-
-        static string? GetEnumStringRepresentationOrNull(Enum? val)
-            => val == null
-                ? null
-                : enumStringRepresentations
-                    .GetOrAdd(val.GetType(), enumStringRepresentationValueFactory)
-                    .GetValueOrDefault(((IConvertible)val).ToInt64(null));
-
-        static string? GetBooleanStringRepresentationOrNull(bool? val)
-            => val == null
-                ? null
-                : val.Value
-                    ? "cast(1 as bit)"
-                    : "cast(0 as bit)";
-
-        public static void AppendParamTo<TCommandFactory>(ref TCommandFactory factory, object? o)
-            where TCommandFactory : struct, ICommandFactory
-        {
-            while (o is SqlParam sp) {
-                o = sp.Value;
             }
-            if (o is IEnumerable enumerable and not string and not byte[]) {
-                ToTableValuedParameterFromPlainValues(enumerable).AppendTo(ref factory);
+            var enumValues = Enum.GetValues(type);
+            if (enumValues.Length == 0) {
+                return empty;
+            }
+            var literalSqlByEnumValue = new Dictionary<long, string>();
+            foreach (var v in enumValues) {
+                var valueAsLong = ((IConvertible)v).ToInt64(null);
+                literalSqlByEnumValue.Add(valueAsLong, $"{valueAsLong.ToStringInvariant()}/*{ObjectToCode.PlainObjectToCode(v)}*/");
+            }
+            return literalSqlByEnumValue;
+        };
+
+    static string? GetEnumStringRepresentationOrNull(Enum? val)
+        => val == null
+            ? null
+            : enumStringRepresentations
+                .GetOrAdd(val.GetType(), enumStringRepresentationValueFactory)
+                .GetValueOrDefault(((IConvertible)val).ToInt64(null));
+
+    static string? GetBooleanStringRepresentationOrNull(bool? val)
+        => val == null
+            ? null
+            : val.Value
+                ? "cast(1 as bit)"
+                : "cast(0 as bit)";
+
+    public static void AppendParamTo<TCommandFactory>(ref TCommandFactory factory, object? o)
+        where TCommandFactory : struct, ICommandFactory
+    {
+        while (o is SqlParam sp) {
+            o = sp.Value;
+        }
+        if (o is IEnumerable enumerable and not string and not byte[]) {
+            ToTableValuedParameterFromPlainValues(enumerable).AppendTo(ref factory);
+        } else {
+            var literalSqlRepresentation =
+                GetBooleanStringRepresentationOrNull(o as bool?)
+                ?? GetEnumStringRepresentationOrNull(o as Enum);
+
+            if (literalSqlRepresentation != null) {
+                factory.AppendSql(literalSqlRepresentation);
             } else {
-                var literalSqlRepresentation =
-                    GetBooleanStringRepresentationOrNull(o as bool?)
-                    ?? GetEnumStringRepresentationOrNull(o as Enum);
-
-                if (literalSqlRepresentation != null) {
-                    factory.AppendSql(literalSqlRepresentation);
-                } else {
-                    QueryScalarParameterComponent.AppendScalarParameter(ref factory, o);
-                }
+                QueryScalarParameterComponent.AppendScalarParameter(ref factory, o);
             }
         }
+    }
 
-        public static ISqlComponent ToTableValuedParameterFromPlainValues(IEnumerable set)
+    public static ISqlComponent ToTableValuedParameterFromPlainValues(IEnumerable set)
+    {
+        var enumerableType = set.GetType();
+        if (!tableValuedParameterFactoryCache.TryGetValue(enumerableType, out var factory)) {
+            factory = CreateTableValuedParameterFactory(enumerableType);
+            _ = tableValuedParameterFactoryCache.TryAdd(enumerableType, factory);
+        }
+        if (factory == null) {
+            throw new ArgumentException($"Cannot interpret {enumerableType.ToCSharpFriendlyTypeName()} as a table valued parameter", nameof(set));
+        }
+        return factory.CreateFromPlainValues(set);
+    }
+
+    public static ISqlComponent ToTableValuedParameter<TIn, TOut>(string tableTypeName, IEnumerable<TIn> set, Func<IEnumerable<TIn>, TOut[]> projection)
+        where TOut : IReadImplicitly, new()
+        => set is IReadOnlyList<TIn> { Count: 1, }
+            ? new SingletonQueryTableValuedParameterComponent<TOut>(projection(set)[0])
+            : new QueryTableValuedParameterComponent<TIn, TOut>(tableTypeName, set, projection);
+
+    static readonly ConcurrentDictionary<Type, ITableValuedParameterFactory?> tableValuedParameterFactoryCache = new();
+
+    static ITableValuedParameterFactory? CreateTableValuedParameterFactory(Type enumerableType)
+    {
+        var elementType = TryGetNonAmbiguousEnumerableElementType(enumerableType);
+        if (elementType == null) {
+            return null;
+        }
+        var converter = AutomaticValueConverters.GetOrNull(elementType);
+        var underlyingType = converter?.ProviderClrType ?? elementType.GetUnderlyingType();
+        var sqlTableTypeName = CustomTableType.SqlTableTypeNameByDotnetType.GetValueOrDefault(underlyingType);
+        if (sqlTableTypeName == null) {
+            return null;
+        }
+        var factoryType = typeof(TableValuedParameterFactory<>).MakeGenericType(elementType);
+        return (ITableValuedParameterFactory?)Activator.CreateInstance(factoryType, sqlTableTypeName);
+    }
+
+    internal readonly struct CustomTableType
+    {
+        public readonly Type Type;
+        public readonly string SqlTypeName;
+        public readonly string TableDeclaration;
+
+        CustomTableType(Type type, string sqlTypeName, string tableDeclaration)
         {
-            var enumerableType = set.GetType();
-            if (!tableValuedParameterFactoryCache.TryGetValue(enumerableType, out var factory)) {
-                factory = CreateTableValuedParameterFactory(enumerableType);
-                _ = tableValuedParameterFactoryCache.TryAdd(enumerableType, factory);
-            }
-            if (factory == null) {
-                throw new ArgumentException($"Cannot interpret {enumerableType.ToCSharpFriendlyTypeName()} as a table valued parameter", nameof(set));
-            }
-            return factory.CreateFromPlainValues(set);
+            Type = type;
+            SqlTypeName = sqlTypeName;
+            TableDeclaration = tableDeclaration;
         }
 
-        public static ISqlComponent ToTableValuedParameter<TIn, TOut>(string tableTypeName, IEnumerable<TIn> set, Func<IEnumerable<TIn>, TOut[]> projection)
-            where TOut : IReadImplicitly, new()
-            => set is IReadOnlyList<TIn> { Count: 1, }
-                ? new SingletonQueryTableValuedParameterComponent<TOut>(projection(set)[0])
-                : new QueryTableValuedParameterComponent<TIn, TOut>(tableTypeName, set, projection);
+        public static readonly CustomTableType[] All = {
+            new(typeof(long), "TVar_Bigint", "querytablevalue bigint not null"),
+            new(typeof(bool), "TVar_Bit", "querytablevalue bit not null"),
+            new(typeof(DateTime), "TVar_DateTime2", "querytablevalue datetime2(7) not null"),
+            new(typeof(decimal), "TVar_Decimal", "querytablevalue decimal(18, 0) not null"),
+            new(typeof(double), "TVar_Float", "querytablevalue float not null"),
+            new(typeof(int), "TVar_Int", "querytablevalue int not null, primary key clustered (querytablevalue asc) with (ignore_dup_key = off)"),
+            new(typeof(char), "TVar_NChar1", "querytablevalue nchar(1) not null"),
+            new(typeof(string), "TVar_NVarcharMax", "querytablevalue nvarchar(max) not null"),
+            new(typeof(short), "TVar_Smallint", "querytablevalue smallint not null"),
+            new(typeof(TimeSpan), "TVar_Time", "querytablevalue time(7) not null"),
+            new(typeof(byte), "TVar_Tinyint", "querytablevalue tinyint not null"),
+            new(typeof(byte[]), "TVar_VarBinaryMax", "querytablevalue varbinary(max) not null"),
+            new(typeof(Guid), "TVar_Uniqueidentifier", "querytablevalue uniqueidentifier not null"),
+        };
 
-        static readonly ConcurrentDictionary<Type, ITableValuedParameterFactory?> tableValuedParameterFactoryCache = new();
+        public static readonly Dictionary<Type, string> SqlTableTypeNameByDotnetType = All.ToDictionary(o => o.Type, o => o.SqlTypeName);
 
-        static ITableValuedParameterFactory? CreateTableValuedParameterFactory(Type enumerableType)
-        {
-            var elementType = TryGetNonAmbiguousEnumerableElementType(enumerableType);
-            if (elementType == null) {
-                return null;
-            }
-            var converter = AutomaticValueConverters.GetOrNull(elementType);
-            var underlyingType = converter?.ProviderClrType ?? elementType.GetUnderlyingType();
-            var sqlTableTypeName = CustomTableType.SqlTableTypeNameByDotnetType.GetValueOrDefault(underlyingType);
-            if (sqlTableTypeName == null) {
-                return null;
-            }
-            var factoryType = typeof(TableValuedParameterFactory<>).MakeGenericType(elementType);
-            return (ITableValuedParameterFactory?)Activator.CreateInstance(factoryType, sqlTableTypeName);
-        }
-
-        internal readonly struct CustomTableType
-        {
-            public readonly Type Type;
-            public readonly string SqlTypeName;
-            public readonly string TableDeclaration;
-
-            CustomTableType(Type type, string sqlTypeName, string tableDeclaration)
-            {
-                Type = type;
-                SqlTypeName = sqlTypeName;
-                TableDeclaration = tableDeclaration;
-            }
-
-            public static readonly CustomTableType[] All = {
-                new(typeof(long), "TVar_Bigint", "querytablevalue bigint not null"),
-                new(typeof(bool), "TVar_Bit", "querytablevalue bit not null"),
-                new(typeof(DateTime), "TVar_DateTime2", "querytablevalue datetime2(7) not null"),
-                new(typeof(decimal), "TVar_Decimal", "querytablevalue decimal(18, 0) not null"),
-                new(typeof(double), "TVar_Float", "querytablevalue float not null"),
-                new(typeof(int), "TVar_Int", "querytablevalue int not null, primary key clustered (querytablevalue asc) with (ignore_dup_key = off)"),
-                new(typeof(char), "TVar_NChar1", "querytablevalue nchar(1) not null"),
-                new(typeof(string), "TVar_NVarcharMax", "querytablevalue nvarchar(max) not null"),
-                new(typeof(short), "TVar_Smallint", "querytablevalue smallint not null"),
-                new(typeof(TimeSpan), "TVar_Time", "querytablevalue time(7) not null"),
-                new(typeof(byte), "TVar_Tinyint", "querytablevalue tinyint not null"),
-                new(typeof(byte[]), "TVar_VarBinaryMax", "querytablevalue varbinary(max) not null"),
-                new(typeof(Guid), "TVar_Uniqueidentifier", "querytablevalue uniqueidentifier not null"),
-            };
-
-            public static readonly Dictionary<Type, string> SqlTableTypeNameByDotnetType = All.ToDictionary(o => o.Type, o => o.SqlTypeName);
-
-            public static ParameterizedSql DefinitionScripts
-                => SQL(
-                    $@"
+        public static ParameterizedSql DefinitionScripts
+            => SQL(
+                $@"
                     begin tran;
                     {All
                         .Select(o => SQL($@"
@@ -141,54 +141,53 @@ namespace ProgressOnderwijsUtils
                         .ConcatenateSql()}
                     commit;
                 "
-                );
-        }
+            );
+    }
 
-        interface ITableValuedParameterFactory
-        {
-            ISqlComponent CreateFromPlainValues(IEnumerable enumerable);
-        }
+    interface ITableValuedParameterFactory
+    {
+        ISqlComponent CreateFromPlainValues(IEnumerable enumerable);
+    }
 
-        sealed class TableValuedParameterFactory<T> : ITableValuedParameterFactory
-        {
-            readonly string sqlTableTypeName;
+    sealed class TableValuedParameterFactory<T> : ITableValuedParameterFactory
+    {
+        readonly string sqlTableTypeName;
 
-            //cache delegate to save some allocs and avoid risking slow paths like COMDelegate::DelegateConstruct
-            readonly Func<IEnumerable<T>, TableValuedParameterWrapper<T>[]> WrapPlainValueInSinglePropertyPoco = TableValuedParameterWrapperHelper.WrapPlainValueInSinglePropertyPoco;
+        //cache delegate to save some allocs and avoid risking slow paths like COMDelegate::DelegateConstruct
+        readonly Func<IEnumerable<T>, TableValuedParameterWrapper<T>[]> WrapPlainValueInSinglePropertyPoco = TableValuedParameterWrapperHelper.WrapPlainValueInSinglePropertyPoco;
 
-            public TableValuedParameterFactory(string sqlTableTypeName)
-                => this.sqlTableTypeName = sqlTableTypeName;
+        public TableValuedParameterFactory(string sqlTableTypeName)
+            => this.sqlTableTypeName = sqlTableTypeName;
 
-            public ISqlComponent CreateFromPlainValues(IEnumerable enumerable)
-                => ToTableValuedParameter(sqlTableTypeName, (IEnumerable<T>)enumerable, WrapPlainValueInSinglePropertyPoco);
-        }
+        public ISqlComponent CreateFromPlainValues(IEnumerable enumerable)
+            => ToTableValuedParameter(sqlTableTypeName, (IEnumerable<T>)enumerable, WrapPlainValueInSinglePropertyPoco);
+    }
 
-        static Type? TryGetNonAmbiguousEnumerableElementType(Type enumerableType)
-        {
-            var elementType = default(Type);
-            foreach (var interfaceType in enumerableType.GetInterfaces()) {
-                if (interfaceType.IsGenericType && interfaceType.GetGenericTypeDefinition() == typeof(IEnumerable<>)) {
-                    if (elementType != null) {
-                        return null; //non-unique, no best match
-                    }
-                    elementType = interfaceType.GetGenericArguments()[0];
+    static Type? TryGetNonAmbiguousEnumerableElementType(Type enumerableType)
+    {
+        var elementType = default(Type);
+        foreach (var interfaceType in enumerableType.GetInterfaces()) {
+            if (interfaceType.IsGenericType && interfaceType.GetGenericTypeDefinition() == typeof(IEnumerable<>)) {
+                if (elementType != null) {
+                    return null; //non-unique, no best match
                 }
+                elementType = interfaceType.GetGenericArguments()[0];
             }
-            return elementType;
         }
+        return elementType;
+    }
 
-        public static void AppendParamOrFragment<TCommandFactory>(ref TCommandFactory factory, object? argument)
-            where TCommandFactory : struct, ICommandFactory
-        {
-            if (argument is ParameterizedSql sql) {
-                sql.AppendTo(ref factory);
-            } else if (argument is INestableSql nestableSql) {
-                nestableSql.Sql.AppendTo(ref factory);
-            } else if (argument is { } and not Enum && AutomaticValueConverters.GetOrNull(argument.GetType()) is { } converter) {
-                AppendParamTo(ref factory, converter.ConvertToProvider(argument));
-            } else {
-                AppendParamTo(ref factory, argument);
-            }
+    public static void AppendParamOrFragment<TCommandFactory>(ref TCommandFactory factory, object? argument)
+        where TCommandFactory : struct, ICommandFactory
+    {
+        if (argument is ParameterizedSql sql) {
+            sql.AppendTo(ref factory);
+        } else if (argument is INestableSql nestableSql) {
+            nestableSql.Sql.AppendTo(ref factory);
+        } else if (argument is { } and not Enum && AutomaticValueConverters.GetOrNull(argument.GetType()) is { } converter) {
+            AppendParamTo(ref factory, converter.ConvertToProvider(argument));
+        } else {
+            AppendParamTo(ref factory, argument);
         }
     }
 }

--- a/src/ProgressOnderwijsUtils/Data/SqlParameterComponent.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlParameterComponent.cs
@@ -1,6 +1,3 @@
-using System.ComponentModel.DataAnnotations;
-using ProgressOnderwijsUtils.Internal;
-
 namespace ProgressOnderwijsUtils
 {
     static class SqlParameterComponent
@@ -141,8 +138,7 @@ namespace ProgressOnderwijsUtils
                             create type {ParameterizedSql.RawSql_PotentialForSqlInjection(o.SqlTypeName)}
                             as table ({ParameterizedSql.RawSql_PotentialForSqlInjection(o.TableDeclaration)});
                         "))
-                        .ConcatenateSql()
-                    }
+                        .ConcatenateSql()}
                     commit;
                 "
                 );
@@ -192,54 +188,6 @@ namespace ProgressOnderwijsUtils
                 AppendParamTo(ref factory, converter.ConvertToProvider(argument));
             } else {
                 AppendParamTo(ref factory, argument);
-            }
-        }
-    }
-
-    namespace Internal
-    {
-        //public needed for auto-mapping
-        public struct TableValuedParameterWrapper<T> : IWrittenImplicitly, IOptionalObjectProjectionForDebugging, IReadImplicitly
-        {
-            [Key]
-            public T QueryTableValue { get; init; }
-
-            public override string? ToString()
-                => QueryTableValue is null ? "NULL" : QueryTableValue.ToString();
-
-            public object? ProjectionForDebuggingOrNull()
-                => QueryTableValue;
-        }
-
-        public static class TableValuedParameterWrapperHelper
-        {
-            /// <summary>
-            /// Efficiently wraps an enumerable of objects in DbTableValuedParameterWrapper and materialized the sequence as array.
-            /// Effectively it's like .Select(x => new DbTableValuedParameterWrapper { querytablevalue = x }).ToArray() but faster.
-            /// </summary>
-            public static TableValuedParameterWrapper<T>[] WrapPlainValueInSinglePropertyPoco<T>(IEnumerable<T> typedEnumerable)
-            {
-                if (typedEnumerable is T[] typedArray) {
-                    var projectedArray = new TableValuedParameterWrapper<T>[typedArray.Length];
-                    for (var i = 0; i < projectedArray.Length; i++) {
-                        projectedArray[i] = new() { QueryTableValue = typedArray[i], };
-                    }
-                    return projectedArray;
-                }
-
-                if (typedEnumerable is IReadOnlyList<T> typedList) {
-                    var projectedArray = new TableValuedParameterWrapper<T>[typedList.Count];
-                    for (var i = 0; i < projectedArray.Length; i++) {
-                        projectedArray[i] = new() { QueryTableValue = typedList[i], };
-                    }
-                    return projectedArray;
-                }
-
-                var arrayBuilder = new ArrayBuilder<TableValuedParameterWrapper<T>>();
-                foreach (var item in typedEnumerable) {
-                    arrayBuilder.Add(new() { QueryTableValue = item, });
-                }
-                return arrayBuilder.ToArray();
             }
         }
     }

--- a/src/ProgressOnderwijsUtils/Data/TableValuedParameterWrapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/TableValuedParameterWrapper.cs
@@ -3,7 +3,7 @@ using System.ComponentModel.DataAnnotations;
 namespace ProgressOnderwijsUtils.Internal;
 
 //public needed for auto-mapping
-public struct TableValuedParameterWrapper<T> : IWrittenImplicitly, IOptionalObjectProjectionForDebugging, IReadImplicitly
+readonly struct TableValuedParameterWrapper<T> : IWrittenImplicitly, IOptionalObjectProjectionForDebugging, IReadImplicitly
 {
     [Key]
     public T QueryTableValue { get; init; }
@@ -16,7 +16,7 @@ public struct TableValuedParameterWrapper<T> : IWrittenImplicitly, IOptionalObje
 }
 
 
-public static class TableValuedParameterWrapperHelper
+static class TableValuedParameterWrapperHelper
 {
     /// <summary>
     /// Efficiently wraps an enumerable of objects in DbTableValuedParameterWrapper and materialized the sequence as array.

--- a/src/ProgressOnderwijsUtils/Data/TableValuedParameterWrapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/TableValuedParameterWrapper.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 
-namespace ProgressOnderwijsUtils.Internal;
+namespace ProgressOnderwijsUtils;
 
 //public needed for auto-mapping
 readonly struct TableValuedParameterWrapper<T> : IWrittenImplicitly, IOptionalObjectProjectionForDebugging, IReadImplicitly

--- a/src/ProgressOnderwijsUtils/Data/TableValuedParameterWrapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/TableValuedParameterWrapper.cs
@@ -1,0 +1,49 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ProgressOnderwijsUtils.Internal;
+
+//public needed for auto-mapping
+public struct TableValuedParameterWrapper<T> : IWrittenImplicitly, IOptionalObjectProjectionForDebugging, IReadImplicitly
+{
+    [Key]
+    public T QueryTableValue { get; init; }
+
+    public override string? ToString()
+        => QueryTableValue is null ? "NULL" : QueryTableValue.ToString();
+
+    public object? ProjectionForDebuggingOrNull()
+        => QueryTableValue;
+}
+
+
+public static class TableValuedParameterWrapperHelper
+{
+    /// <summary>
+    /// Efficiently wraps an enumerable of objects in DbTableValuedParameterWrapper and materialized the sequence as array.
+    /// Effectively it's like .Select(x => new DbTableValuedParameterWrapper { querytablevalue = x }).ToArray() but faster.
+    /// </summary>
+    public static TableValuedParameterWrapper<T>[] WrapPlainValueInSinglePropertyPoco<T>(IEnumerable<T> typedEnumerable)
+    {
+        if (typedEnumerable is T[] typedArray) {
+            var projectedArray = new TableValuedParameterWrapper<T>[typedArray.Length];
+            for (var i = 0; i < projectedArray.Length; i++) {
+                projectedArray[i] = new() { QueryTableValue = typedArray[i], };
+            }
+            return projectedArray;
+        }
+
+        if (typedEnumerable is IReadOnlyList<T> typedList) {
+            var projectedArray = new TableValuedParameterWrapper<T>[typedList.Count];
+            for (var i = 0; i < projectedArray.Length; i++) {
+                projectedArray[i] = new() { QueryTableValue = typedList[i], };
+            }
+            return projectedArray;
+        }
+
+        var arrayBuilder = new ArrayBuilder<TableValuedParameterWrapper<T>>();
+        foreach (var item in typedEnumerable) {
+            arrayBuilder.Add(new() { QueryTableValue = item, });
+        }
+        return arrayBuilder.ToArray();
+    }
+}

--- a/src/ProgressOnderwijsUtils/Html/HtmlDirectory.cs
+++ b/src/ProgressOnderwijsUtils/Html/HtmlDirectory.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ProgressOnderwijsUtils.Html;
 sealed class HtmlDirectory

--- a/src/ProgressOnderwijsUtils/Html/HtmlToStringExtensions.cs
+++ b/src/ProgressOnderwijsUtils/Html/HtmlToStringExtensions.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Buffers;
 using System.IO.Pipelines;
-using System.Text;
 
 namespace ProgressOnderwijsUtils.Html;
 

--- a/src/ProgressOnderwijsUtils/Pocos/SmallBatchInsertImplementation.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/SmallBatchInsertImplementation.cs
@@ -1,5 +1,3 @@
-using System.ComponentModel.DataAnnotations.Schema;
-
 namespace ProgressOnderwijsUtils;
 
 public static class SmallBatchInsertImplementation

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtils.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup Label="Configuration">
-    <Version>102.5.0</Version>
-    <PackageReleaseNotes>Added GenerateUniqueQueryAlias methods</PackageReleaseNotes>
+    <Version>102.6.0</Version>
+    <PackageReleaseNotes>Support collection expression equality in ParameterizedSql equality; mark ParameterizedSql as readonly</PackageReleaseNotes>
     <Title>ProgressOnderwijsUtils</Title>
     <Description>Collection of utilities developed by ProgressOnderwijs</Description>
     <PackageTags>ProgressOnderwijs</PackageTags>

--- a/src/ProgressOnderwijsUtils/ProgressOnderwijsUtilsAssembly.cs
+++ b/src/ProgressOnderwijsUtils/ProgressOnderwijsUtilsAssembly.cs
@@ -27,3 +27,5 @@ global using global::ProgressOnderwijsUtils.Collections;
 global using global::ProgressOnderwijsUtils.Internal;
 global using static global::ProgressOnderwijsUtils.SafeSql;
 global using PureAttribute = global::System.Diagnostics.Contracts.PureAttribute;
+
+[assembly: InternalsVisibleTo("ProgressOnderwijsUtils.Tests")]

--- a/test/ProgressOnderwijsUtils.Tests/.editorconfig
+++ b/test/ProgressOnderwijsUtils.Tests/.editorconfig
@@ -1,0 +1,2 @@
+[*.cs]
+resharper_usage_of_default_struct_equality_highlighting = none

--- a/test/ProgressOnderwijsUtils.Tests/Data/ParameterizedSqlTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/ParameterizedSqlTest.cs
@@ -116,9 +116,9 @@ public sealed class ParameterizedSqlTest
             withPar_1_2 = SQL($"a param: {new[] { 1, 2, }}"),
             withPar_1_2b = SQL($"a param: {new[] { 1, 2, }}"),
             withPar_2_1 = SQL($"a param: {new[] { 2, 1, }}"),
-            withParEnum_1_2 = SQL($"a param: {new[] { (DayOfWeek)1, (DayOfWeek)2, }}"),
-            withParString_1_2 = SQL($"a param: {new[] { "1", "2", }}"),
-            withParString_1_2b = SQL($"a param: {new[] { "1", "2", }}")
+            withParEnum_1_2 = SQL($"a param: {[(DayOfWeek)1, (DayOfWeek)2,]}"),
+            withParString_1_2 = SQL($"a param: {["1", "2",]}"),
+            withParString_1_2b = SQL($"a param: {["1", "2",]}")
             ;
 
         PAssert.That(() => withPar_1_2 == withPar_1_2b);

--- a/test/ProgressOnderwijsUtils.Tests/Data/ParameterizedSqlTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/ParameterizedSqlTest.cs
@@ -142,6 +142,22 @@ public sealed class ParameterizedSqlTest
     }
 
     [Fact]
+    public void EscapedSqlObjectName_works()
+    {
+        PAssert.That(() => ParameterizedSql.EscapedSqlObjectName("foo").CommandText() == "[foo]");
+        PAssert.That(() => ParameterizedSql.EscapedSqlObjectName("foo 'bar").CommandText() == "[foo 'bar]");
+        PAssert.That(() => ParameterizedSql.EscapedSqlObjectName("test [ this ]").CommandText() == "[test [ this ]]]");
+    }
+
+    [Fact]
+    public void EscapedLiteralString_works()
+    {
+        PAssert.That(() => ParameterizedSql.EscapedLiteralString("foo").CommandText() == "'foo'");
+        PAssert.That(() => ParameterizedSql.EscapedLiteralString("foo [%bar").CommandText() == "'foo [%bar'");
+        PAssert.That(() => ParameterizedSql.EscapedLiteralString("test ' this '").CommandText() == "'test '' this '''");
+    }
+
+    [Fact]
     public void ParameterizedSqlValidation()
         // ReSharper disable once NullableWarningSuppressionIsUsed
         => _ = Assert.Throws<ArgumentNullException>(() => _ = ParameterizedSql.RawSql_PotentialForSqlInjection(null!));

--- a/test/ProgressOnderwijsUtils.Tests/Data/ParameterizedSqlTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/ParameterizedSqlTest.cs
@@ -294,9 +294,7 @@ public sealed class ParameterizedSqlTest
             $$"""
             select a={{42}}
                 , b = 'consider {}'
-                , c = {{
-                    SQL($"[{'a'}{"$@"}]")
-                }}
+                , c = {{SQL($"[{'a'}{"$@"}]")}}
             ;
             """
         );

--- a/test/ProgressOnderwijsUtils.Tests/Data/ParameterizedSqlTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/ParameterizedSqlTest.cs
@@ -158,6 +158,14 @@ public sealed class ParameterizedSqlTest
     }
 
     [Fact]
+    public void LiteralSqlNumericString_works()
+    {
+        PAssert.That(() => ParameterizedSql.LiteralSqlNumericString(0).CommandText() == "0");
+        PAssert.That(() => ParameterizedSql.LiteralSqlNumericString(-100_000).CommandText() == "-100000");
+        PAssert.That(() => ParameterizedSql.LiteralSqlNumericString(23456).CommandText() == "23456");
+    }
+
+    [Fact]
     public void ParameterizedSqlValidation()
         // ReSharper disable once NullableWarningSuppressionIsUsed
         => _ = Assert.Throws<ArgumentNullException>(() => _ = ParameterizedSql.RawSql_PotentialForSqlInjection(null!));

--- a/test/ProgressOnderwijsUtils.Tests/Data/ParameterizedSqlTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/ParameterizedSqlTest.cs
@@ -165,10 +165,10 @@ public sealed class ParameterizedSqlTest
     [Fact]
     public void ValidIdentifierCharsOnly_ThrowsOnInvalid()
     {
-        _ = ParameterizedSql.UnescapedSqlIdentifier("a$b");//assert does not throw
-        _ = ParameterizedSql.UnescapedSqlIdentifier("#tempTable");//assert does not throw
-        _ = ParameterizedSql.UnescapedSqlIdentifier("bla");//assert does not throw
-        _ = ParameterizedSql.UnescapedSqlIdentifier("bla0");//assert does not throw
+        _ = ParameterizedSql.UnescapedSqlIdentifier("a$b"); //assert does not throw
+        _ = ParameterizedSql.UnescapedSqlIdentifier("#tempTable"); //assert does not throw
+        _ = ParameterizedSql.UnescapedSqlIdentifier("bla"); //assert does not throw
+        _ = ParameterizedSql.UnescapedSqlIdentifier("bla0"); //assert does not throw
 
         _ = Assert.Throws<Exception>(() => _ = ParameterizedSql.UnescapedSqlIdentifier(""));
         _ = Assert.Throws<Exception>(() => _ = ParameterizedSql.UnescapedSqlIdentifier("--\n\n drop bobby tables"));
@@ -185,11 +185,11 @@ public sealed class ParameterizedSqlTest
     [Fact]
     public void AssertQualifiedSqlIdentifier_ThrowsOnInvalid()
     {
-        _ = ParameterizedSql.AssertQualifiedSqlIdentifier("a.b");//assert does not throw
-        _ = ParameterizedSql.AssertQualifiedSqlIdentifier("a$b.c$d");//assert does not throw
-        _ = ParameterizedSql.AssertQualifiedSqlIdentifier("#temptable.col");//assert does not throw
-        _ = ParameterizedSql.AssertQualifiedSqlIdentifier("hmm.#dubious");//assert does not throw, but not dangerous
-        _ = ParameterizedSql.AssertQualifiedSqlIdentifier("bla0.col");//assert does not throw, but not dangerous
+        _ = ParameterizedSql.AssertQualifiedSqlIdentifier("a.b"); //assert does not throw
+        _ = ParameterizedSql.AssertQualifiedSqlIdentifier("a$b.c$d"); //assert does not throw
+        _ = ParameterizedSql.AssertQualifiedSqlIdentifier("#temptable.col"); //assert does not throw
+        _ = ParameterizedSql.AssertQualifiedSqlIdentifier("hmm.#dubious"); //assert does not throw, but not dangerous
+        _ = ParameterizedSql.AssertQualifiedSqlIdentifier("bla0.col"); //assert does not throw, but not dangerous
 
         _ = Assert.Throws<Exception>(() => _ = ParameterizedSql.AssertQualifiedSqlIdentifier(""));
         _ = Assert.Throws<Exception>(() => _ = ParameterizedSql.AssertQualifiedSqlIdentifier("--\n\n drop bobby tables"));

--- a/test/ProgressOnderwijsUtils.Tests/Data/TableValuedParameterTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/TableValuedParameterTest.cs
@@ -1,5 +1,4 @@
 using System.Data.Common;
-using Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
 using ProgressOnderwijsUtils.Internal;
 
 namespace ProgressOnderwijsUtils.Tests.Data;

--- a/test/ProgressOnderwijsUtils.Tests/ReferenceEqualityComparerTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/ReferenceEqualityComparerTest.cs
@@ -2,14 +2,7 @@ namespace ProgressOnderwijsUtils.Tests;
 
 public sealed class ReferenceEqualityComparerTest
 {
-    struct TestType
-    {
-        [UsedImplicitly] //for equality
-        int value;
-
-        public TestType(int value)
-            => this.value = value;
-    }
+    record struct TestType(int value);
 
     static readonly TestType t1 = new(1);
     static readonly TestType t2 = new(1);

--- a/test/ProgressOnderwijsUtils.Tests/TreeTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/TreeTest.cs
@@ -198,6 +198,7 @@ public sealed class TreeTest
     {
         var input = Tree.Node(1u, Tree.Node(2u));
         var output = input.Rebuild(node => 2 * (long)node.NodeValue, (oldNode, value, newKids) => new[] { Tree.Node(value, newKids), Tree.Node(value + 1, newKids), }.Where(_ => oldNode.NodeValue != 1).ToArray());
+        // ReSharper disable once CollectionNeverUpdated.Local
         var expected = Array.Empty<Tree<long>>();
         PAssert.That(() => output.SequenceEqual(expected));
     }

--- a/test/ProgressOnderwijsUtils.Tests/UtilsTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/UtilsTest.cs
@@ -117,6 +117,16 @@ public sealed class UtilsTest
     }
 
     [Fact]
+    public void ComparisonComparer_supports_ordering_by_the_comparison()
+    {
+        var arr = new[] { (1, 200), (3, 7), (1, 2), (9, 3) };
+        Array.Sort(arr, new ComparisonComparer<(int, int)>((a, b) => Math.Abs(a.Item1 - a.Item2).CompareTo(Math.Abs(b.Item1 - b.Item2))));
+
+        var expected = new[] { (1, 2), (3, 7), (9, 3), (1, 200), };
+        PAssert.That(() => arr.SequenceEqual(expected));
+    }
+
+    [Fact]
     public void IsDbConnFailureTest()
     {
         PAssert.That(() => !new Exception().IsRetriableConnectionFailure());

--- a/tools/ProgressOnderwijsUtilsBenchmarks/BenchmarkProgram.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/BenchmarkProgram.cs
@@ -1,5 +1,4 @@
 using BenchmarkDotNet.Running;
-using ProgressOnderwijsUtilsBenchmarks.NullabilityVerifierBenchmark;
 
 namespace ProgressOnderwijsUtilsBenchmarks;
 

--- a/tools/ProgressOnderwijsUtilsBenchmarks/HtmlFragmentBenchmark.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/HtmlFragmentBenchmark.cs
@@ -1,7 +1,4 @@
 using System.IO.Pipelines;
-using AngleSharp;
-using AngleSharp.Html.Dom;
-using AngleSharp.Html.Parser;
 using ProgressOnderwijsUtils.Tests;
 
 namespace ProgressOnderwijsUtilsBenchmarks;

--- a/tools/ProgressOnderwijsUtilsBenchmarks/RandomHelperBenchmark.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/RandomHelperBenchmark.cs
@@ -1,9 +1,3 @@
-using System.IO.Pipelines;
-using AngleSharp;
-using AngleSharp.Html.Dom;
-using AngleSharp.Html.Parser;
-using ProgressOnderwijsUtils.Tests;
-
 namespace ProgressOnderwijsUtilsBenchmarks;
 
 [MedianColumn]


### PR DESCRIPTION
 - also, when applying R# suggestions about collection expressions it became apparent that those aren't supported StructuralEqualityComparer, hence the introduction of `TvpEqualityToken`
 - Actual initial motivation: mark ParameterizedSql as readonly, so that a noisy warning in progress is silenced (https://github.com/progressonderwijs/progress/pull/64060#discussion_r1820201783)
 - https://github.com/progressonderwijs/progress/issues/63558