### PR TITLE
Apply code-cleanups (mostly replace verbatim strings)

### DIFF
--- a/src/ProgressOnderwijsUtils.AspNetCore/ModelStateFilter.cs
+++ b/src/ProgressOnderwijsUtils.AspNetCore/ModelStateFilter.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc;
 
 namespace ProgressOnderwijsUtils.AspNetCore;
+
 public sealed class ModelStateFilter : IActionFilter
 {
     public void OnActionExecuted(ActionExecutedContext context) { }

--- a/src/ProgressOnderwijsUtils/Collections/CachedTreeBuilder.cs
+++ b/src/ProgressOnderwijsUtils/Collections/CachedTreeBuilder.cs
@@ -60,4 +60,3 @@ static class TreeBuilder<TInput, TOutput>
         }
     }
 }
-

--- a/src/ProgressOnderwijsUtils/Data/CascadedDelete.cs
+++ b/src/ProgressOnderwijsUtils/Data/CascadedDelete.cs
@@ -24,10 +24,10 @@ public static class CascadedDelete
             foreignKeyPredicate,
             new[] { pkColumn, },
             SQL(
-                $@"
+                $"""
                 select {pkColumnSql} = q.QueryTableValue 
                 from {pksToDelete} q
-            "
+                """
             )
         );
     }
@@ -112,23 +112,20 @@ public static class CascadedDelete
         pkColumnsMetaData.CreateNewTableQuery(delTable).ExecuteNonQuery(conn);
 
         var idsToDelete = SQL(
-            $@"
-                insert into {delTable} ({initialKeyColumns.ConcatenateSql(SQL($", "))})
-                {pksTVParameter};
-
-                select count(*) from {delTable};
-            "
+            $"""
+            insert into {delTable} ({initialKeyColumns.ConcatenateSql(SQL($", "))}) {pksTVParameter};
+            select count(*) from {delTable};
+            """
         ).ReadScalar<int>(conn);
 
         var initialRowCountToDelete = SQL(
-            $@"
-                delete dt
-                from {delTable} dt
-                left join {initialTableAsEntered.QualifiedNameSql} initT on {initialKeyColumns.Select(col => SQL($"dt.{col}=initT.{col}")).ConcatenateSql(SQL($" and "))}
-                where {initialKeyColumns.Select(col => SQL($"initT.{col} is null")).ConcatenateSql(SQL($" and "))}
-                ;
-                select count(*) from {delTable}
-            "
+            $"""
+            delete dt from {delTable} dt
+            left join {initialTableAsEntered.QualifiedNameSql} initT on {initialKeyColumns.Select(col => SQL($"dt.{col}=initT.{col}")).ConcatenateSql(SQL($" and "))}
+            where {initialKeyColumns.Select(col => SQL($"initT.{col} is null")).ConcatenateSql(SQL($" and "))}
+            ;
+            select count(*) from {delTable}
+            """
         ).ReadScalar<int>(conn);
 
         log($"Recursively deleting {initialRowCountToDelete} rows (of {idsToDelete} ids) from {initialTableAsEntered.QualifiedName})");
@@ -176,12 +173,12 @@ public static class CascadedDelete
 
                     ParameterizedSql DeletionQuery(ParameterizedSql outputClause)
                         => SQL(
-                            $@"
-                                delete pk
-                                {outputClause}
-                                from {table.QualifiedNameSql} pk
-                                join {tempTableName} tt on {ttPkJoin};
-                            "
+                            $"""
+                            delete pk
+                            {outputClause}
+                            from {table.QualifiedNameSql} pk
+                            join {tempTableName} tt on {ttPkJoin};
+                            """
                         );
 
                     DataTable? DeletionExecution()

--- a/src/ProgressOnderwijsUtils/Data/CascadedDelete.cs
+++ b/src/ProgressOnderwijsUtils/Data/CascadedDelete.cs
@@ -53,26 +53,10 @@ public static class CascadedDelete
             PocoUtils.GetProperties<TId>().ArraySelect((pocoProperty, index) => new ColumnDefinition(pocoProperty.DataType, pocoProperty.Name, index, ColumnAccessibility.Normal))
         );
         pksToDelete.BulkCopyToSqlServer(conn, target);
-        var report = RecursivelyDelete(
-            conn,
-            initialTableAsEntered,
-            outputAllDeletedRows,
-            logger,
-            foreignKeyPredicate,
-            pkColumns,
-            SQL(
-                $@"
-                select {pkColumnsSql.ConcatenateSql(SQL($", "))}
-                from {pksTable}
-            "
-            )
-        );
+        var pksTvParameter = SQL($"select {pkColumnsSql.ConcatenateSql(SQL($", "))} from {pksTable}");
+        var report = RecursivelyDelete(conn, initialTableAsEntered, outputAllDeletedRows, logger, foreignKeyPredicate, pkColumns, pksTvParameter);
 
-        SQL(
-            $@"
-                drop table {pksTable}
-            "
-        ).ExecuteNonQuery(conn);
+        SQL($"drop table {pksTable}").ExecuteNonQuery(conn);
 
         return report;
     }
@@ -93,26 +77,10 @@ public static class CascadedDelete
         pkColumnsMetaData.CreateNewTableQuery(pksTable).ExecuteNonQuery(conn);
         BulkInsertTarget.FromCompleteSetOfColumns(pksTable.CommandText(), pkColumnsMetaData).BulkInsert(conn, pksToDelete);
 
-        var report = RecursivelyDelete(
-            conn,
-            initialTableAsEntered,
-            outputAllDeletedRows,
-            logger,
-            foreignKeyPredicate,
-            pkColumns,
-            SQL(
-                $@"
-                select {pkColumnsSql.ConcatenateSql(SQL($", "))}
-                from {pksTable}
-            "
-            )
-        );
+        var pksTvParameter = SQL($"select {pkColumnsSql.ConcatenateSql(SQL($", "))} from {pksTable}");
+        var report = RecursivelyDelete(conn, initialTableAsEntered, outputAllDeletedRows, logger, foreignKeyPredicate, pkColumns, pksTvParameter);
 
-        SQL(
-            $@"
-                drop table {pksTable}
-            "
-        ).ExecuteNonQuery(conn);
+        SQL($"drop table {pksTable}").ExecuteNonQuery(conn);
 
         return report;
     }
@@ -227,14 +195,13 @@ public static class CascadedDelete
                             return DeletionQuery(SQL($"output deleted.*")).OfDataTable().Execute(conn);
                         }
 
+                        var outputColumnsSpecification = table.Columns.Select(col => col.AsStaticRowVersion().ToSqlColumnDefinitionSql()).ConcatenateSql(SQL($", "));
                         return SQL(
-                            $@"
-                                declare @output_deleted table(
-                                    {table.Columns.Select(col => col.AsStaticRowVersion().ToSqlColumnDefinitionSql()).ConcatenateSql(SQL($", "))}
-                                );
-                                {DeletionQuery(SQL($"output deleted.* into @output_deleted"))}
-                                select * from @output_deleted;
-                            "
+                            $"""
+                            declare @output_deleted table({outputColumnsSpecification});
+                            {DeletionQuery(SQL($"output deleted.* into @output_deleted"))}
+                            select * from @output_deleted;
+                            """
                         ).OfDataTable().Execute(conn);
                     }
 

--- a/src/ProgressOnderwijsUtils/Data/ColumnDefinition.cs
+++ b/src/ProgressOnderwijsUtils/Data/ColumnDefinition.cs
@@ -4,9 +4,7 @@ namespace ProgressOnderwijsUtils;
 
 public enum ColumnAccessibility
 {
-    Normal,
-    AutoIncrementIdentity,
-    Readonly,
+    Normal, AutoIncrementIdentity, Readonly,
 }
 
 public sealed record ColumnDefinition(Type DataType, string Name, int Index, ColumnAccessibility ColumnAccessibility)

--- a/src/ProgressOnderwijsUtils/Data/ParameterizedSql.cs
+++ b/src/ProgressOnderwijsUtils/Data/ParameterizedSql.cs
@@ -100,6 +100,7 @@ public readonly struct ParameterizedSql : IEquatable<ParameterizedSql>
         AssertIsIdentifier(rawSqlString, 0);
         return new StringSqlFragment(rawSqlString).BuildableToQuery();
     }
+
     /// <summary>
     /// raw sql string, throws exception if the identifier does not follow https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers rules.
     /// </summary>
@@ -162,8 +163,6 @@ public readonly struct ParameterizedSql : IEquatable<ParameterizedSql>
 
     static void ThrowInvalidIdentifierChar(string rawSqlString, int index)
         => throw new($"Invalid SQL identifier @ index {index} ({rawSqlString[index]}): {rawSqlString}");
-
-
 
     public static ParameterizedSql EscapedSqlObjectName(string objectName)
         => RawSql_PotentialForSqlInjection("[" + objectName.Replace("]", "]]") + "]");

--- a/src/ProgressOnderwijsUtils/Data/SqlParameterComponent.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlParameterComponent.cs
@@ -130,18 +130,21 @@ static class SqlParameterComponent
 
         public static ParameterizedSql DefinitionScripts
             => SQL(
-                $@"
-                    begin tran;
-                    {All
-                        .Select(o => SQL($@"
-                            drop type if exists {ParameterizedSql.RawSql_PotentialForSqlInjection(o.SqlTypeName)};
-                            create type {ParameterizedSql.RawSql_PotentialForSqlInjection(o.SqlTypeName)}
-                            as table ({ParameterizedSql.RawSql_PotentialForSqlInjection(o.TableDeclaration)});
-                        "))
-                        .ConcatenateSql()}
-                    commit;
-                "
+                $"""
+                begin tran;
+                {All.Select(o => o.TypeDefinitionScript()).ConcatenateSql()}
+                commit;
+
+                """
             );
+
+        ParameterizedSql TypeDefinitionScript()
+            => SQL($"""
+                drop type if exists {ParameterizedSql.RawSql_PotentialForSqlInjection(SqlTypeName)};
+                create type {ParameterizedSql.RawSql_PotentialForSqlInjection(SqlTypeName)}
+                as table ({ParameterizedSql.RawSql_PotentialForSqlInjection(TableDeclaration)});
+
+                """);
     }
 
     interface ITableValuedParameterFactory

--- a/src/ProgressOnderwijsUtils/Data/SqlServerUtils.cs
+++ b/src/ProgressOnderwijsUtils/Data/SqlServerUtils.cs
@@ -9,19 +9,19 @@ public static class SqlServerUtils
     {
         try {
             SQL(
-                $@"
-                    declare @query as nvarchar(max) = isnull((
-                            select string_agg(N'kill ' + cast(s.session_id as nvarchar(max)) + N'; ', nchar(10))
-                            from sys.dm_exec_sessions s
-                            where 1=1
-                                and s.database_id  = db_id({catalog})
-                                and s.security_id <> 1
-                                and s.session_id <> @@spid
-                                and s.status in ('running', 'sleeping')
-                        ),'');
+                $"""
+                declare @query as nvarchar(max) = isnull((
+                    select string_agg(N'kill ' + cast(s.session_id as nvarchar(max)) + N'; ', nchar(10))
+                    from sys.dm_exec_sessions s
+                    where 1=1
+                        and s.database_id  = db_id({catalog})
+                        and s.security_id <> 1
+                        and s.session_id <> @@spid
+                        and s.status in ('running', 'sleeping')
+                ),'');
 
-                    exec(@query);
-                "
+                exec(@query);
+                """
             ).ExecuteNonQuery(sqlContext);
         } catch (Exception e) when (IsSpidAlreadyDeadException(e)) {
             //the spid may already be dead by the time we get around to killing it, which throws an error.  We ignore that error.

--- a/src/ProgressOnderwijsUtils/Data/TableValuedParameterWrapper.cs
+++ b/src/ProgressOnderwijsUtils/Data/TableValuedParameterWrapper.cs
@@ -15,7 +15,6 @@ readonly struct TableValuedParameterWrapper<T> : IWrittenImplicitly, IOptionalOb
         => QueryTableValue;
 }
 
-
 static class TableValuedParameterWrapperHelper
 {
     /// <summary>

--- a/src/ProgressOnderwijsUtils/GitExe.cs
+++ b/src/ProgressOnderwijsUtils/GitExe.cs
@@ -54,8 +54,8 @@ public sealed class GitExe
     }
 
     public async Task<bool> IsUpToDateWithOriginBranch(string sourceBranch)
-        => await Git_MayFail($@"fetch origin +refs/heads/{sourceBranch}:refs/remotes/origin/{sourceBranch} ").ExitCode == 0
-            && await Git_MayFail($@"merge-base --is-ancestor origin/{sourceBranch} HEAD").ExitCode == 0;
+        => await Git_MayFail($"fetch origin +refs/heads/{sourceBranch}:refs/remotes/origin/{sourceBranch} ").ExitCode == 0
+            && await Git_MayFail($"merge-base --is-ancestor origin/{sourceBranch} HEAD").ExitCode == 0;
 
     public bool IsRefMergeable_AndResetWorkingCopy(string gitRef)
     {

--- a/src/ProgressOnderwijsUtils/Html/HtmlDirectory.cs
+++ b/src/ProgressOnderwijsUtils/Html/HtmlDirectory.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 namespace ProgressOnderwijsUtils.Html;
+
 sealed class HtmlDirectory
 {
     public static readonly SourceLocation HtmlDir = SourceLocation.Here();

--- a/src/ProgressOnderwijsUtils/Pocos/NonNullableFieldVerifier.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/NonNullableFieldVerifier.cs
@@ -41,19 +41,19 @@ public static class NonNullableFieldVerifier
             var storeNullabilityErrorCountInVariable = Expression.Block(ForEachInvalidNull(_ => incrementErrorCounter));
 
             var whenNullabilityErrorDetected = Expression.Block(
-                    new[] { exceptionVar, },
-                    Expression.Assign(exceptionVar, Expression.NewArrayBounds(typeof(string), errorCounterVar)),
-                    Expression.Assign(errorCounterVar, Expression.Constant(0, typeof(int))),
-                    Expression.Block(
-                        ForEachInvalidNull(
-                            field => Expression.Block(
-                                Expression.Assign(Expression.ArrayAccess(exceptionVar, errorCounterVar), Expression.Constant(ErrorMessageForField(field))),
-                                incrementErrorCounter
-                            )
+                new[] { exceptionVar, },
+                Expression.Assign(exceptionVar, Expression.NewArrayBounds(typeof(string), errorCounterVar)),
+                Expression.Assign(errorCounterVar, Expression.Constant(0, typeof(int))),
+                Expression.Block(
+                    ForEachInvalidNull(
+                        field => Expression.Block(
+                            Expression.Assign(Expression.ArrayAccess(exceptionVar, errorCounterVar), Expression.Constant(ErrorMessageForField(field))),
+                            incrementErrorCounter
                         )
-                    ),
-                    exceptionVar
-                );
+                    )
+                ),
+                exceptionVar
+            );
 
             var computeErrorMessageGivenCount = Expression.Condition(
                 Expression.Equal(errorCounterVar, Expression.Constant(0, typeof(int))),

--- a/src/ProgressOnderwijsUtils/Pocos/SmallBatchInsertImplementation.cs
+++ b/src/ProgressOnderwijsUtils/Pocos/SmallBatchInsertImplementation.cs
@@ -41,12 +41,10 @@ public static class SmallBatchInsertImplementation
                     return fieldVal == null && !target.Options.HasFlag(SqlBulkCopyOptions.KeepNulls) ? SQL($"default") : ParameterizedSql.Param(fieldVal);
                 }
             );
-            SQL(
-                $@"
-                    insert into {ParameterizedSql.RawSql_PotentialForSqlInjection(target.TableName)} ({destinationColumns.ConcatenateSql(SQL($","))})
-                    values ({sourceValues.ConcatenateSql(SQL($", "))});
-                "
-            ).OfNonQuery().WithTimeout(timeout).Execute(sqlConn);
+            var tableSql = ParameterizedSql.RawSql_PotentialForSqlInjection(target.TableName);
+            var columnSpec = destinationColumns.ConcatenateSql(SQL($","));
+            var valuesSpec = sourceValues.ConcatenateSql(SQL($", "));
+            SQL($"insert into {tableSql} ({columnSpec}) values ({valuesSpec});").OfNonQuery().WithTimeout(timeout).Execute(sqlConn);
         }
     }
 

--- a/src/ProgressOnderwijsUtils/ProcessRunner.cs
+++ b/src/ProgressOnderwijsUtils/ProcessRunner.cs
@@ -157,8 +157,7 @@ public sealed class AsyncProcessResult
     {
         var prefixWithSpace = $"{prefix} ";
         var culture = CultureInfo.InvariantCulture;
-        _ = Output.Subscribe(
-            outputStreamEvent => Console.WriteLine(prefixWithSpace + Utils.ToFixedPointString(outputStreamEvent.OutputMoment.TotalSeconds, culture, 4) + (outputStreamEvent.Kind == ProcessOutputKind.StdOutput ? "> " : "! ") + outputStreamEvent.Line));
+        _ = Output.Subscribe(outputStreamEvent => Console.WriteLine(prefixWithSpace + Utils.ToFixedPointString(outputStreamEvent.OutputMoment.TotalSeconds, culture, 4) + (outputStreamEvent.Kind == ProcessOutputKind.StdOutput ? "> " : "! ") + outputStreamEvent.Line));
     }
 
     public Task<string[]> StdOutput()

--- a/src/ProgressOnderwijsUtils/ReflectionLoadableClassHelper.cs
+++ b/src/ProgressOnderwijsUtils/ReflectionLoadableClassHelper.cs
@@ -66,7 +66,7 @@ public static class ReflectionLoadableClassHelper
         }
         var factories = new List<Func<TBaseType>>();
         foreach (var constructor in constructors) {
-            var constructionExpression = Expression.Lambda<Func<TBaseType>>(Expression.New(constructor), Array.Empty<ParameterExpression>());
+            var constructionExpression = Expression.Lambda<Func<TBaseType>>(Expression.New(constructor));
             var constructorDelegate = constructionExpression.CompileFast(true);
             if (constructorDelegate == null) {
                 return Maybe.Error(new[] { $"Failed to create factory for {typeof(TBaseType).ToCSharpFriendlyTypeName()}", });

--- a/src/ProgressOnderwijsUtils/SchemaReflection/CheckConstraint.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/CheckConstraint.cs
@@ -4,16 +4,15 @@ public sealed record CheckConstraintSqlDefinition(DbObjectId TableObjectId, DbOb
 {
     public static CheckConstraintSqlDefinition[] LoadAll(SqlConnection conn)
         => SQL(
-            $@"
-                select 
-                    TableObjectId = cc.parent_object_id
-                    , CheckConstraintObjectId = cc.object_id
-                    , Name = cc.name
-                    , Definition = cc.definition
-                    , IsNotTrusted = cc.is_not_trusted
-                    , IsDisabled = cc.is_disabled
-
-                from sys.check_constraints cc
-            "
+            $"""
+            select 
+                TableObjectId = cc.parent_object_id
+                , CheckConstraintObjectId = cc.object_id
+                , Name = cc.name
+                , Definition = cc.definition
+                , IsNotTrusted = cc.is_not_trusted
+                , IsDisabled = cc.is_disabled
+            from sys.check_constraints cc
+            """
         ).ReadPocos<CheckConstraintSqlDefinition>(conn);
 }

--- a/src/ProgressOnderwijsUtils/SchemaReflection/ComputedColumnSqlDefinition.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/ComputedColumnSqlDefinition.cs
@@ -4,13 +4,13 @@ public sealed record ComputedColumnSqlDefinition(DbObjectId ObjectId, DbColumnId
 {
     public static ComputedColumnSqlDefinition[] LoadAll(SqlConnection conn)
         => SQL(
-            $@"
-                    select 
-                        ObjectId = c.object_id
-                        , ColumnId = c.column_id
-                        , c.Definition
-                        , IsPersisted = c.is_persisted
-                    from sys.computed_columns c
-                "
+            $"""
+            select 
+                ObjectId = c.object_id
+                , ColumnId = c.column_id
+                , c.Definition
+                , IsPersisted = c.is_persisted
+            from sys.computed_columns c
+            """
         ).ReadPocos<ComputedColumnSqlDefinition>(conn);
 }

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -73,15 +73,15 @@ public sealed class DatabaseDescription
 
         public ParameterizedSql ScriptToAddConstraint()
             => SQL(
-                $@"
-                    alter table {ReferencingChildTable.QualifiedNameSql}
-                    add constraint {ParameterizedSql.RawSql_PotentialForSqlInjection(UnqualifiedName)}
-                        foreign key ({ParameterizedSql.RawSql_PotentialForSqlInjection(Columns.Select(fkc => fkc.ReferencingChildColumn.ColumnName).JoinStrings(", "))}) 
-                        references {ReferencedParentTable.QualifiedNameSql}
-                            ({ParameterizedSql.RawSql_PotentialForSqlInjection(Columns.Select(fkc => fkc.ReferencedParentColumn.ColumnName).JoinStrings(", "))})
-                        on delete {DeleteReferentialAction.AsSql()}
-                        on update {UpdateReferentialAction.AsSql()};
-                    "
+                $"""
+                alter table {ReferencingChildTable.QualifiedNameSql}
+                add constraint {ParameterizedSql.RawSql_PotentialForSqlInjection(UnqualifiedName)}
+                    foreign key ({ParameterizedSql.RawSql_PotentialForSqlInjection(Columns.Select(fkc => fkc.ReferencingChildColumn.ColumnName).JoinStrings(", "))}) 
+                    references {ReferencedParentTable.QualifiedNameSql}
+                        ({ParameterizedSql.RawSql_PotentialForSqlInjection(Columns.Select(fkc => fkc.ReferencedParentColumn.ColumnName).JoinStrings(", "))})
+                    on delete {DeleteReferentialAction.AsSql()}
+                    on update {UpdateReferentialAction.AsSql()};
+                """
             );
 
         public ParameterizedSql ScriptToDropConstraint()

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DatabaseDescription.cs
@@ -87,7 +87,8 @@ public sealed class DatabaseDescription
         public ParameterizedSql ScriptToDropConstraint()
             => SQL($"alter table {ReferencingChildTable.QualifiedNameSql} drop constraint {ParameterizedSql.RawSql_PotentialForSqlInjection(UnqualifiedName)};\n");
 
-        public override string ToString() => $"FK: {QualifiedName} from {ReferencingChildTable.QualifiedName} to {ReferencedParentTable.QualifiedName}";
+        public override string ToString()
+            => $"FK: {QualifiedName} from {ReferencingChildTable.QualifiedName} to {ReferencedParentTable.QualifiedName}";
     }
 
     public sealed class Index<TObject>

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
@@ -90,7 +90,6 @@ public sealed record DbColumnMetaData(
     public override string ToString()
         => ToStringByMembers.ToStringByPublicMembers(this);
 
-
     static readonly ParameterizedSql tempDb = SQL($"tempdb");
 
     public static DbColumnMetaData[] ColumnMetaDatas(SqlConnection conn, ParameterizedSql objectName)
@@ -103,7 +102,6 @@ public sealed record DbColumnMetaData(
 
     public static DbColumnMetaData[] LoadAll(SqlConnection conn)
         => RunQuery(conn, false, new());
-
 
     public static ParameterizedSql BaseQuery(bool fromTempDb)
         => SQL(

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DbColumnMetaData.cs
@@ -97,39 +97,40 @@ public sealed record DbColumnMetaData(
 
     public static DbColumnMetaData[] ColumnMetaDatas(SqlConnection conn, string qualifiedObjectName)
         => qualifiedObjectName.StartsWith("#", StringComparison.OrdinalIgnoreCase)
-            ? RunQuery(conn, true, SQL($@"and c.object_id = object_id({$"{tempDb.CommandText()}..{qualifiedObjectName}"})"))
-            : RunQuery(conn, false, SQL($@"and c.object_id = object_id({qualifiedObjectName})"));
+            ? RunQuery(conn, true, SQL($"and c.object_id = object_id({$"{tempDb.CommandText()}..{qualifiedObjectName}"})"))
+            : RunQuery(conn, false, SQL($"and c.object_id = object_id({qualifiedObjectName})"));
 
     public static DbColumnMetaData[] LoadAll(SqlConnection conn)
         => RunQuery(conn, false, new());
 
     public static ParameterizedSql BaseQuery(bool fromTempDb)
         => SQL(
-            $@"
-                with pks (object_id, column_id) as (
-                    select i.object_id, ic.column_id
-                    from sys.index_columns ic 
-                    join sys.indexes i on ic.object_id = i.object_id and ic.index_id = i.index_id and i.is_primary_key = 1
-                )
-                select
-                    ColumnName = c.name
-                    , DbObjectId = c.object_id
-                    , ColumnId = c.column_id
-                    , UserTypeId = c.user_type_id
-                    , MaxLength = c.max_length
-                    , c.Precision
-                    , c.Scale
-                    , ColumnFlags = convert(tinyint, 0
-                        + 1*c.is_nullable 
-                        + 2*c.is_computed
-                        + 4*iif(pk.column_id is not null, convert(bit, 1), convert(bit, 0))
-                        + 8*c.is_identity
-                        )
-                    , CollationName = c.collation_name
-                from {fromTempDb && SQL($"tempdb.")}sys.columns c
-                left join pks pk on pk.object_id = c.object_id and pk.column_id = c.column_id
-                where 1=1
-            "
+            $"""
+            with pks (object_id, column_id) as (
+                select i.object_id, ic.column_id
+                from sys.index_columns ic 
+                join sys.indexes i on ic.object_id = i.object_id and ic.index_id = i.index_id and i.is_primary_key = 1
+            )
+            select
+                ColumnName = c.name
+                , DbObjectId = c.object_id
+                , ColumnId = c.column_id
+                , UserTypeId = c.user_type_id
+                , MaxLength = c.max_length
+                , c.Precision
+                , c.Scale
+                , ColumnFlags = convert(tinyint, 0
+                    + 1*c.is_nullable 
+                    + 2*c.is_computed
+                    + 4*iif(pk.column_id is not null, convert(bit, 1), convert(bit, 0))
+                    + 8*c.is_identity
+                    )
+                , CollationName = c.collation_name
+            from {fromTempDb && SQL($"tempdb.")}sys.columns c
+            left join pks pk on pk.object_id = c.object_id and pk.column_id = c.column_id
+            where 1=1
+
+            """
         );
 
     static DbColumnMetaData[] RunQuery(SqlConnection conn, bool fromTempDb, ParameterizedSql filter)

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DbNamedObjectId.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DbNamedObjectId.cs
@@ -16,14 +16,14 @@ public struct DbNamedObjectId : IWrittenImplicitly, IDbNamedObject
 
     public static DbNamedObjectId[] LoadAllObjectsOfType(SqlConnection conn, string type)
         => SQL(
-            $@"
-                    select
-                        ObjectId = o.object_id
-                        , QualifiedName = schema_name(o.schema_id) + '.' + o.name
-                    from sys.objects o
-                    where 1=1
-                        and o.type = {type}
-                        and o.is_ms_shipped = {false} -- to filter out the dbo.dtproperties system table
-                "
+            $"""
+            select
+                ObjectId = o.object_id
+                , QualifiedName = schema_name(o.schema_id) + '.' + o.name
+            from sys.objects o
+            where 1=1
+                and o.type = {type}
+                and o.is_ms_shipped = {false} -- to filter out the dbo.dtproperties system table
+            """
         ).ReadPocos<DbNamedObjectId>(conn);
 }

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DefaultValueConstraintSqlDefinition.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DefaultValueConstraintSqlDefinition.cs
@@ -4,13 +4,13 @@ public sealed record DefaultValueConstraintSqlDefinition(DbObjectId ParentObject
 {
     public static DefaultValueConstraintSqlDefinition[] LoadAll(SqlConnection conn)
         => SQL(
-            $@"
-                    select
-                        ParentObjectId = d.parent_object_id
-                        , ParentColumnId = d.parent_column_id
-                        , d.name
-                        , d.definition
-                    from sys.default_constraints d
-                "
+            $"""
+            select
+                ParentObjectId = d.parent_object_id
+                , ParentColumnId = d.parent_column_id
+                , d.name
+                , d.definition
+            from sys.default_constraints d
+            """
         ).ReadPocos<DefaultValueConstraintSqlDefinition>(conn);
 }

--- a/src/ProgressOnderwijsUtils/SchemaReflection/DmlTableTrigger.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/DmlTableTrigger.cs
@@ -10,16 +10,16 @@ public sealed record TriggerSqlDefinition(DbObjectId ObjectId, string Name, DbOb
 
     static TriggerSqlDefinition[] LoadAll(SqlConnection conn, int parentClass)
         => SQL(
-            $@"
-                    select
-                        ObjectId = tr.object_id
-                        , tr.name
-                        , TableObjectId = t.object_id
-                        , Definition = OBJECT_DEFINITION(tr.object_id)
-                    from sys.triggers tr
-                    left join sys.tables t on t.object_id = tr.parent_id
-                    where 1=1
-                        and tr.parent_class = {parentClass}
-                "
+            $"""
+            select
+                ObjectId = tr.object_id
+                , tr.name
+                , TableObjectId = t.object_id
+                , Definition = OBJECT_DEFINITION(tr.object_id)
+            from sys.triggers tr
+            left join sys.tables t on t.object_id = tr.parent_id
+            where 1=1
+                and tr.parent_class = {parentClass}
+            """
         ).ReadPocos<TriggerSqlDefinition>(conn);
 }

--- a/src/ProgressOnderwijsUtils/SchemaReflection/ForeignKeyLookup.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/ForeignKeyLookup.cs
@@ -45,7 +45,7 @@ struct ForeignKeyColumnEntry : IWrittenImplicitly
     public static ForeignKeySqlDefinition[] LoadAll(SqlConnection conn)
     {
         var foreignKeys = SQL(
-                $@"
+                $"""
                 select 
                     ForeignKeyObjectId = fk.object_id
                     , DeleteReferentialAction = fk.delete_referential_action
@@ -60,7 +60,7 @@ struct ForeignKeyColumnEntry : IWrittenImplicitly
                 order by 
                     fk.object_id
                     , fkc.constraint_column_id
-            "
+                """
             ).ReadPocos<ForeignKeyColumnEntry>(conn)
             .GroupBy(fkCol => fkCol.ForeignKeyObjectId)
             .Select(

--- a/src/ProgressOnderwijsUtils/SchemaReflection/SequenceSqlDefinition.cs
+++ b/src/ProgressOnderwijsUtils/SchemaReflection/SequenceSqlDefinition.cs
@@ -46,17 +46,17 @@ public sealed record SequenceSqlDefinition(
 
     public static SequenceSqlDefinition[] LoadAll(SqlConnection conn)
         => SQL(
-            $@"
-                    select
-                        QualifiedName = object_schema_name(s.object_id) + '.' + object_name(s.object_id)
-                        , Type = cast(s.system_type_id as int)
-                        , IsCycling = s.is_cycling
-                        , IsCached = s.is_cached
-                        , CacheSize = s.cache_size
-                        , Increment = cast(s.increment as bigint)
-                        , MinimumValue = cast(s.minimum_value as bigint)
-                        , MaximumValue = cast(s.maximum_value as bigint)
-                    from sys.sequences s
-                "
+            $"""
+            select
+                QualifiedName = object_schema_name(s.object_id) + '.' + object_name(s.object_id)
+                , Type = cast(s.system_type_id as int)
+                , IsCycling = s.is_cycling
+                , IsCached = s.is_cached
+                , CacheSize = s.cache_size
+                , Increment = cast(s.increment as bigint)
+                , MinimumValue = cast(s.minimum_value as bigint)
+                , MaximumValue = cast(s.maximum_value as bigint)
+            from sys.sequences s
+            """
         ).ReadPocos<SequenceSqlDefinition>(conn);
 }

--- a/test/ProgressOnderwijsUtils.Tests/Collections/SelectIndexableTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Collections/SelectIndexableTest.cs
@@ -38,9 +38,6 @@ public sealed class SelectIndexableTest
         PAssert.That(() => mapped.SequenceEqual(new[] { 2, 3, 4 }));
     }
 
-
-
-
     static Func<A, X> CountCalls<A, X>(Func<A, X> func, out Func<int> callCount)
     {
         var callCounter = 0;

--- a/test/ProgressOnderwijsUtils.Tests/Data/AsSqlInExpressionTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/AsSqlInExpressionTest.cs
@@ -27,10 +27,10 @@ public sealed class AsSqlInExpressionTest : TransactedLocalConnection
     public void In_helper_works_on_actual_query()
     {
         SQL(
-            $@"
-                create table Tin (x int not null, y int null);
-                insert into Tin (x, y) values (3, 7), (11, null);
-            "
+            $"""
+            create table Tin (x int not null, y int null);
+            insert into Tin (x, y) values (3, 7), (11, null);
+            """
         ).ExecuteNonQuery(Connection);
 
         var xQueriedInEmpty = SQL($"select t.x from Tin t where t.x in {Array.Empty<int>().AsUnrolledSqlInExpression()}").ReadPlain<int?>(Connection);

--- a/test/ProgressOnderwijsUtils.Tests/Data/BulkInsertTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/BulkInsertTest.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace ProgressOnderwijsUtils.Tests.Data;
 
 public sealed record BulkInsertTestSampleRow : IWrittenImplicitly, IReadImplicitly
@@ -233,6 +235,7 @@ public sealed class BulkInsertTest : TransactedLocalConnection
         CheckPostConditions(Enumerable.Range(1, 4).ToArray(), 5); //there's a special case for collections such as IReadOnlyList
         CheckPostConditions(Enumerable.Range(1, 4).ToArray(), 2);
 
+        [SuppressMessage("ReSharper", "PossibleMultipleEnumeration")]
         void CheckPostConditions(IEnumerable<int> enumerable, int count)
         {
             var output = SmallBatchInsertImplementation.PeekAtPrefix(enumerable, count);

--- a/test/ProgressOnderwijsUtils.Tests/Data/BulkInsertTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/BulkInsertTest.cs
@@ -15,17 +15,17 @@ public sealed record BulkInsertTestSampleRow : IWrittenImplicitly, IReadImplicit
     public static BulkInsertTarget CreateTable(SqlConnection sqlConnection, ParameterizedSql tempTableName)
     {
         SQL(
-            $@"
-                create table {tempTableName} (
-                    AnEnum int not null
-                    , ADateTime datetime2
-                    , SomeString nvarchar(max)
-                    , LotsOfMoney decimal(19, 5)
-                    , VagueNumber float not null
-                    , CustomBla nvarchar(max) not null
-                    , CustomBlaThanCanBeNull nvarchar(max) null
-                )
-            "
+            $"""
+            create table {tempTableName} (
+                AnEnum int not null
+                , ADateTime datetime2
+                , SomeString nvarchar(max)
+                , LotsOfMoney decimal(19, 5)
+                , VagueNumber float not null
+                , CustomBla nvarchar(max) not null
+                , CustomBlaThanCanBeNull nvarchar(max) null
+            )
+            """
         ).ExecuteNonQuery(sqlConnection);
 
         return BulkInsertTarget.LoadFromTable(sqlConnection, tempTableName.CommandText());
@@ -153,13 +153,13 @@ public sealed class BulkInsertTest : TransactedLocalConnection
         using var conn2 = new SqlConnection(ConnectionString);
         conn2.Open();
         var query = SQL(
-            $@"
-                    select *
-                    from (
-                        values (1, null, 'test', 'test2')
-                        , (2, 1, null, 'test3')
-                    ) x(intNonNull, intNull, stringNull, stringNonNull)
-                "
+            $"""
+            select *
+            from (
+                values (1, null, 'test', 'test2')
+                , (2, 1, null, 'test3')
+            ) x(intNonNull, intNull, stringNull, stringNonNull)
+            """
         ).OfPocos<SampleRow2>();
         var expectedData = new[] {
             new SampleRow2 { intNonNull = 1, intNull = null, stringNull = "test", stringNonNull = "test2", },
@@ -168,14 +168,14 @@ public sealed class BulkInsertTest : TransactedLocalConnection
         AssertCollectionsEquivalent(expectedData, query.Execute(conn2)); //sanity check that we're testing consistent data
 
         SQL(
-            $@"
-                    create table #tmp (
-                        intNonNull int not null
-                        , intNull int null
-                        , stringNull nvarchar(max) null
-                        , stringNonNull nvarchar(max) not null
-                    )
-                "
+            $"""
+            create table #tmp (
+                intNonNull int not null
+                , intNull int null
+                , stringNull nvarchar(max) null
+                , stringNonNull nvarchar(max) not null
+            )
+            """
         ).ExecuteNonQuery(Connection);
         var target = BulkInsertTarget.LoadFromTable(Connection, "#tmp");
 
@@ -201,14 +201,14 @@ public sealed class BulkInsertTest : TransactedLocalConnection
     public void BulkInsertSmallBatchesRespectsKeepNul()
     {
         SQL(
-            $@"
-                    create table #tmp (
-                        intNonNull int not null
-                        , intNull int null default 37 
-                        , stringNull nvarchar(max) null
-                        , stringNonNull nvarchar(max) not null
-                    )
-                "
+            $"""
+            create table #tmp (
+                intNonNull int not null
+                , intNull int null default 37 
+                , stringNull nvarchar(max) null
+                , stringNonNull nvarchar(max) not null
+            )
+            """
         ).ExecuteNonQuery(Connection);
         var target = BulkInsertTarget.LoadFromTable(Connection, "#tmp");
         new[] { new SampleRow2 { intNonNull = 1, intNull = null, stringNull = "test", stringNonNull = "test", }, }

--- a/test/ProgressOnderwijsUtils.Tests/Data/CascadedDeleteTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/CascadedDeleteTest.cs
@@ -8,13 +8,13 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
     public void CascadedDeleteFollowsAForeignKey()
     {
         SQL(
-            $@"
-                create table T1 ( A int primary key, B int);
-                create table T2 ( C int primary key, A int references T1 (A) );
+            $"""
+            create table T1 ( A int primary key, B int);
+            create table T2 ( C int primary key, A int references T1 (A) );
 
-                insert into T1 values (1,11), (2,22), (3, 33);
-                insert into T2 values (111,1), (333,3);
-            "
+            insert into T1 values (1,11), (2,22), (3, 33);
+            insert into T2 values (111,1), (333,3);
+            """
         ).ExecuteNonQuery(Connection);
 
         var initialDependentValues = SQL($"select C from T2").ReadPlain<int>(Connection);
@@ -33,13 +33,13 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
     public void CascadedDeleteFollowsAUniqueConstraintBasedForeignKey()
     {
         SQL(
-            $@"
-                create table T1 ( A int not null unique, B int);
-                create table T2 ( C int not null, A int references T1 (A) );
+            $"""
+            create table T1 ( A int not null unique, B int);
+            create table T2 ( C int not null, A int references T1 (A) );
 
-                insert into T1 values (1,11), (2,22), (3, 33);
-                insert into T2 values (111,1), (333,3);
-            "
+            insert into T1 values (1,11), (2,22), (3, 33);
+            insert into T2 values (111,1), (333,3);
+            """
         ).ExecuteNonQuery(Connection);
 
         var initialDependentValues = SQL($"select C from T2").ReadPlain<int>(Connection);
@@ -58,18 +58,17 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
     public void CascadedDeleteDetectsCycles()
     {
         SQL(
-            $@"
-                create table T1 ( A int not null unique, B int);
-                create table T2 ( B int not null unique, A int references T1 (A) );
-                alter table T1 add constraint T1FK foreign key (B) references T2(B);
+            $"""
+            create table T1 ( A int not null unique, B int);
+            create table T2 ( B int not null unique, A int references T1 (A) );
+            alter table T1 add constraint T1FK foreign key (B) references T2(B);
 
-                insert into T1 values (1,null), (2,null), (3, null);
-                insert into T2 values (111,1), (333,3);
-                
-                update T1 set B = 111 where A = 1;
-                update T1 set B = 333 where A = 3;
+            insert into T1 values (1,null), (2,null), (3, null);
+            insert into T2 values (111,1), (333,3);
 
-            "
+            update T1 set B = 111 where A = 1;
+            update T1 set B = 333 where A = 3;
+            """
         ).ExecuteNonQuery(Connection);
 
         var initialDependentValues = SQL($"select B from T2").ReadPlain<int>(Connection);
@@ -95,11 +94,11 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         }
 
         SQL(
-            $@"
-                create table T1 ( A int primary key identity(1,1), B int);
+            $"""
+            create table T1 ( A int primary key identity(1,1), B int);
 
-                insert into T1 values (11), (22), (33);
-            "
+            insert into T1 values (11), (22), (33);
+            """
         ).ExecuteNonQuery(Connection);
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
@@ -119,22 +118,22 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
     public void CascadedDeleteFollowsADiamondOfForeignKey()
     {
         SQL(
-            $@"
-                create table TRoot ( root int primary key, B int);
-                create table T1 ( C int primary key, root int references TRoot (root));
-                create table T2 ( D int primary key, root int references TRoot (root));
-                create table TLeaf ( Z int primary key, C int references T1 (C), D int references T2 (D) );
-            "
+            $"""
+            create table TRoot ( root int primary key, B int);
+            create table T1 ( C int primary key, root int references TRoot (root));
+            create table T2 ( D int primary key, root int references TRoot (root));
+            create table TLeaf ( Z int primary key, C int references T1 (C), D int references T2 (D) );
+            """
         ).ExecuteNonQuery(Connection);
 
         SQL(
-            $@"
-                insert into TRoot values (1,11), (2,22), (3, 33);
-                insert into T1 values (4,1), (5, 2);
-                insert into T2 values (4,2), (5, 3);
+            $"""
+            insert into TRoot values (1,11), (2,22), (3, 33);
+            insert into T1 values (4,1), (5, 2);
+            insert into T2 values (4,2), (5, 3);
 
-                insert into TLeaf values (1, 4, null), (2, null, 4), (3, null, 5), (4, null, null);
-            "
+            insert into TLeaf values (1, 4, null), (2, null, 4), (3, null, 5), (4, null, null);
+            """
         ).ExecuteNonQuery(Connection);
 
         var initialTLeafKeys = SQL($"select Z from TLeaf").ReadPlain<int>(Connection);
@@ -158,20 +157,20 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
     public void NonUniqueForeignKeyDoesNotLeadToExplosionOfDeletions()
     {
         SQL(
-            $@"
-                create table TRoot ( root int primary key, B int);
-                create table T1 ( C int primary key, root int references TRoot (root));
-                create table TLeaf ( Z int primary key, C int references T1 (C));
-            "
+            $"""
+            create table TRoot ( root int primary key, B int);
+            create table T1 ( C int primary key, root int references TRoot (root));
+            create table TLeaf ( Z int primary key, C int references T1 (C));
+            """
         ).ExecuteNonQuery(Connection);
 
         SQL(
-            $@"
-                insert into TRoot values (1, 11), (2, 22), (3, 33);
-                insert into T1 values (1,1), (2, 2), (3, 3), (11,1), (22,2), (33,3);
+            $"""
+            insert into TRoot values (1, 11), (2, 22), (3, 33);
+            insert into T1 values (1,1), (2, 2), (3, 3), (11,1), (22,2), (33,3);
 
-                insert into TLeaf values (1, 1);
-            "
+            insert into TLeaf values (1, 1);
+            """
         ).ExecuteNonQuery(Connection);
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
@@ -189,15 +188,15 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
     public void CascadeDeleteBreaksOnSpecificTable()
     {
         SQL(
-            $@"
-                create table T1 (A int primary key);
-                create table T2 (B int primary key, A int references T1 (A) on delete set null);
-                create table T3 (C int primary key, A int references T1 (A));
+            $"""
+            create table T1 (A int primary key);
+            create table T2 (B int primary key, A int references T1 (A) on delete set null);
+            create table T3 (C int primary key, A int references T1 (A));
 
-                insert into T1 values (1);
-                insert into T2 values (2, 1);
-                insert into T3 values (3, 1);
-            "
+            insert into T1 values (1);
+            insert into T2 values (2, 1);
+            insert into T3 values (3, 1);
+            """
         ).ExecuteNonQuery(Connection);
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
@@ -290,15 +289,15 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
     public void CascadeDeleteAllowsSameTableCyclesWhenThoseAreSimultaneouslyDeletable()
     {
         SQL(
-            $@"
-                create table T1 (A int primary key);
-                create table T2 (B int primary key, A int references T1, C int references T2);
+            $"""
+            create table T1 (A int primary key);
+            create table T2 (B int primary key, A int references T1, C int references T2);
 
-                insert into T1 values (1);
-                insert into T2 values (2, 1, null);
-                insert into T2 values (3, 1, 2);
-                update T2 set C=3 where B=2
-            "
+            insert into T1 values (1);
+            insert into T2 values (2, 1, null);
+            insert into T2 values (3, 1, 2);
+            update T2 set C=3 where B=2
+            """
         ).ExecuteNonQuery(Connection);
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
@@ -311,14 +310,14 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
     public void CascadeDeleteWithForeignKeySpecificationOnDeleteSetNull_is_honored()
     {
         SQL(
-            $@"
-                create table T1 (A int primary key);
-                create table T2 (B int primary key, A int references T1 on delete set null);
+            $"""
+            create table T1 (A int primary key);
+            create table T2 (B int primary key, A int references T1 on delete set null);
 
-                insert into T1 values (1);
-                insert into T2 values (2, 1);
-                insert into T2 values (3, 1);
-            "
+            insert into T1 values (1);
+            insert into T2 values (2, 1);
+            insert into T2 values (3, 1);
+            """
         ).ExecuteNonQuery(Connection);
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);

--- a/test/ProgressOnderwijsUtils.Tests/Data/CascadedDeleteTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/CascadedDeleteTest.cs
@@ -307,7 +307,6 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         PAssert.That(() => deletionReport.Select(t => t.Table).SequenceEqual(new[] { "dbo.T2", "dbo.T1", }));
     }
 
-
     [Fact]
     public void CascadeDeleteWithForeignKeySpecificationOnDeleteSetNull_is_honored()
     {
@@ -331,7 +330,6 @@ public sealed class CascadedDeleteTest : TransactedLocalConnection
         PAssert.That(() => initialValues.All(o => o == 1));
         PAssert.That(() => finalValues.All(o => o == null));
     }
-
 
     [Fact]
     public void CascadeDelete_also_reports_on_tables_with_rowversion_column()

--- a/test/ProgressOnderwijsUtils.Tests/Data/DatabaseDescriptionTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/DatabaseDescriptionTest.cs
@@ -58,14 +58,12 @@ public sealed class DatabaseDescriptionTest : TransactedLocalConnection
     public void CheckConstraintWithTable_works()
     {
         SQL(
-            $@"
-                create table dbo.CheckConstraintTest (
-                    IdRoot int not null primary key,
-                    Test int not null
-                );
-
-                alter table dbo.CheckConstraintTest add constraint ck_TestConstraint check (Test <> 0);
-            "
+            $"""
+            create table dbo.CheckConstraintTest (
+                IdRoot int not null primary key,
+                Test int not null constraint ck_TestConstraint check (Test <> 0)
+            );
+            """
         ).ExecuteNonQuery(Connection);
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
@@ -170,12 +168,11 @@ end;";
     public void DefaultValueConstraint_LoadOK()
     {
         SQL(
-            $@"
-                create table dbo.CheckDefaultValues (
-                    SomeValue int not null
-                );
-                alter table dbo.CheckDefaultValues add constraint df_SomeValue default (42) for SomeValue;
-            "
+            $"""
+            create table dbo.CheckDefaultValues (
+                SomeValue int not null constraint df_SomeValue default (42)
+            );
+            """
         ).ExecuteNonQuery(Connection);
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);

--- a/test/ProgressOnderwijsUtils.Tests/Data/DatabaseDescriptionTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/DatabaseDescriptionTest.cs
@@ -17,23 +17,23 @@ public sealed class DatabaseDescriptionTest : TransactedLocalConnection
     DatabaseDescription CreateSampleData()
     {
         SQL(
-            $@"
-                create table dbo.ForeignKeyLookupRoot (
-                    IdRoot int not null primary key
-                );
+            $"""
+            create table dbo.ForeignKeyLookupRoot (
+                IdRoot int not null primary key
+            );
 
-                create table dbo.ForeignKeyLookupLevel (
-                    IdLevel int not null primary key
-                    , IdRoot int not null constraint LevelToRoot foreign key references dbo.ForeignKeyLookupRoot(IdRoot)
-                    , SomeDataWithDefault nvarchar(max) not null default('test')
-                    , SomeDataWithoutDefault nvarchar(max) not null
-                );
+            create table dbo.ForeignKeyLookupLevel (
+                IdLevel int not null primary key
+                , IdRoot int not null constraint LevelToRoot foreign key references dbo.ForeignKeyLookupRoot(IdRoot)
+                , SomeDataWithDefault nvarchar(max) not null default('test')
+                , SomeDataWithoutDefault nvarchar(max) not null
+            );
 
-                create table dbo.ForeignKeyLookupLeaf (
-                    IdLeaf int not null primary key
-                    , IdLevel int not null constraint LeafToLevel foreign key references dbo.ForeignKeyLookupLevel(IdLevel) on delete cascade
-                );
-            "
+            create table dbo.ForeignKeyLookupLeaf (
+                IdLeaf int not null primary key
+                , IdLevel int not null constraint LeafToLevel foreign key references dbo.ForeignKeyLookupLevel(IdLevel) on delete cascade
+            );
+            """
         ).ExecuteNonQuery(Connection);
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
         return db;
@@ -86,10 +86,12 @@ public sealed class DatabaseDescriptionTest : TransactedLocalConnection
     public void CheckTableTriggers_works()
     {
         SQL($"create table dbo.TableTriggerTest (Iets int null)").ExecuteNonQuery(Connection);
-        var definition = @"create trigger dbo.EenTrigger on dbo.TableTriggerTest for insert as
-begin
-    do_nothing:
-end;";
+        var definition = """
+            create trigger dbo.EenTrigger on dbo.TableTriggerTest for insert as
+            begin
+                do_nothing:
+            end;
+            """;
         SQL($"{ParameterizedSql.RawSql_PotentialForSqlInjection(definition)}").ExecuteNonQuery(Connection);
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
@@ -104,8 +106,7 @@ end;";
     [Fact]
     public void CheckDatabaseTriggers_works()
     {
-        var definition =
-            """
+        var definition = """
             create trigger EenTrigger on database for create_table, alter_table as
             begin
                 do_nothing:
@@ -133,17 +134,17 @@ end;";
     public void CheckIsStringAndIsUnicode_works()
     {
         SQL(
-            $@"
-                create table dbo.CheckIsString (
-                    IdRoot int not null primary key,
-                    Testint int not null,
-                    Testchar char(10) not null,
-                    Testvarchar varchar(10) not null,
-                    Testnchar nchar(10) not null,
-                    Testnvarchar nvarchar(10) not null,
-                    Testxml xml not null
-                );
-            "
+            $"""
+            create table dbo.CheckIsString (
+                IdRoot int not null primary key,
+                Testint int not null,
+                Testchar char(10) not null,
+                Testvarchar varchar(10) not null,
+                Testnchar nchar(10) not null,
+                Testnvarchar nvarchar(10) not null,
+                Testxml xml not null
+            );
+            """
         ).ExecuteNonQuery(Connection);
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
@@ -189,13 +190,13 @@ end;";
     public void ComputedColumns_LoadOK()
     {
         SQL(
-            $@"
-                create table dbo.CheckComputedValues (
-                    Bla int not null,
-                    SomeValue as (42) persisted not null,
-                    SomeOtherValue as (cast(null as nvarchar(max)))
-                );
-            "
+            $"""
+            create table dbo.CheckComputedValues (
+                Bla int not null,
+                SomeValue as (42) persisted not null,
+                SomeOtherValue as (cast(null as nvarchar(max)))
+            );
+            """
         ).ExecuteNonQuery(Connection);
 
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);

--- a/test/ProgressOnderwijsUtils.Tests/Data/EnumeratePocosTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/EnumeratePocosTest.cs
@@ -68,7 +68,6 @@ public sealed class EnumeratePocosTest : TransactedLocalConnection
         Assert.Equal(new() { Id = 37, Content = "hmm", }, value);
     }
 
-
     [Fact]
     public void ConcurrentReadersCrash()
     {

--- a/test/ProgressOnderwijsUtils.Tests/Data/EnumeratePocosTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/EnumeratePocosTest.cs
@@ -4,13 +4,13 @@ public sealed class EnumeratePocosTest : TransactedLocalConnection
 {
     static ParameterizedSql ExampleQuery
         => SQL(
-            $@"
-                select content='bla', id= 3
-                union all
-                select content='hmm', id= 37
-                union all
-                select content=null, id= 1337
-                "
+            $"""
+            select content='bla', id= 3
+            union all
+            select content='hmm', id= 37
+            union all
+            select content=null, id= 1337
+            """
         );
 
     public sealed record ExampleRow : IWrittenImplicitly

--- a/test/ProgressOnderwijsUtils.Tests/Data/ForeignKeyLookupTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/ForeignKeyLookupTest.cs
@@ -6,21 +6,21 @@ public sealed class ForeignKeyLookupTest : TransactedLocalConnection
     public void AllDependantTables_works_recursively()
     {
         SQL(
-            $@"
-                create table dbo.ForeignKeyLookupRoot (
-                    IdRoot int not null primary key
-                );
+            $"""
+            create table dbo.ForeignKeyLookupRoot (
+                IdRoot int not null primary key
+            );
 
-                create table dbo.ForeignKeyLookupLevel (
-                    IdLevel int not null primary key
-                    , IdRoot int not null foreign key references dbo.ForeignKeyLookupRoot(IdRoot)
-                );
+            create table dbo.ForeignKeyLookupLevel (
+                IdLevel int not null primary key
+                , IdRoot int not null foreign key references dbo.ForeignKeyLookupRoot(IdRoot)
+            );
 
-                create table dbo.ForeignKeyLookupLeaf (
-                    IdLeaf int not null primary key
-                    , IdLevel int not null foreign key references dbo.ForeignKeyLookupLevel(IdLevel)
-                );
-            "
+            create table dbo.ForeignKeyLookupLeaf (
+                IdLeaf int not null primary key
+                , IdLevel int not null foreign key references dbo.ForeignKeyLookupLevel(IdLevel)
+            );
+            """
         ).ExecuteNonQuery(Connection);
         var db = DatabaseDescription.LoadFromSchemaTables(Connection);
 

--- a/test/ProgressOnderwijsUtils.Tests/Data/PocoBulkCopyFieldMappingTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/PocoBulkCopyFieldMappingTest.cs
@@ -11,7 +11,7 @@ public sealed class PocoBulkCopyFieldMappingTest : TransactedLocalConnection
         public int? OtherColumn { get; set; }
 
         public static ExactMapping[] Load(SqlConnection context)
-            => SQL($@"select t.* from {testTableName} t").ReadPocos<ExactMapping>(context);
+            => SQL($"select t.* from {testTableName} t").ReadPocos<ExactMapping>(context);
     }
 
     struct LessColumns : IWrittenImplicitly, IReadImplicitly
@@ -45,13 +45,13 @@ public sealed class PocoBulkCopyFieldMappingTest : TransactedLocalConnection
     BulkInsertTarget CreateTargetTable()
     {
         SQL(
-            $@"
-                create table {testTableName} (
-                    Id int not null
-                    , SomeColumn int null
-                    , OtherColumn int null
-                );
-            "
+            $"""
+            create table {testTableName} (
+                Id int not null
+                , SomeColumn int null
+                , OtherColumn int null
+            );
+            """
         ).ExecuteNonQuery(Connection);
 
         return BulkInsertTarget.FromCompleteSetOfColumns(testTableName.CommandText(), DbColumnMetaData.ColumnMetaDatas(Connection, testTableName));

--- a/test/ProgressOnderwijsUtils.Tests/Data/PocoObjectMapperTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/PocoObjectMapperTest.cs
@@ -7,22 +7,22 @@ public sealed class PocoObjectMapperTest : TransactedLocalConnection
 {
     public static ParameterizedSql ParameterizedSqlForRows(int rows)
         => SQL(
-            $@"
-                SELECT top ({rows})
-                    SalesOrderID,DueDate,ShipDate,Status,OnlineOrderFlag,AccountNumber,SalesPersonID,TotalDue,Comment,rowGuid, SomeBlob, SomeNullableBlob
-                from (select SalesOrderID = 13 union all select 14) a01
-                cross join(select AccountNumber = N'abracadabra fee fi fo fum' union all select N'abcdef') a02
-                cross join(select Comment = N'abracadabra fee fi fo fum' union all select null) a04
-                cross join(select DueDate = cast('2014-01-02' as datetime2) union all select cast('2014-01-03' as datetime2)) a09
-                cross join(select OnlineOrderFlag = cast(1 as bit) union all select cast(0 as bit)) a12
-                cross join(select Rowguid = NEWID ( )) a16
-                cross join(select SalesPersonId = 37 union all select null ) a18
-                cross join(select ShipDate = cast('2014-01-02' as datetime2) union all select null) a19
-                cross join(select Status = cast(1 as tinyint) union all select cast(10 as tinyint)) a22
-                cross join(select TotalDue = cast(1.1 as decimal(18,2))) a26
-                cross join(select SomeBlob = cast('deadbeef' as varbinary(max))) a27
-                cross join(select SomeNullableBlob = cast('deadbeef' as varbinary(max)) union all select null) a28
-            "
+            $"""
+            select top ({rows})
+                SalesOrderID,DueDate,ShipDate,Status,OnlineOrderFlag,AccountNumber,SalesPersonID,TotalDue,Comment,rowGuid, SomeBlob, SomeNullableBlob
+            from (select SalesOrderID = 13 union all select 14) a01
+            cross join(select AccountNumber = N'abracadabra fee fi fo fum' union all select N'abcdef') a02
+            cross join(select Comment = N'abracadabra fee fi fo fum' union all select null) a04
+            cross join(select DueDate = cast('2014-01-02' as datetime2) union all select cast('2014-01-03' as datetime2)) a09
+            cross join(select OnlineOrderFlag = cast(1 as bit) union all select cast(0 as bit)) a12
+            cross join(select Rowguid = NEWID ( )) a16
+            cross join(select SalesPersonId = 37 union all select null ) a18
+            cross join(select ShipDate = cast('2014-01-02' as datetime2) union all select null) a19
+            cross join(select Status = cast(1 as tinyint) union all select cast(10 as tinyint)) a22
+            cross join(select TotalDue = cast(1.1 as decimal(18,2))) a26
+            cross join(select SomeBlob = cast('deadbeef' as varbinary(max))) a27
+            cross join(select SomeNullableBlob = cast('deadbeef' as varbinary(max)) union all select null) a28
+            """
         );
 
     public sealed class ExampleWithJustSetters : IWrittenImplicitly
@@ -263,7 +263,7 @@ public sealed class PocoObjectMapperTest : TransactedLocalConnection
         {
             var tableName = SQL($"#rowversions");
             SQL(
-                $@"
+                $"""
                 create table {tableName} (
                     AShorterVersion binary(4)
                     , AnotherVersion binary(8) not null
@@ -271,17 +271,17 @@ public sealed class PocoObjectMapperTest : TransactedLocalConnection
                     , AFinalVersion varbinary(max)
                     , Counter int identity not null
                 );
-            "
+                """
             ).ExecuteNonQuery(sqlConnection);
 
             SQL(
-                $@"
+                $"""
                 insert into {tableName} (AShorterVersion, AnotherVersion, AFinalVersion) values (cast(1 as int), cast(2 as bigint), cast(3 as bigint));
                 insert into {tableName} (AShorterVersion, AnotherVersion, AFinalVersion) values (cast(100 as int), cast(20000 as bigint), cast(30000 as bigint));
                 insert into {tableName} (AShorterVersion, AnotherVersion, AFinalVersion) values (cast(10000 as int), cast(200000000 as bigint), cast(300000000 as bigint));
                 insert into {tableName} (AShorterVersion, AnotherVersion, AFinalVersion) values (cast(1000000 as int), cast(2000000000000 as bigint), cast(3000000000000 as bigint));
                 insert into {tableName} (AShorterVersion, AnotherVersion, AFinalVersion) values (cast(100000000 as int), cast(20000000000000000 as bigint), cast(30000000000000000 as bigint));
-            "
+                """
             ).ExecuteNonQuery(sqlConnection);
             return tableName;
         }

--- a/test/ProgressOnderwijsUtils.Tests/Data/PocoPropertyConvertibleLoaderTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/PocoPropertyConvertibleLoaderTest.cs
@@ -108,13 +108,13 @@ public sealed class PocoPropertyConvertibleLoaderTest : TransactedLocalConnectio
     {
         var tableName = SQL($"#MyTable");
         SQL(
-            $@"
-                create table {tableName} (
-                    id int not null primary key
-                    , bla nvarchar(max) null
-                    , bla2 nvarchar(max) not null
-                )
-            "
+            $"""
+            create table {tableName} (
+                id int not null primary key
+                , bla nvarchar(max) null
+                , bla2 nvarchar(max) not null
+            )
+            """
         ).ExecuteNonQuery(Connection);
         return BulkInsertTarget.LoadFromTable(Connection, tableName);
     }

--- a/test/ProgressOnderwijsUtils.Tests/Data/ReadJsonTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/ReadJsonTest.cs
@@ -41,61 +41,61 @@ public sealed class ReadJsonTest : TransactedLocalConnection
     public void ReadJson_can_read_all_known_used_column_types_from_the_db()
     {
         SQL(
-            $@"
-                create table #ReadJsonTest (
-                    ReadJsonTestId int not null
-
-                    -- exact numerics
-                    , BitColumn bit
-                    , IntColumn int
-                    , BigIntColumn bigint
-                    , DecimalColumn decimal(4,2)
-
-                    -- Approximate numerics
-                    , FloatColumn float
-
-                    -- Date and time
-                    , DateColumn date
-                    , DateTimeOffsetColumn datetimeoffset
-
-                    -- Character strings
-                    , CharColumn char
-                    , VarCharColumn varchar(32)
-
-                    -- Unicode character strings
-                    , NCharColumn nchar
-                    , NVarCharColumn nvarchar(32)
-
-                    -- Binary strings (equiv. to rowversion)
-                    , BinaryColumn binary(8)
-
-                    -- Other data types
-                    , UniqueIdentifierColumn uniqueidentifier
-                );
-            "
+            $"""
+            create table #ReadJsonTest (
+                ReadJsonTestId int not null
+            
+                -- exact numerics
+                , BitColumn bit
+                , IntColumn int
+                , BigIntColumn bigint
+                , DecimalColumn decimal(4,2)
+            
+                -- Approximate numerics
+                , FloatColumn float
+            
+                -- Date and time
+                , DateColumn date
+                , DateTimeOffsetColumn datetimeoffset
+            
+                -- Character strings
+                , CharColumn char
+                , VarCharColumn varchar(32)
+            
+                -- Unicode character strings
+                , NCharColumn nchar
+                , NVarCharColumn nvarchar(32)
+            
+                -- Binary strings (equiv. to rowversion)
+                , BinaryColumn binary(8)
+            
+                -- Other data types
+                , UniqueIdentifierColumn uniqueidentifier
+            );
+            """
         ).ExecuteNonQuery(Connection);
 
         SQL(
-            $@"
-                insert into #ReadJsonTest (
-                    ReadJsonTestId
-                    , BitColumn
-                    , IntColumn
-                    , BigIntColumn
-                    , DecimalColumn
-                    , FloatColumn
-                    , DateColumn
-                    , DateTimeOffsetColumn
-                    , CharColumn
-                    , VarCharColumn
-                    , NCharColumn
-                    , NVarCharColumn
-                    , BinaryColumn
-                    , UniqueIdentifierColumn
-                ) values
-                    (1, {true}, {int.MaxValue}, {long.MaxValue}, {0.99m}, {1.234}, {new DateTime(2008, 4, 1)}, {new DateTime(2023, 11, 9, 8, 25, 01, DateTimeKind.Utc)}, 'x', 'xyz', N'p', N'pqr', {new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }}, {"82DBEE37-3AF8-46F2-A403-AE0A1950BC6E"} )
-                    , (2, null, null, null, null, null, null, null, null, null, null, null, null, null);
-            "
+            $"""
+            insert into #ReadJsonTest (
+                ReadJsonTestId
+                , BitColumn
+                , IntColumn
+                , BigIntColumn
+                , DecimalColumn
+                , FloatColumn
+                , DateColumn
+                , DateTimeOffsetColumn
+                , CharColumn
+                , VarCharColumn
+                , NCharColumn
+                , NVarCharColumn
+                , BinaryColumn
+                , UniqueIdentifierColumn
+            ) values
+                (1, {true}, {int.MaxValue}, {long.MaxValue}, {0.99m}, {1.234}, {new DateTime(2008, 4, 1)}, {new DateTime(2023, 11, 9, 8, 25, 01, DateTimeKind.Utc)}, 'x', 'xyz', N'p', N'pqr', {new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }}, {"82DBEE37-3AF8-46F2-A403-AE0A1950BC6E"} )
+                , (2, null, null, null, null, null, null, null, null, null, null, null, null, null);
+            """
         ).ExecuteNonQuery(Connection);
 
         var pipe = new Pipe();
@@ -112,25 +112,25 @@ public sealed class ReadJsonTest : TransactedLocalConnection
     {
         SQL(
             $"""
-                create table #ReadJsonTest (
-                    DateTimeColumn datetime
-                    , DateTime2Column datetime2
-                    , DateTime2Column_Utc datetime2
-                    , DateTimeOffsetColumn datetimeoffset
-                );
+            create table #ReadJsonTest (
+                DateTimeColumn datetime
+                , DateTime2Column datetime2
+                , DateTime2Column_Utc datetime2
+                , DateTimeOffsetColumn datetimeoffset
+            );
             """
         ).ExecuteNonQuery(Connection);
 
         var dateTime = new DateTime(1, 2, 3, 4, 5, 6, 7);
         SQL(
             $"""
-                insert into #ReadJsonTest (
-                    DateTimeColumn
-                    , DateTime2Column
-                    , DateTime2Column_Utc
-                    , DateTimeOffsetColumn
-                ) values
-                    ({new DateTime(2023, 5, 6, 16, 13, 55)}, {dateTime}, {dateTime.ToUniversalTime()}, {new DateTime(2023, 11, 9, 8, 19, 27, DateTimeKind.Utc)})
+            insert into #ReadJsonTest (
+                DateTimeColumn
+                , DateTime2Column
+                , DateTime2Column_Utc
+                , DateTimeOffsetColumn
+            ) values
+                ({new DateTime(2023, 5, 6, 16, 13, 55)}, {dateTime}, {dateTime.ToUniversalTime()}, {new DateTime(2023, 11, 9, 8, 19, 27, DateTimeKind.Utc)})
             """
         ).ExecuteNonQuery(Connection);
 
@@ -161,37 +161,37 @@ public sealed class ReadJsonTest : TransactedLocalConnection
     public void Deserialize_ReadJson_gives_the_same_result_as_ReadPocos()
     {
         SQL(
-            $@"
-                create table #ReadJsonPocoTest (
-                    ReadJsonPocoTestId int not null
-                    , BooleanColumn bit not null
-                    , NumberColumn int
-                    , LongColumn bigint
-                    , DecimalColumn decimal(10, 2)
-                    , DoubleColumn float(53)
-                    , StringColumn nvarchar(32)
-                    , DateTimeColumn datetime2
-                    , BinaryColumn varbinary(32)
-                );
-            "
+            $"""
+            create table #ReadJsonPocoTest (
+                ReadJsonPocoTestId int not null
+                , BooleanColumn bit not null
+                , NumberColumn int
+                , LongColumn bigint
+                , DecimalColumn decimal(10, 2)
+                , DoubleColumn float(53)
+                , StringColumn nvarchar(32)
+                , DateTimeColumn datetime2
+                , BinaryColumn varbinary(32)
+            );
+            """
         ).ExecuteNonQuery(Connection);
 
         SQL(
-            $@"
-                insert into #ReadJsonPocoTest (
-                    ReadJsonPocoTestId
-                    , BooleanColumn
-                    , NumberColumn
-                    , LongColumn
-                    , DoubleColumn
-                    , DecimalColumn
-                    , StringColumn
-                    , DateTimeColumn
-                    , BinaryColumn
-                ) values
-                    (1, {true}, {17}, {long.MaxValue}, {12.99m}, {1.23456789}, {"iets"}, {new DateTime(2000, 4, 1, 9, 32, 55)}, {new byte[] { 255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245 }})
-                    , (2, {false}, null, null, null, null, null, null, null);
-            "
+            $"""
+            insert into #ReadJsonPocoTest (
+                ReadJsonPocoTestId
+                , BooleanColumn
+                , NumberColumn
+                , LongColumn
+                , DoubleColumn
+                , DecimalColumn
+                , StringColumn
+                , DateTimeColumn
+                , BinaryColumn
+            ) values
+                (1, {true}, {17}, {long.MaxValue}, {12.99m}, {1.23456789}, {"iets"}, {new DateTime(2000, 4, 1, 9, 32, 55)}, {new byte[] { 255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245 }})
+                , (2, {false}, null, null, null, null, null, null, null);
+            """
         ).ExecuteNonQuery(Connection);
 
         var query = SQL($"select t.* from #ReadJsonPocoTest t order by t.ReadJsonPocoTestId");

--- a/test/ProgressOnderwijsUtils.Tests/Data/ReadJsonTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/ReadJsonTest.cs
@@ -112,26 +112,26 @@ public sealed class ReadJsonTest : TransactedLocalConnection
     {
         SQL(
             $"""
-                 create table #ReadJsonTest (
-                     DateTimeColumn datetime
-                     , DateTime2Column datetime2
-                     , DateTime2Column_Utc datetime2
-                     , DateTimeOffsetColumn datetimeoffset
-                 );
-             """
+                create table #ReadJsonTest (
+                    DateTimeColumn datetime
+                    , DateTime2Column datetime2
+                    , DateTime2Column_Utc datetime2
+                    , DateTimeOffsetColumn datetimeoffset
+                );
+            """
         ).ExecuteNonQuery(Connection);
 
         var dateTime = new DateTime(1, 2, 3, 4, 5, 6, 7);
         SQL(
             $"""
-                 insert into #ReadJsonTest (
-                     DateTimeColumn
-                     , DateTime2Column
-                     , DateTime2Column_Utc
-                     , DateTimeOffsetColumn
-                 ) values
-                     ({new DateTime(2023, 5, 6, 16, 13, 55)}, {dateTime}, {dateTime.ToUniversalTime()}, {new DateTime(2023, 11, 9, 8, 19, 27, DateTimeKind.Utc)})
-             """
+                insert into #ReadJsonTest (
+                    DateTimeColumn
+                    , DateTime2Column
+                    , DateTime2Column_Utc
+                    , DateTimeOffsetColumn
+                ) values
+                    ({new DateTime(2023, 5, 6, 16, 13, 55)}, {dateTime}, {dateTime.ToUniversalTime()}, {new DateTime(2023, 11, 9, 8, 19, 27, DateTimeKind.Utc)})
+            """
         ).ExecuteNonQuery(Connection);
 
         var pipe = new Pipe();

--- a/test/ProgressOnderwijsUtils.Tests/Data/SqlErrorParserTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/SqlErrorParserTest.cs
@@ -6,12 +6,12 @@ public sealed class SqlErrorParserTest : TransactedLocalConnection
     public void Parse_returns_KeyConstraintViolation_when_single_column_unique_key_constraint_is_violated_with_value_containing_parentheses()
     {
         SQL(
-            $@"
-                    create table #T (
-                        Id int identity primary key,
-                        C nchar(4) not null constraint uc_T_C unique
-                    )
-                "
+            $"""
+            create table #T (
+                Id int identity primary key,
+                C nchar(4) not null constraint uc_T_C unique
+            )
+            """
         ).ExecuteNonQuery(Connection);
         SQL($"insert #T (C) values ('A(1)')").ExecuteNonQuery(Connection);
 
@@ -30,13 +30,13 @@ public sealed class SqlErrorParserTest : TransactedLocalConnection
     public void Parse_returns_DuplicateKeyUniqueIndex_when_duplicate_value_is_inserted_in_unique_index()
     {
         SQL(
-            $@"
-                    create table #T (
-                        Id int identity primary key,
-                        C nchar(1) not null
-                    )
-                    create unique index ix_T on #T (C)
-                "
+            $"""
+            create table #T (
+                Id int identity primary key,
+                C nchar(1) not null
+            )
+            create unique index ix_T on #T (C)
+            """
         ).ExecuteNonQuery(Connection);
         SQL($"insert #T (C) values ('A')").ExecuteNonQuery(Connection);
 
@@ -54,11 +54,11 @@ public sealed class SqlErrorParserTest : TransactedLocalConnection
     public void Parse_returns_KeyConstraintViolation_when_single_column_primary_key_constraint_is_violated()
     {
         SQL(
-            $@"
-                    create table #T (
-                        Id int constraint pk_T primary key
-                    )
-                "
+            $"""
+            create table #T (
+                Id int constraint pk_T primary key
+            )
+            """
         ).ExecuteNonQuery(Connection);
         SQL($"insert #T (Id) values (1)").ExecuteNonQuery(Connection);
         var exception = Assert.Throws<ParameterizedSqlExecutionException>(() => SQL($"insert #T (Id) values (1)").ExecuteNonQuery(Connection));
@@ -76,14 +76,14 @@ public sealed class SqlErrorParserTest : TransactedLocalConnection
     public void Parse_returns_KeyConstraintViolation_when_multi_column_unique_key_constraint_is_violated()
     {
         SQL(
-            $@"
-                    create table #T (
-                        Id int identity primary key,
-                        C1 nchar(1) not null,
-                        C2 nchar(1) not null,
-                        constraint uc_T_C1_C2 unique (C1, C2)
-                    )
-                "
+            $"""
+            create table #T (
+                Id int identity primary key,
+                C1 nchar(1) not null,
+                C2 nchar(1) not null,
+                constraint uc_T_C1_C2 unique (C1, C2)
+            )
+            """
         ).ExecuteNonQuery(Connection);
         SQL($"insert #T (C1, C2) values ('A', 'B')").ExecuteNonQuery(Connection);
         var exception = Assert.Throws<ParameterizedSqlExecutionException>(() => SQL($"insert #T (C1, C2) values ('A', 'B')").ExecuteNonQuery(Connection));
@@ -101,12 +101,12 @@ public sealed class SqlErrorParserTest : TransactedLocalConnection
     public void Parse_returns_GenericConstraintViolation_when_check_constraint_is_violated_using_insert()
     {
         SQL(
-            $@"
-                    create table T1 (
-                        Id int identity primary key,
-                        C int not null constraint ck_T_C check (C <> 1)
-                    )
-                "
+            $"""
+            create table T1 (
+                Id int identity primary key,
+                C int not null constraint ck_T_C check (C <> 1)
+            )
+            """
         ).ExecuteNonQuery(Connection);
         var exception = Assert.Throws<ParameterizedSqlExecutionException>(() => SQL($"insert T1 (C) values (1)").ExecuteNonQuery(Connection));
 
@@ -125,12 +125,12 @@ public sealed class SqlErrorParserTest : TransactedLocalConnection
     public void Parse_returns_GenericConstraintViolation_when_check_constraint_is_violated_using_update()
     {
         SQL(
-            $@"
-                    create table #T (
-                        Id int identity primary key,
-                        C int not null constraint ck_T_C check (C <> 1)
-                    )
-                "
+            $"""
+            create table #T (
+                Id int identity primary key,
+                C int not null constraint ck_T_C check (C <> 1)
+            )
+            """
         ).ExecuteNonQuery(Connection);
         SQL($"insert #T (C) values (2)").ExecuteNonQuery(Connection);
         var exception = Assert.Throws<ParameterizedSqlExecutionException>(() => SQL($"update #T set C = 1").ExecuteNonQuery(Connection));
@@ -151,15 +151,15 @@ public sealed class SqlErrorParserTest : TransactedLocalConnection
     {
         // Reference constraints on temporary tables aren't enforced or something.
         SQL(
-            $@"
-                    create table T1 (
-                        Id int identity primary key
-                    )
-                    create table T2 (
-                        Id int identity primary key,
-                        C int not null constraint fk_T2_T1 references T1
-                    )
-                "
+            $"""
+            create table T1 (
+                Id int identity primary key
+            )
+            create table T2 (
+                Id int identity primary key,
+                C int not null constraint fk_T2_T1 references T1
+            )
+            """
         ).ExecuteNonQuery(Connection);
         var exception = Assert.Throws<ParameterizedSqlExecutionException>(() => SQL($"insert T2 (C) values (1)").ExecuteNonQuery(Connection));
 
@@ -178,12 +178,12 @@ public sealed class SqlErrorParserTest : TransactedLocalConnection
     public void Parse_returns_CannotInsertNull_when_attempting_to_insert_null_value_in_not_null_column()
     {
         SQL(
-            $@"
-                    create table #T (
-                        Id int identity primary key,
-                        C int not null
-                    )
-                "
+            $"""
+            create table #T (
+                Id int identity primary key,
+                C int not null
+            )
+            """
         ).ExecuteNonQuery(Connection);
         var exception = Assert.Throws<ParameterizedSqlExecutionException>(() => SQL($"insert #T (C) values (null)").ExecuteNonQuery(Connection));
 

--- a/test/ProgressOnderwijsUtils.Tests/Data/TableValuedParameterTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/Data/TableValuedParameterTest.cs
@@ -1,5 +1,4 @@
 using System.Data.Common;
-using ProgressOnderwijsUtils.Internal;
 
 namespace ProgressOnderwijsUtils.Tests.Data;
 
@@ -10,28 +9,28 @@ public sealed class TableValuedParameterTest : TransactedLocalConnection
     [Fact]
     public void ConvertibleProperty()
     {
-        var value = SQL($@"select {TrivialConvertibleValue.Create("aap")}").ReadScalar<TrivialValue<string>>(Connection);
+        var value = SQL($"select {TrivialConvertibleValue.Create("aap")}").ReadScalar<TrivialValue<string>>(Connection);
         PAssert.That(() => value.Value == "aap");
     }
 
     [Fact]
     public void ConvertibleNullablePropertyWitValue()
     {
-        var value = SQL($@"select {TrivialConvertibleValue.Create("aap")}").ReadScalar<TrivialValue<string>?>(Connection);
+        var value = SQL($"select {TrivialConvertibleValue.Create("aap")}").ReadScalar<TrivialValue<string>?>(Connection);
         PAssert.That(() => value.AssertNotNull().Value == "aap");
     }
 
     [Fact]
     public void ConvertibleNullablePropertyWithoutValue()
     {
-        var value = SQL($@"select {default(TrivialValue<string>?)}").ReadScalar<TrivialValue<string>?>(Connection);
+        var value = SQL($"select {default(TrivialValue<string>?)}").ReadScalar<TrivialValue<string>?>(Connection);
         PAssert.That(() => value == null);
     }
 
     [Fact]
     public void ConvertibleNonNullablePropertyWithoutValueShouldThrow()
     {
-        var nullStringReturningQuery = SQL($@"select cast(null as nvarchar(max))");
+        var nullStringReturningQuery = SQL($"select cast(null as nvarchar(max))");
 
         _ = nullStringReturningQuery.ReadScalar<string>(Connection);
 
@@ -41,7 +40,7 @@ public sealed class TableValuedParameterTest : TransactedLocalConnection
     [Fact]
     public void DatabaseCanProcessTableValuedParameters()
     {
-        var q = SQL($@"select sum(x.querytablevalue) from ") + ParameterizedSql.TableParamDynamic(Enumerable.Range(1, 100).ToArray()) + SQL($" x");
+        var q = SQL($"select sum(x.querytablevalue) from ") + ParameterizedSql.TableParamDynamic(Enumerable.Range(1, 100).ToArray()) + SQL($" x");
         var sum = q.ReadScalar<int>(Connection);
         PAssert.That(() => sum == (100 * 100 + 100) / 2);
     }
@@ -49,7 +48,7 @@ public sealed class TableValuedParameterTest : TransactedLocalConnection
     [Fact]
     public void ParameterizedSqlCanIncludeTvps()
     {
-        var q = SQL($@"select sum(x.querytablevalue) from {Enumerable.Range(1, 100)} x");
+        var q = SQL($"select sum(x.querytablevalue) from {Enumerable.Range(1, 100)} x");
         var sum = q.ReadScalar<int>(Connection);
         PAssert.That(() => sum == (100 * 100 + 100) / 2);
     }
@@ -69,7 +68,7 @@ public sealed class TableValuedParameterTest : TransactedLocalConnection
     [Fact]
     public void ParameterizedSqlCanIncludeEnumTvps()
     {
-        var q = SQL($@"select sum(x.querytablevalue) from {Enumerable.Range(1, 100).Select(i => (SomeEnum)i)} x");
+        var q = SQL($"select sum(x.querytablevalue) from {Enumerable.Range(1, 100).Select(i => (SomeEnum)i)} x");
         var sum = (int)q.ReadScalar<SomeEnum>(Connection);
         PAssert.That(() => sum == (100 * 100 + 100) / 2);
     }
@@ -77,7 +76,7 @@ public sealed class TableValuedParameterTest : TransactedLocalConnection
     [Fact]
     public void ParameterizedSqlCanIncludeAutomaticallyConvertedTvps()
     {
-        var q = SQL($@"select sum(x.querytablevalue) from {AsSqlParam(Enumerable.Range(1, 100).Select(TrivialConvertibleValue.Create))} x");
+        var q = SQL($"select sum(x.querytablevalue) from {AsSqlParam(Enumerable.Range(1, 100).Select(TrivialConvertibleValue.Create))} x");
         var sum = (int)q.ReadScalar<SomeEnum>(Connection);
         PAssert.That(() => sum == (100 * 100 + 100) / 2);
     }
@@ -85,7 +84,7 @@ public sealed class TableValuedParameterTest : TransactedLocalConnection
     [Fact]
     public void ParameterizedSqlTvpsCanCountDaysOfWeek()
     {
-        var q = SQL($@"select count(x.querytablevalue) from {new[] { DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Friday, }} x");
+        var q = SQL($"select count(x.querytablevalue) from {new[] { DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Friday, }} x");
         var dayCount = q.ReadScalar<int>(Connection);
         PAssert.That(() => dayCount == 5);
     }
@@ -93,7 +92,7 @@ public sealed class TableValuedParameterTest : TransactedLocalConnection
     [Fact]
     public void ParameterizedSqlTvpsCanCountGuids()
     {
-        var q = SQL($@"select count(x.querytablevalue) from {new[] { new Guid(), new Guid(), }} x");
+        var q = SQL($"select count(x.querytablevalue) from {new[] { new Guid(), new Guid(), }} x");
         var dayCount = q.ReadScalar<int>(Connection);
         PAssert.That(() => dayCount == 2);
     }
@@ -101,7 +100,7 @@ public sealed class TableValuedParameterTest : TransactedLocalConnection
     [Fact]
     public void ParameterizedSqlTvpsCanCountStrings()
     {
-        var q = SQL($@"select count(distinct x.querytablevalue) from {new[] { "foo", "bar", "foo", }} x");
+        var q = SQL($"select count(distinct x.querytablevalue) from {new[] { "foo", "bar", "foo", }} x");
         var dayCount = q.ReadScalar<int>(Connection);
         PAssert.That(() => dayCount == 2);
     }
@@ -113,12 +112,12 @@ public sealed class TableValuedParameterTest : TransactedLocalConnection
         var pocos = stringsWithNull.ArraySelect(s => new TableValuedParameterWrapper<string?> { QueryTableValue = s, });
 
         var tableName = SQL($"#strings");
-        SQL($@"create table {tableName} (querytablevalue nvarchar(max))").ExecuteNonQuery(Connection);
+        SQL($"create table {tableName} (querytablevalue nvarchar(max))").ExecuteNonQuery(Connection);
         //manual bulk insert because our default TVP types explicitly forbid null
         pocos.BulkCopyToSqlServer(Connection, BulkInsertTarget.LoadFromTable(Connection, tableName));
 
-        var output = SQL($@"select x.querytablevalue from #strings x").ReadPlain<string>(Connection);
-        SQL($@"drop table #strings").ExecuteNonQuery(Connection);
+        var output = SQL($"select x.querytablevalue from #strings x").ReadPlain<string>(Connection);
+        SQL($"drop table #strings").ExecuteNonQuery(Connection);
         PAssert.That(() => stringsWithNull.SetEqual(output));
     }
 
@@ -126,10 +125,10 @@ public sealed class TableValuedParameterTest : TransactedLocalConnection
     public void Binary_columns_can_be_used_in_tvps()
     {
         var dataLengthSumQuery = SQL(
-            $@"
-                select sum(datalength(hashes.QueryTableValue))
-                from {new[] { Encoding.ASCII.GetBytes("0123456789"), Encoding.ASCII.GetBytes("abcdef"), }} hashes
-            "
+            $"""
+            select sum(datalength(hashes.QueryTableValue))
+            from {new[] { Encoding.ASCII.GetBytes("0123456789"), Encoding.ASCII.GetBytes("abcdef"), }} hashes
+            """
         );
         PAssert.That(() => dataLengthSumQuery.ReadPlain<long>(Connection).Single() == 16);
     }
@@ -155,18 +154,17 @@ public sealed class TableValuedParameterTest : TransactedLocalConnection
     public void Test_SqlDataReader_GetBytes_for_its_spec()
     {
         SQL(
-            $@"
-                create table get_bytes_test
-                (
-                    data varbinary(max) not null
-                );
+            $"""
+            create table get_bytes_test (
+                data varbinary(max) not null
+            );
 
-                insert into get_bytes_test
-                values ({testData});
-            "
+            insert into get_bytes_test
+            values ({testData});
+            """
         ).ExecuteNonQuery(Connection);
 
-        using var cmd = SQL($@"select data from get_bytes_test").CreateSqlCommand(Connection, CommandTimeout.DeferToConnectionDefault);
+        using var cmd = SQL($"select data from get_bytes_test").CreateSqlCommand(Connection, CommandTimeout.DeferToConnectionDefault);
         using var reader = cmd.Command.ExecuteReader(CommandBehavior.Default);
         Assert_DataReader_GetBytes_works(reader);
     }

--- a/test/ProgressOnderwijsUtils.Tests/HtmlDslGenerator.cs
+++ b/test/ProgressOnderwijsUtils.Tests/HtmlDslGenerator.cs
@@ -154,49 +154,49 @@ public sealed class HtmlDslGenerator
                     voidElements.Contains(el.elementName)
                         ? $$"""
                         
-                                public struct {{el.csUpperName}} : IHtmlElement<{{el.csUpperName}}>{{el.attributes.Select(attrName => $", IHasAttr_{toClassName(attrName)}").JoinStrings("")}}
-                                {
-                                    public string TagName => "{{el.elementName}}";
-                                    string IHtmlElement.TagStart => "<{{el.elementName}}";
-                                    string IHtmlElement.EndTag => "";
-                                    ReadOnlySpan<byte> IHtmlElement.TagStartUtf8 => "<{{el.elementName}}"u8;
-                                    ReadOnlySpan<byte> IHtmlElement.EndTagUtf8 => ""u8;
-                                    public bool ContainsUnescapedText => {{(el.elementName is "script" or "style" ? "true" : "false")}};
-                                    HtmlAttributes attrs;
-                                    {{el.csUpperName}} IHtmlElement<{{el.csUpperName}}>.ReplaceAttributesWith(HtmlAttributes replacementAttributes) => new {{el.csUpperName}} { attrs = replacementAttributes };
-                                    HtmlAttributes IHtmlElement.Attributes => attrs;
-                                    IHtmlElement IHtmlElement.ApplyAlteration<THtmlTagAlteration>(THtmlTagAlteration change) => change.AlterEmptyElement(this);
-                                    [Pure] public HtmlFragment AsFragment() => HtmlFragment.Element(this);
-                                    public static implicit operator HtmlFragment({{el.csUpperName}} tag) => tag.AsFragment();
-                                    public static HtmlFragment operator +({{el.csUpperName}} unary) => unary;
-                                    public static HtmlFragment operator +({{el.csUpperName}} head, HtmlFragment tail) => HtmlFragment.Fragment(HtmlFragment.Element(head), tail);
-                                    public static HtmlFragment operator +(string head, {{el.csUpperName}} tail) => HtmlFragment.Fragment(head, HtmlFragment.Element(tail));
-                                }
-                            """
+                            public struct {{el.csUpperName}} : IHtmlElement<{{el.csUpperName}}>{{el.attributes.Select(attrName => $", IHasAttr_{toClassName(attrName)}").JoinStrings("")}}
+                            {
+                                public string TagName => "{{el.elementName}}";
+                                string IHtmlElement.TagStart => "<{{el.elementName}}";
+                                string IHtmlElement.EndTag => "";
+                                ReadOnlySpan<byte> IHtmlElement.TagStartUtf8 => "<{{el.elementName}}"u8;
+                                ReadOnlySpan<byte> IHtmlElement.EndTagUtf8 => ""u8;
+                                public bool ContainsUnescapedText => {{(el.elementName is "script" or "style" ? "true" : "false")}};
+                                HtmlAttributes attrs;
+                                {{el.csUpperName}} IHtmlElement<{{el.csUpperName}}>.ReplaceAttributesWith(HtmlAttributes replacementAttributes) => new {{el.csUpperName}} { attrs = replacementAttributes };
+                                HtmlAttributes IHtmlElement.Attributes => attrs;
+                                IHtmlElement IHtmlElement.ApplyAlteration<THtmlTagAlteration>(THtmlTagAlteration change) => change.AlterEmptyElement(this);
+                                [Pure] public HtmlFragment AsFragment() => HtmlFragment.Element(this);
+                                public static implicit operator HtmlFragment({{el.csUpperName}} tag) => tag.AsFragment();
+                                public static HtmlFragment operator +({{el.csUpperName}} unary) => unary;
+                                public static HtmlFragment operator +({{el.csUpperName}} head, HtmlFragment tail) => HtmlFragment.Fragment(HtmlFragment.Element(head), tail);
+                                public static HtmlFragment operator +(string head, {{el.csUpperName}} tail) => HtmlFragment.Fragment(head, HtmlFragment.Element(tail));
+                            }
+                        """
                         : $$"""
-                            
-                                public struct {{el.csUpperName}} : IHtmlElementAllowingContent<{{el.csUpperName}}>{{el.attributes.Select(attrName => $", IHasAttr_{toClassName(attrName)}").JoinStrings("")}}
-                                {
-                                    public string TagName => "{{el.elementName}}";
-                                    string IHtmlElement.TagStart => "<{{el.elementName}}";
-                                    string IHtmlElement.EndTag => "</{{el.elementName}}>";
-                                    ReadOnlySpan<byte> IHtmlElement.TagStartUtf8 => "<{{el.elementName}}"u8;
-                                    ReadOnlySpan<byte> IHtmlElement.EndTagUtf8 => "</{{el.elementName}}>"u8;
-                                    public bool ContainsUnescapedText => {{(el.elementName is "script" or "style" ? "true" : "false")}};
-                                    HtmlAttributes attrs;
-                                    {{el.csUpperName}} IHtmlElement<{{el.csUpperName}}>.ReplaceAttributesWith(HtmlAttributes replacementAttributes) => new {{el.csUpperName}} { attrs = replacementAttributes, children = children };
-                                    HtmlAttributes IHtmlElement.Attributes => attrs;
-                                    HtmlFragment children;
-                                    {{el.csUpperName}} IHtmlElementAllowingContent<{{el.csUpperName}}>.ReplaceContentWith(HtmlFragment replacementContents) => new {{el.csUpperName}} { attrs = attrs, children = replacementContents };
-                                    HtmlFragment IHtmlElementAllowingContent.GetContent() => children;
-                                    IHtmlElement IHtmlElement.ApplyAlteration<THtmlTagAlteration>(THtmlTagAlteration change) => change.AlterElementAllowingContent(this);
-                                    [Pure] public HtmlFragment AsFragment() => HtmlFragment.Element(this);
-                                    public static implicit operator HtmlFragment({{el.csUpperName}} tag) => tag.AsFragment();
-                                    public static HtmlFragment operator +({{el.csUpperName}} unary) => unary;
-                                    public static HtmlFragment operator +({{el.csUpperName}} head, HtmlFragment tail) => HtmlFragment.Fragment(HtmlFragment.Element(head), tail);
-                                    public static HtmlFragment operator +(string head, {{el.csUpperName}} tail) => HtmlFragment.Fragment(head, HtmlFragment.Element(tail));
-                                }
-                            """
+                        
+                            public struct {{el.csUpperName}} : IHtmlElementAllowingContent<{{el.csUpperName}}>{{el.attributes.Select(attrName => $", IHasAttr_{toClassName(attrName)}").JoinStrings("")}}
+                            {
+                                public string TagName => "{{el.elementName}}";
+                                string IHtmlElement.TagStart => "<{{el.elementName}}";
+                                string IHtmlElement.EndTag => "</{{el.elementName}}>";
+                                ReadOnlySpan<byte> IHtmlElement.TagStartUtf8 => "<{{el.elementName}}"u8;
+                                ReadOnlySpan<byte> IHtmlElement.EndTagUtf8 => "</{{el.elementName}}>"u8;
+                                public bool ContainsUnescapedText => {{(el.elementName is "script" or "style" ? "true" : "false")}};
+                                HtmlAttributes attrs;
+                                {{el.csUpperName}} IHtmlElement<{{el.csUpperName}}>.ReplaceAttributesWith(HtmlAttributes replacementAttributes) => new {{el.csUpperName}} { attrs = replacementAttributes, children = children };
+                                HtmlAttributes IHtmlElement.Attributes => attrs;
+                                HtmlFragment children;
+                                {{el.csUpperName}} IHtmlElementAllowingContent<{{el.csUpperName}}>.ReplaceContentWith(HtmlFragment replacementContents) => new {{el.csUpperName}} { attrs = attrs, children = replacementContents };
+                                HtmlFragment IHtmlElementAllowingContent.GetContent() => children;
+                                IHtmlElement IHtmlElement.ApplyAlteration<THtmlTagAlteration>(THtmlTagAlteration change) => change.AlterElementAllowingContent(this);
+                                [Pure] public HtmlFragment AsFragment() => HtmlFragment.Element(this);
+                                public static implicit operator HtmlFragment({{el.csUpperName}} tag) => tag.AsFragment();
+                                public static HtmlFragment operator +({{el.csUpperName}} unary) => unary;
+                                public static HtmlFragment operator +({{el.csUpperName}} head, HtmlFragment tail) => HtmlFragment.Fragment(HtmlFragment.Element(head), tail);
+                                public static HtmlFragment operator +(string head, {{el.csUpperName}} tail) => HtmlFragment.Fragment(head, HtmlFragment.Element(tail));
+                            }
+                        """
             );
 
         var elFields = elements
@@ -213,53 +213,53 @@ public sealed class HtmlDslGenerator
             AssertFileExistsAndApproveContent(
                 HtmlTagKinds_GeneratedOutputFilePath,
                 $$"""
-            #nullable enable
-            using ProgressOnderwijsUtils.Html.AttributeNameInterfaces;
+                #nullable enable
+                using ProgressOnderwijsUtils.Html.AttributeNameInterfaces;
 
-            namespace ProgressOnderwijsUtils.Html;
+                namespace ProgressOnderwijsUtils.Html;
 
-            public static class HtmlTagKinds
-            {{{elTagNameClasses.JoinStrings("")}}
-            }
+                public static class HtmlTagKinds
+                {{{elTagNameClasses.JoinStrings("")}}
+                }
 
-            """
+                """
             ),
 
             AssertFileExistsAndApproveContent(
                 HtmlTags_GeneratedOutputFilePath,
                 $$"""
-            #nullable enable
-            namespace ProgressOnderwijsUtils.Html;
+                #nullable enable
+                namespace ProgressOnderwijsUtils.Html;
 
-            public static class Tags
-            {{{elFields.JoinStrings("")}}}
+                public static class Tags
+                {{{elFields.JoinStrings("")}}}
 
-            """
+                """
             ),
 
             AssertFileExistsAndApproveContent(
                 AttributeNameInterfaces_GeneratedOutputFilePath,
                 $$"""
-            #nullable enable
-            namespace ProgressOnderwijsUtils.Html.AttributeNameInterfaces;
+                #nullable enable
+                namespace ProgressOnderwijsUtils.Html.AttributeNameInterfaces;
 
-            {{elAttrInterfaces.JoinStrings("")}}
-            """
+                {{elAttrInterfaces.JoinStrings("")}}
+                """
             ),
 
             AssertFileExistsAndApproveContent(
                 AttributeConstructionMethods_GeneratedOutputFilePath,
                 $$"""
-            #nullable enable
-            using ProgressOnderwijsUtils.Html.AttributeNameInterfaces;
+                #nullable enable
+                using ProgressOnderwijsUtils.Html.AttributeNameInterfaces;
 
-            namespace ProgressOnderwijsUtils.Html;
+                namespace ProgressOnderwijsUtils.Html;
 
-            public static class AttributeConstructionMethods
-            {{{globalAttributeExtensionMethods.JoinStrings("")}}{{elAttrExtensionMethods.JoinStrings("")}}
-            }
+                public static class AttributeConstructionMethods
+                {{{globalAttributeExtensionMethods.JoinStrings("")}}{{elAttrExtensionMethods.JoinStrings("")}}
+                }
 
-            """
+                """
             ),
         }.WhereNotNull().ToArray();
 

--- a/test/ProgressOnderwijsUtils.Tests/HtmlDslGenerator.cs
+++ b/test/ProgressOnderwijsUtils.Tests/HtmlDslGenerator.cs
@@ -141,7 +141,7 @@ public sealed class HtmlDslGenerator
         var elAttrExtensionMethods = specificAttributes
             .Select(
                 attrName => $"""
-
+                    
                         public static THtmlTag _{toClassName(attrName)}<THtmlTag>(this THtmlTag htmlTagExpr, string? attrValue)
                             where THtmlTag : struct, IHasAttr_{toClassName(attrName)}, IHtmlElement<THtmlTag>
                             => htmlTagExpr.Attribute("{attrName}", attrValue);

--- a/test/ProgressOnderwijsUtils.Tests/HtmlTests.cs
+++ b/test/ProgressOnderwijsUtils.Tests/HtmlTests.cs
@@ -139,7 +139,7 @@ public sealed class HtmlTests
     public void StringIsEquivalentToStreamOutput()
     {
         var html = WikiPageHtml5.MakeHtml();
-        var htmlToString =  html.ToStringWithDoctype();
+        var htmlToString = html.ToStringWithDoctype();
         using var ms = new MemoryStream();
         html.SaveHtmlFragmentToStream(ms, StringUtils.Utf8WithoutBom);
         var htmlToStreamToString = StringUtils.Utf8WithoutBom.GetString(ms.ToArray());
@@ -150,7 +150,7 @@ public sealed class HtmlTests
     public void StringIsEquivalentToPipeOutput()
     {
         var html = WikiPageHtml5.MakeHtml();
-        var htmlToString =  html.ToStringWithDoctype();
+        var htmlToString = html.ToStringWithDoctype();
         var ms = new Pipe();
         html.SaveHtmlFragmentToPipe(ms.Writer);
         ms.Writer.Complete();

--- a/test/ProgressOnderwijsUtils.Tests/HtmlTests.cs
+++ b/test/ProgressOnderwijsUtils.Tests/HtmlTests.cs
@@ -159,5 +159,4 @@ public sealed class HtmlTests
         var htmlToPipeToString = textReader.ReadToEnd();
         PAssert.That(() => htmlToString == htmlToPipeToString);
     }
-
 }

--- a/test/ProgressOnderwijsUtils.Tests/TreeWhereTest.cs
+++ b/test/ProgressOnderwijsUtils.Tests/TreeWhereTest.cs
@@ -42,8 +42,10 @@ public sealed class TreeWhereTest
             Tree.Node("3"),
             Tree.Node(
                 "y",
-                Tree.Node("4",
-                Tree.Node("5")),
+                Tree.Node(
+                    "4",
+                    Tree.Node("5")
+                ),
                 Tree.Node(
                     "x",
                     Tree.Node("ee"),

--- a/test/ProgressOnderwijsUtils.Tests/WikiPageHtml5.cs
+++ b/test/ProgressOnderwijsUtils.Tests/WikiPageHtml5.cs
@@ -191,7 +191,6 @@ public static class WikiPageHtml5
         css_wikitable = new CssClass("wikitable"),
         css_Z3988 = new CssClass("Z3988");
 
-
     public static HtmlFragment MakeHtml()
         => _html._class(css_client_nojs)
             ._lang("en")

--- a/tools/ProgressOnderwijsUtilsBenchmarks/ArrayBuilderBenchmark.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/ArrayBuilderBenchmark.cs
@@ -1,4 +1,5 @@
 // ReSharper disable ClassCanBeSealed.Global  - for Benchmark.NET
+
 namespace ProgressOnderwijsUtilsBenchmarks;
 
 public interface IFactory<out T>

--- a/tools/ProgressOnderwijsUtilsBenchmarks/ArrayBuilderBenchmark.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/ArrayBuilderBenchmark.cs
@@ -114,7 +114,7 @@ public abstract class ArrayBuilderBenchmark<T, TFactory>
     static int[] GetSizes(int count, int maxSize)
     {
         var r = new Random(42);
-        return Enumerable.Range(0, count + 1).Select(i => (int)(i / (double)count * maxSize + 0.5)).OrderBy(_=>r.Next()).ToArray();
+        return Enumerable.Range(0, count + 1).Select(i => (int)(i / (double)count * maxSize + 0.5)).OrderBy(_ => r.Next()).ToArray();
     }
 
     [Benchmark]

--- a/tools/ProgressOnderwijsUtilsBenchmarks/BenchmarkProgram.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/BenchmarkProgram.cs
@@ -5,12 +5,12 @@ namespace ProgressOnderwijsUtilsBenchmarks;
 public static class BenchmarkProgram
 {
     static void Main()
-         => RunTreeBenchmarks();
-        //=> MicroOrmBenchmarkProgram.RunBenchmarks();
-        //=> RunArrayBuilderBenchmarks();
-        //=> BenchmarkRunner.Run<SmallBatchInsertBench>();
-        //=> BenchmarkRunner.Run<NullabilityBenchmark>();
-        //=> BenchmarkRunner.Run<RandomHelperBenchmark>();
+        => RunTreeBenchmarks();
+    //=> MicroOrmBenchmarkProgram.RunBenchmarks();
+    //=> RunArrayBuilderBenchmarks();
+    //=> BenchmarkRunner.Run<SmallBatchInsertBench>();
+    //=> BenchmarkRunner.Run<NullabilityBenchmark>();
+    //=> BenchmarkRunner.Run<RandomHelperBenchmark>();
 
     [UsedImplicitly]
     static void RunArrayBuilderBenchmarks()

--- a/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/ExampleObject.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/ExampleObject.cs
@@ -11,22 +11,22 @@ public sealed class ExampleObject : IWrittenImplicitly
     public int E { get; set; }
     public long Arg { get; set; }
 
-    static readonly FormattableString formattableQueryString = $@"
-            select top ({0}) 
-                a.x+{2} as a
-                , b.x as b
-                , c.x as c
-                , d.x as d
-                , e.x as e
-                , {default(long)} as Arg
-            from       (select 0 as x union all select 1 union all select null) a
-            cross join (select 0 as x union all select 1 union all select 2) b
-            cross join (select N'abracadabra fee fi fo fum' as x union all select {"hehe"} union all select N'quick brown fox') c
-            cross join (select cast(1 as bit) as x union all select cast(0 as bit) union all select null) d
-            cross join (select 0 as x union all select 1 union all select 2) e
-            cross join (select 0 as x union all select 1 union all select 2 union all select 3) f
-            cross join (select 0 as x union all select 1 union all select 2 union all select 3) g
-        ";
+    static readonly FormattableString formattableQueryString = $"""
+        select top ({0}) 
+            a.x+{2} as a
+            , b.x as b
+            , c.x as c
+            , d.x as d
+            , e.x as e
+            , {default(long)} as Arg
+        from       (select 0 as x union all select 1 union all select null) a
+        cross join (select 0 as x union all select 1 union all select 2) b
+        cross join (select N'abracadabra fee fi fo fum' as x union all select {"hehe"} union all select N'quick brown fox') c
+        cross join (select cast(1 as bit) as x union all select cast(0 as bit) union all select null) d
+        cross join (select 0 as x union all select 1 union all select 2) e
+        cross join (select 0 as x union all select 1 union all select 2 union all select 3) f
+        cross join (select 0 as x union all select 1 union all select 2 union all select 3) g
+        """;
 
     static readonly string formatString = formattableQueryString.Format;
     public static readonly string RawQueryString = string.Format(formatString, "@Top", "@Num2", "@Arg", "@Hehe");
@@ -37,17 +37,17 @@ public sealed class ExampleObject : IWrittenImplicitly
     public static FormattableString InterpolatedQuery(int rows)
         => FormattableStringFactory.Create(formatString, rows, 2, someInt64Value, "hehe");
 
-    static readonly FormattableString formattableSqliteQueryString = $@"
-            select
-                ex.a + {2} as a
-                , ex.b
-                , coalesce(ex.c, {"hehe"}) as c
-                , ex.d
-                , ex.e
-                , {default(long)} as Arg
-            from example ex
-            limit {0}
-        ";
+    static readonly FormattableString formattableSqliteQueryString = $"""
+        select
+            ex.a + {2} as a
+            , ex.b
+            , coalesce(ex.c, {"hehe"}) as c
+            , ex.d
+            , ex.e
+            , {default(long)} as Arg
+        from example ex
+        limit {0}
+        """;
 
     static readonly string formatSqliteString = formattableSqliteQueryString.Format;
     public static readonly string RawSqliteQueryString = string.Format(formatSqliteString, "@Num2", "@Hehe", "@Arg", "@Top");

--- a/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/ExampleObject.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/ExampleObject.cs
@@ -4,6 +4,7 @@ public sealed class ExampleObject : IWrittenImplicitly
 {
     public int? A { get; set; }
     public int B { get; set; }
+
     // ReSharper disable once EntityFramework.ModelValidation.UnlimitedStringLength
     public string? C { get; set; }
     public bool? D { get; set; }

--- a/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/WideExampleObject.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/WideExampleObject.cs
@@ -1,4 +1,5 @@
 // ReSharper disable EntityFramework.ModelValidation.UnlimitedStringLength
+
 namespace ProgressOnderwijsUtilsBenchmarks.MicroOrmBench;
 
 public sealed class WideExampleObject : IWrittenImplicitly

--- a/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/WideExampleObject.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/WideExampleObject.cs
@@ -31,38 +31,39 @@ public sealed class WideExampleObject : IWrittenImplicitly
     public int? TerritoryId { get; set; }
     public decimal TotalDue { get; set; }
 
-    static readonly FormattableString formattableQueryString = $@"
-                SELECT top ({1})
-                    SalesOrderID,RevisionNumber,OrderDate,DueDate,ShipDate,Status,OnlineOrderFlag,SalesOrderNumber,PurchaseOrderNumber,AccountNumber
-                    ,CustomerID,SalesPersonID,TerritoryID,BillToAddressID,ShipToAddressID,ShipMethodID,CreditCardID,CreditCardApprovalCode,CurrencyRateID
-                    ,SubTotal,TaxAmt,Freight,TotalDue,Comment,rowguid,ModifiedDate	
-                from (select SalesOrderID = 13 union all select 14) a01
-                cross join(select AccountNumber = N'abracadabra fee fi fo fum' union all select N'abcdef') a02
-                cross join (select BillToAddressId = 0 union all select 1) a03
-                cross join(select Comment = N'abracadabra fee fi fo fum' union all select null) a04
-                cross join(select CreditCardApprovalCode = N'abracadabra fee fi fo fum' union all select null) a05
-                cross join(select CreditCardId = 42 union all select null ) a06
-                cross join(select CurrencyRateId = 37 union all select null ) a07
-                cross join(select CustomerId = 37 union all select 38 ) a08
-                cross join(select DueDate = cast('2014-01-02' as datetime2) union all select cast('2014-01-03' as datetime2)) a09
-                cross join(select Freight = cast(1.1 as decimal(18,2)) union all select cast(1.1 as decimal(18,2))) a10
-                cross join(select ModifiedDate = cast('2014-01-02' as datetime2) union all select cast('2014-01-03' as datetime2)) a11
-                cross join(select OnlineOrderFlag = cast(1 as bit) union all select cast(0 as bit)) a12
-                cross join(select OrderDate = cast('2014-01-02' as datetime2) union all select cast('2014-01-03' as datetime2)) a13
-                cross join(select PurchaseOrderNumber = N'blablablabla' union all select N'fizzbuzzqwerp') a14
-                cross join(select RevisionNumber = cast(1 as tinyint) union all select cast(10 as tinyint)) a15    
-                cross join(select Rowguid = NEWID ( )) a16
-                cross join(select SalesOrderNumber = N'blablablabla' union all select N'fizzbuzzqwerp') a17
-                cross join(select SalesPersonId = 37 union all select null ) a18
-                cross join(select ShipDate = cast('2014-01-02' as datetime2) union all select null) a19
-                cross join(select ShipMethodId = 0 union all select 1) a20
-                cross join(select ShipToAddressId = 0 union all select 1) a21
-                cross join(select Status = cast(1 as tinyint) union all select cast(10 as tinyint)) a22
-                cross join(select SubTotal = cast(1.1 as decimal(18,2)) union all select cast(1.1 as decimal(18,2))) a23
-                cross join(select TaxAmt = cast(1.1 as decimal(18,2)) union all select cast(1.1 as decimal(18,2))) a24
-                cross join(select TerritoryId = 37 union all select null ) a25
-                cross join(select TotalDue = cast(1.1 as decimal(18,2)) union all select cast(1.1 as decimal(18,2))) a26
-            ";
+    static readonly FormattableString formattableQueryString = $"""
+        select top ({1})
+            SalesOrderID,RevisionNumber,OrderDate,DueDate,ShipDate,Status,OnlineOrderFlag,SalesOrderNumber,PurchaseOrderNumber,AccountNumber
+            ,CustomerID,SalesPersonID,TerritoryID,BillToAddressID,ShipToAddressID,ShipMethodID,CreditCardID,CreditCardApprovalCode,CurrencyRateID
+            ,SubTotal,TaxAmt,Freight,TotalDue,Comment,rowguid,ModifiedDate	
+        from (select SalesOrderID = 13 union all select 14) a01
+        cross join(select AccountNumber = N'abracadabra fee fi fo fum' union all select N'abcdef') a02
+        cross join (select BillToAddressId = 0 union all select 1) a03
+        cross join(select Comment = N'abracadabra fee fi fo fum' union all select null) a04
+        cross join(select CreditCardApprovalCode = N'abracadabra fee fi fo fum' union all select null) a05
+        cross join(select CreditCardId = 42 union all select null ) a06
+        cross join(select CurrencyRateId = 37 union all select null ) a07
+        cross join(select CustomerId = 37 union all select 38 ) a08
+        cross join(select DueDate = cast('2014-01-02' as datetime2) union all select cast('2014-01-03' as datetime2)) a09
+        cross join(select Freight = cast(1.1 as decimal(18,2)) union all select cast(1.1 as decimal(18,2))) a10
+        cross join(select ModifiedDate = cast('2014-01-02' as datetime2) union all select cast('2014-01-03' as datetime2)) a11
+        cross join(select OnlineOrderFlag = cast(1 as bit) union all select cast(0 as bit)) a12
+        cross join(select OrderDate = cast('2014-01-02' as datetime2) union all select cast('2014-01-03' as datetime2)) a13
+        cross join(select PurchaseOrderNumber = N'blablablabla' union all select N'fizzbuzzqwerp') a14
+        cross join(select RevisionNumber = cast(1 as tinyint) union all select cast(10 as tinyint)) a15    
+        cross join(select Rowguid = NEWID ( )) a16
+        cross join(select SalesOrderNumber = N'blablablabla' union all select N'fizzbuzzqwerp') a17
+        cross join(select SalesPersonId = 37 union all select null ) a18
+        cross join(select ShipDate = cast('2014-01-02' as datetime2) union all select null) a19
+        cross join(select ShipMethodId = 0 union all select 1) a20
+        cross join(select ShipToAddressId = 0 union all select 1) a21
+        cross join(select Status = cast(1 as tinyint) union all select cast(10 as tinyint)) a22
+        cross join(select SubTotal = cast(1.1 as decimal(18,2)) union all select cast(1.1 as decimal(18,2))) a23
+        cross join(select TaxAmt = cast(1.1 as decimal(18,2)) union all select cast(1.1 as decimal(18,2))) a24
+        cross join(select TerritoryId = 37 union all select null ) a25
+        cross join(select TotalDue = cast(1.1 as decimal(18,2)) union all select cast(1.1 as decimal(18,2))) a26
+
+        """;
 
     static readonly string formatString = formattableQueryString.Format;
     public static readonly string RawQueryString = string.Format(formatString, "@Top");

--- a/tools/ProgressOnderwijsUtilsBenchmarks/NullabilityVerifierBenchmark/NonNullableFieldVerifier0.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/NullabilityVerifierBenchmark/NonNullableFieldVerifier0.cs
@@ -15,7 +15,7 @@ public static class NonNullableFieldVerifier0
         statements.Add(Expression.Assign(exceptionVar, Expression.Constant("")));
 
         NullabilityInfoContext context = new();
-        var fields = typeof(T).GetFields(BindingFlags.NonPublic|BindingFlags.Public |BindingFlags.Instance)
+        var fields = typeof(T).GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
             .Where(f => context.Create(f).WriteState == NullabilityState.NotNull)
             .ToArray();
         var concatCall = ((Func<string, string, string>)string.Concat).Method;

--- a/tools/ProgressOnderwijsUtilsBenchmarks/NullabilityVerifierBenchmark/NonNullableFieldVerifier1.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/NullabilityVerifierBenchmark/NonNullableFieldVerifier1.cs
@@ -20,7 +20,7 @@ public static class NonNullableFieldVerifier1
         NullabilityInfoContext context = new();
         var concatCall = ((Func<string, string, string>)string.Concat).Method;
 
-        var fields = typeof(T).GetFields(BindingFlags.NonPublic|BindingFlags.Public |BindingFlags.Instance)
+        var fields = typeof(T).GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
             .Where(f => context.Create(f).WriteState == NullabilityState.NotNull)
             .ToArray();
         statements.AddRange(
@@ -61,7 +61,7 @@ public static class NonNullableFieldVerifier1
             ))
         );
         statements.Add(exceptionList);
-        var ToLambda = Expression.Lambda<Func<T, string[]?>>(Expression.Block(new[] {exception, exceptionList, }, statements), objectParam);
+        var ToLambda = Expression.Lambda<Func<T, string[]?>>(Expression.Block(new[] { exception, exceptionList, }, statements), objectParam);
         return ToLambda.Compile();
     }
 }

--- a/tools/ProgressOnderwijsUtilsBenchmarks/NullabilityVerifierBenchmark/NonNullableFieldVerifier1.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/NullabilityVerifierBenchmark/NonNullableFieldVerifier1.cs
@@ -7,8 +7,8 @@ namespace ProgressOnderwijsUtilsBenchmarks.NullabilityVerifierBenchmark;
 
 public static class NonNullableFieldVerifier1
 {
-
     static readonly Func<string, StringSplitOptions, string[]> x = "".Split;
+
     //string split
     public static Func<T, string[]?> MissingRequiredProperties_FuncFactory<T>()
     {

--- a/tools/ProgressOnderwijsUtilsBenchmarks/NullabilityVerifierBenchmark/NonNullableFieldVerifier2.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/NullabilityVerifierBenchmark/NonNullableFieldVerifier2.cs
@@ -18,7 +18,7 @@ public static class NonNullableFieldVerifier2
 
         NullabilityInfoContext context = new();
 
-        var fields = typeof(T).GetFields(BindingFlags.NonPublic|BindingFlags.Public |BindingFlags.Instance)
+        var fields = typeof(T).GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
             .Where(f => context.Create(f).WriteState == NullabilityState.NotNull)
             .ToArray();
         var count = fields.Length;

--- a/tools/ProgressOnderwijsUtilsBenchmarks/NullabilityVerifierBenchmark/NonNullableFieldVerifier3.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/NullabilityVerifierBenchmark/NonNullableFieldVerifier3.cs
@@ -18,7 +18,7 @@ public static class NonNullableFieldVerifier3
 
         NullabilityInfoContext context = new();
 
-        var fields = typeof(T).GetFields(BindingFlags.NonPublic|BindingFlags.Public |BindingFlags.Instance)
+        var fields = typeof(T).GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
             .Where(f => context.Create(f).WriteState == NullabilityState.NotNull)
             .ToArray();
 

--- a/tools/ProgressOnderwijsUtilsBenchmarks/NullabilityVerifierBenchmark/NonNullableFieldVerifier5.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/NullabilityVerifierBenchmark/NonNullableFieldVerifier5.cs
@@ -14,7 +14,7 @@ public static class NonNullableFieldVerifier5
         var exception = Expression.Variable(typeof(string[]), "exception");
 
         NullabilityInfoContext context = new();
-        var fields = typeof(T).GetFields(BindingFlags.NonPublic|BindingFlags.Public |BindingFlags.Instance)
+        var fields = typeof(T).GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
             .Where(f => context.Create(f).WriteState == NullabilityState.NotNull)
             .ToArray();
 

--- a/tools/ProgressOnderwijsUtilsBenchmarks/NullabilityVerifierBenchmark/NonNullableFieldVerifier5.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/NullabilityVerifierBenchmark/NonNullableFieldVerifier5.cs
@@ -5,7 +5,6 @@ using static ProgressOnderwijsUtils.BackingFieldDetector;
 
 namespace ProgressOnderwijsUtilsBenchmarks.NullabilityVerifierBenchmark;
 
-
 public static class NonNullableFieldVerifier5
 {
     public static Func<T, string[]?> MissingRequiredProperties_FuncFactory<T>()


### PR DESCRIPTION
I'd advise a review via [?w=1](https://github.com/progressonderwijs/ProgressOnderwijsUtils/pull/1102/files?w=1) because the autoformat changed a bunch of indents, and the raw-string syntax does too.