### PR TITLE
Dust off the micro ORM bench

### DIFF
--- a/tools/ProgressOnderwijsUtilsBenchmarks/BenchmarkProgram.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/BenchmarkProgram.cs
@@ -1,12 +1,13 @@
 using BenchmarkDotNet.Running;
+using ProgressOnderwijsUtilsBenchmarks.MicroOrmBench;
 
 namespace ProgressOnderwijsUtilsBenchmarks;
 
 public static class BenchmarkProgram
 {
     static void Main()
-        => RunTreeBenchmarks();
-    //=> MicroOrmBenchmarkProgram.RunBenchmarks();
+        //=> RunTreeBenchmarks();
+    => MicroOrmBenchmarkProgram.RunBenchmarks();
     //=> RunArrayBuilderBenchmarks();
     //=> BenchmarkRunner.Run<SmallBatchInsertBench>();
     //=> BenchmarkRunner.Run<NullabilityBenchmark>();

--- a/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/BenchmarkUtil.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/BenchmarkUtil.cs
@@ -110,7 +110,7 @@ sealed class Benchmarker
         var initialGen1 = GC.CollectionCount(1);
         var initialGen2 = GC.CollectionCount(2);
         var elapsed = new List<double>();
-        long ignore = 0;
+        long rowsum = 0;
         var latencyDistribution = MeanVarianceAccumulator.Empty;
         for (var k = 0L; k < Tries; k++) {
             var i = 0;
@@ -126,7 +126,7 @@ sealed class Benchmarker
                     swInner.Restart();
                     var val = action(conn, IndexToRowCount(localI));
                     latencies = latencies.Add(swInner.Elapsed.TotalMilliseconds);
-                    Interlocked.Add(ref ignore, val);
+                    Interlocked.Add(ref rowsum, val);
                 }
                 return latencies;
             };
@@ -150,7 +150,7 @@ sealed class Benchmarker
         Output(
             $"{mean / IterationsPerTry:f1}μs ~ {stddev / IterationsPerTry:f2}μs parallel;" +
             $"{latencyDistribution.Mean * 1000:f0}μs ~ {latencyDistribution.SampleStandardDeviation * 1000:f1}μs latency;" +
-            $" {gen0 * scale:f2}/{gen1 * scale:f2}/{gen2 * scale:f2} milliGC;  {name}  {ignore}"
+            $" {gen0 * scale:f2}/{gen1 * scale:f2}/{gen2 * scale:f2} milliGC;  {name}  checksum:{rowsum}"
         );
     }
 

--- a/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/BenchmarkUtil.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/BenchmarkUtil.cs
@@ -93,24 +93,24 @@ sealed class Benchmarker
             sqliteConn.Open();
 
             _ = sqliteConn.Query<ExampleObject>(
-                @"
-                    create table example (key INTEGER PRIMARY KEY, a int null, b int not null, c TEXT, d BOOLEAN null, e int not null);
-
-                    insert into example (a,b,c,d,e)
-                    select
-                        a.x as a
-                        , b.x as b
-                        , c.x as c
-                        , d.x as d
-                        , e.x as e
-                    from       (select 0 as x union all select 1 union all select null) a
-                    cross join (select 0 as x union all select 1 union all select 2) b
-                    cross join (select 'abracadabra fee fi fo fum' as x union all select null union all select 'quick brown fox') c
-                    cross join(select cast(1 as bit) as x union all select cast(0 as bit) union all select null) d
-                    cross join(select 0 as x union all select 1 union all select 2) e
-                    cross join(select 0 as x union all select 1 union all select 2 union all select 3) f
-                    cross join(select 0 as x union all select 1 union all select 2 union all select 3) g
-                "
+                """
+                create table example (key INTEGER PRIMARY KEY, a int null, b int not null, c TEXT, d BOOLEAN null, e int not null);
+                
+                insert into example (a,b,c,d,e)
+                select
+                    a.x as a
+                    , b.x as b
+                    , c.x as c
+                    , d.x as d
+                    , e.x as e
+                from       (select 0 as x union all select 1 union all select null) a
+                cross join (select 0 as x union all select 1 union all select 2) b
+                cross join (select 'abracadabra fee fi fo fum' as x union all select null union all select 'quick brown fox') c
+                cross join(select cast(1 as bit) as x union all select cast(0 as bit) union all select null) d
+                cross join(select 0 as x union all select 1 union all select 2) e
+                cross join(select 0 as x union all select 1 union all select 2 union all select 3) f
+                cross join(select 0 as x union all select 1 union all select 2 union all select 3) g
+                """
             );
             ok = true;
             return sqliteConn;

--- a/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/BenchmarkUtil.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/BenchmarkUtil.cs
@@ -92,27 +92,7 @@ sealed class Benchmarker
         var ok = false;
         try {
             sqliteConn.Open();
-
-            _ = sqliteConn.Query<ExampleObject>(
-                """
-                create table example (key INTEGER PRIMARY KEY, a int null, b int not null, c TEXT, d BOOLEAN null, e int not null);
-                
-                insert into example (a,b,c,d,e)
-                select
-                    a.x as a
-                    , b.x as b
-                    , c.x as c
-                    , d.x as d
-                    , e.x as e
-                from       (select 0 as x union all select 1 union all select null) a
-                cross join (select 0 as x union all select 1 union all select 2) b
-                cross join (select 'abracadabra fee fi fo fum' as x union all select null union all select 'quick brown fox') c
-                cross join(select cast(1 as bit) as x union all select cast(0 as bit) union all select null) d
-                cross join(select 0 as x union all select 1 union all select 2) e
-                cross join(select 0 as x union all select 1 union all select 2 union all select 3) f
-                cross join(select 0 as x union all select 1 union all select 2 union all select 3) g
-                """
-            );
+            ExampleObject.PrefillExampleTable(sqliteConn);
             ok = true;
             return sqliteConn;
         } finally {

--- a/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/BenchmarkUtil.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/BenchmarkUtil.cs
@@ -155,7 +155,7 @@ sealed class Benchmarker
                 elapsed.Add(sw.Elapsed.TotalMilliseconds * 1000.0);
                 latencyDistribution = latencyDistribution.Add(innerLatencyDistribution);
 #else
-            var tasks = Enumerable.Range(0, Environment.ProcessorCount).Select(_ => Task.Factory.StartNew(ExecuteBenchLoop, TaskCreationOptions.LongRunning)).ToArray();
+            var tasks = Enumerable.Range(0, Environment.ProcessorCount + 1 >> 1).Select(_ => Task.Factory.StartNew(ExecuteBenchLoop, TaskCreationOptions.LongRunning)).ToArray();
             Task.WaitAll(tasks);
             elapsed.Add(sw.Elapsed.TotalMilliseconds * 1000.0);
             foreach (var task in tasks) {

--- a/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/BenchmarkUtil.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/BenchmarkUtil.cs
@@ -60,7 +60,7 @@ sealed class Benchmarker
             ParameterizedSql.TableValuedTypeDefinitionScripts.ExecuteNonQuery(sqlConn);
         }
 
-        Bench(name, () => new EntityFrameworkBench(CreateSqlConnection()), action);
+        Bench(name, () => new(CreateSqlConnection()), action);
     }
 
     public void BenchSQLite(string name, Func<SQLiteConnection, int, int> action)

--- a/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/BenchmarkUtil.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/BenchmarkUtil.cs
@@ -37,12 +37,13 @@ sealed class Benchmarker
 
         Output($"Testing {Tries} groups of {IterationsPerTry} queries with {rowCounts.Min()}-{rowCounts.Max()} rows");
         Output(
-            $"median: {rowCounts.OrderBy(x => x).Skip((IterationsPerTry - 1) / 2).Take(2).Average()}; "
-            + $"mean: {rowCounts.Average():f2}; "
-            + $"{rowCounts.Count(x => x == 0) * 100.0 / IterationsPerTry:f2}% 0; "
-            + $"{rowCounts.Count(x => x == 1) * 100.0 / IterationsPerTry:f2}% 1; "
-            + $"{rowCounts.Count(x => x < 50) * 100.0 / IterationsPerTry:f2}% <50; "
+            $"Row-count median: {rowCounts.OrderBy(x => x).Skip((IterationsPerTry - 1) / 2).Take(2).Average()}; "
+            + $"mean: {rowCounts.Average():f1}; "
+            + $"0 rows: {rowCounts.Count(x => x == 0) * 100.0 / IterationsPerTry:f2}%; "
+            + $"1 row: {rowCounts.Count(x => x == 1) * 100.0 / IterationsPerTry:f2}%; "
+            + $"<50 rows: {rowCounts.Count(x => x < 50) * 100.0 / IterationsPerTry:f2}% <50"
         );
+        Output($"Reporting time per query execution; parallel executions use {ThreadCount} threads");
     }
 
     public void BenchSqlServer(string name, Func<SqlConnection, int, int> action)
@@ -167,9 +168,9 @@ sealed class Benchmarker
         var stddev = Math.Sqrt(variance);
         var scale = 1000.0 / (Tries * IterationsPerTry);
         Output(
-            $"{mean / IterationsPerTry:f2}μs ~ {stddev / IterationsPerTry:f2}μs overall;" +
-            $"{latencyDistribution.Mean * 1000:f2}μs ~ {latencyDistribution.SampleStandardDeviation * 1000:f2}μs latency;" +
-            $" {gen0 * scale:f4}/{gen1 * scale:f4}/{gen2 * scale:f4} milliGC;  {name}  {ignore}"
+            $"{mean / IterationsPerTry:f1}μs ~ {stddev / IterationsPerTry:f2}μs parallel;" +
+            $"{latencyDistribution.Mean * 1000:f0}μs ~ {latencyDistribution.SampleStandardDeviation * 1000:f1}μs latency;" +
+            $" {gen0 * scale:f2}/{gen1 * scale:f2}/{gen2 * scale:f2} milliGC;  {name}  {ignore}"
         );
     }
 

--- a/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/DapperBench.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/DapperBench.cs
@@ -6,16 +6,15 @@ static class DapperExecutor
 {
     public static void RunQuery(Benchmarker benchmarker)
     {
-        benchmarker.BenchSQLite(
-            "Dapper (sqlite)",
-            (sqlConn, rows) =>
-                sqlConn.Query<ExampleObject>(ExampleObject.RawSqliteQueryString, new { Arg = ExampleObject.someInt64Value, Top = rows, Num2 = 2, Hehe = "hehe", }).Count()
-        );
-
         benchmarker.BenchSqlServer(
             "Dapper",
             (sqlConn, rows) =>
                 sqlConn.Query<ExampleObject>(ExampleObject.RawQueryString, new { Arg = ExampleObject.someInt64Value, Top = rows, Num2 = 2, Hehe = "hehe", }).Count()
+        );
+        benchmarker.BenchSQLite(
+            "Dapper (sqlite)",
+            (sqlConn, rows) =>
+                sqlConn.Query<ExampleObject>(ExampleObject.RawSqliteQueryString, new { Arg = ExampleObject.someInt64Value, Top = rows, Num2 = 2, Hehe = "hehe", }).Count()
         );
     }
 

--- a/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/EntityFrameworkBench.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/EntityFrameworkBench.cs
@@ -26,29 +26,29 @@ sealed class EntityFrameworkBench : DbContext
 
     public static void RunQuery(Benchmarker benchmarker)
     {
-        benchmarker.BenchEFSqlServer(
-            "EF (reused context)",
-            (ctx, rows) =>
-                ctx.ExampleObjects.FromSqlInterpolated(ExampleObject.InterpolatedQuery(rows)).ToArray().Length
-        );
         benchmarker.BenchSqlServer(
-            "EF (fresh contexts)",
+            "EF FromSqlInterpolated (fresh contexts)",
             (sqlConn, rows) =>
                 new EntityFrameworkBench(sqlConn).ExampleObjects.FromSqlInterpolated(ExampleObject.InterpolatedQuery(rows)).ToArray().Length
+        );
+        benchmarker.BenchEFSqlServer(
+            "EF FromSqlInterpolated (reused context)",
+            (ctx, rows) =>
+                ctx.ExampleObjects.FromSqlInterpolated(ExampleObject.InterpolatedQuery(rows)).ToArray().Length
         );
     }
 
     public static void RunWideQuery(Benchmarker benchmarker)
     {
-        benchmarker.BenchEFSqlServer(
-            "EF (reused context)",
-            (ctx, rows) =>
-                ctx.WideExampleObjects.FromSqlInterpolated(WideExampleObject.InterpolatedQuery(rows)).ToArray().Length
-        );
         benchmarker.BenchSqlServer(
-            "EF (fresh contexts)",
+            "EF FromSqlInterpolated (26-col, fresh contexts)",
             (sqlConn, rows) =>
                 new EntityFrameworkBench(sqlConn).WideExampleObjects.FromSqlInterpolated(WideExampleObject.InterpolatedQuery(rows)).ToArray().Length
+        );
+        benchmarker.BenchEFSqlServer(
+            "EF FromSqlInterpolated (26-col, reused context)",
+            (ctx, rows) =>
+                ctx.WideExampleObjects.FromSqlInterpolated(WideExampleObject.InterpolatedQuery(rows)).ToArray().Length
         );
     }
 }

--- a/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/HandrolledAdoNetExecutor.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/HandrolledAdoNetExecutor.cs
@@ -7,10 +7,10 @@ static class HandrolledAdoNetExecutor
 {
     public static void RunQuery(Benchmarker benchmarker)
     {
-        benchmarker.BenchSQLite("Raw (sqlite, cached)", ExecuteSqliteQueryCached);
+        benchmarker.BenchSqlServer("Raw (via GetSql...)", ExecuteQuery2);
+        benchmarker.BenchSqlServer("Raw (via IsDBNull+Get...)", ExecuteQuery);
         benchmarker.BenchSQLite("Raw (sqlite)", ExecuteSqliteQuery);
-        benchmarker.BenchSqlServer("Raw", ExecuteQuery);
-        benchmarker.BenchSqlServer("Raw (SqlDbTypes)", ExecuteQuery2);
+        benchmarker.BenchSQLite("Raw (sqlite, cached)", ExecuteSqliteQueryCached);
     }
 
     static int ExecuteQuery(SqlConnection sqlConn, int rows)

--- a/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/HandrolledAdoNetExecutor.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/HandrolledAdoNetExecutor.cs
@@ -82,7 +82,7 @@ static class HandrolledAdoNetExecutor
         };
         var heheP = new SQLiteParameter {
             DbType = DbType.String,
-            ParameterName = "@hehe",
+            ParameterName = "@Hehe",
             IsNullable = false,
             Value = "hehe",
         };
@@ -143,7 +143,7 @@ static class HandrolledAdoNetExecutor
             };
             var heheP = new SQLiteParameter {
                 DbType = DbType.String,
-                ParameterName = "@hehe",
+                ParameterName = "@Hehe",
                 IsNullable = false,
                 //Value = "hehe",
             };

--- a/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/ParameterizedSqlExecutor.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/ParameterizedSqlExecutor.cs
@@ -10,21 +10,21 @@ static class ParameterizedSqlExecutor
                 .Length
         );
 
-    public static void RunTvpQuery(Benchmarker benchmarker)
-        => benchmarker.BenchSqlServer(
-            "ParameterizedSql-TVP",
-            (sqlConn, rows) =>
-                SQL($"select QueryTableValue from ({Enumerable.Range(0, rows).ToArray()}) x")
-                    .ReadPlain<int>(sqlConn)
-                    .Length
-        );
-
     public static void RunWideQuery(Benchmarker benchmarker)
         => benchmarker.BenchSqlServer(
             "ParameterizedSql (26-col)",
             (sqlConn, rows) => WideExampleObject.ParameterizedSqlForRows(rows)
                 .ReadPocos<WideExampleObject>(sqlConn)
                 .Length
+        );
+
+    public static void RunTvpQuery(Benchmarker benchmarker)
+        => benchmarker.BenchSqlServer(
+            "ParameterizedSql table valued parameter",
+            (sqlConn, rows) =>
+                SQL($"select QueryTableValue from ({Enumerable.Range(0, rows).ToArray()}) x")
+                    .ReadPlain<int>(sqlConn)
+                    .Length
         );
 
     public static void ConstructWithoutExecuting(Benchmarker benchmarker)

--- a/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/Program.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/Program.cs
@@ -6,7 +6,9 @@ static class MicroOrmBenchmarkProgram
     {
         var benchmarker = new Benchmarker { IterationsPerTry = 2000, Tries = 100, };
         benchmarker.ReportInitialDistribution();
-        RunCurrentBenchmarks(new() { IterationsPerTry = 8, Tries = 2, Output = _ => { }, }); //warm-up
+        Console.WriteLine("Warming up...");
+        RunCurrentBenchmarks(new() { IterationsPerTry = 16, Tries = 3, Output = _ => { }, }); //warm-up
+        Console.WriteLine("Benchmarking...");
         RunCurrentBenchmarks(benchmarker);
     }
 

--- a/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/Program.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/Program.cs
@@ -4,6 +4,8 @@ static class MicroOrmBenchmarkProgram
 {
     public static void RunBenchmarks()
     {
+        using var proc = Process.GetCurrentProcess();
+        proc.PriorityClass = ProcessPriorityClass.AboveNormal;
         var benchmarker = new Benchmarker { IterationsPerTry = 2000, Tries = 100, };
         benchmarker.ReportInitialDistribution();
         Console.WriteLine("Warming up...");

--- a/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/Program.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/Program.cs
@@ -12,15 +12,15 @@ static class MicroOrmBenchmarkProgram
 
     static void RunCurrentBenchmarks(Benchmarker benchmarker)
     {
-        HandrolledAdoNetExecutor.RunQuery(benchmarker);
         EntityFrameworkBench.RunQuery(benchmarker);
-        ParameterizedSqlExecutor.RunQuery(benchmarker);
         DapperExecutor.RunQuery(benchmarker);
+        ParameterizedSqlExecutor.RunQuery(benchmarker);
+        HandrolledAdoNetExecutor.RunQuery(benchmarker);
 
-        HandrolledAdoNetExecutor.RunWideQuery(benchmarker);
         EntityFrameworkBench.RunWideQuery(benchmarker);
         DapperExecutor.RunWideQuery(benchmarker);
         ParameterizedSqlExecutor.RunWideQuery(benchmarker);
+        HandrolledAdoNetExecutor.RunWideQuery(benchmarker);
 
         ParameterizedSqlExecutor.RunTvpQuery(benchmarker);
         ParameterizedSqlExecutor.ConstructWithoutExecuting(benchmarker);

--- a/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/Program.cs
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/MicroOrmBench/Program.cs
@@ -12,15 +12,21 @@ static class MicroOrmBenchmarkProgram
 
     static void RunCurrentBenchmarks(Benchmarker benchmarker)
     {
+        benchmarker.Output("Running 6-column queries ");
+
         EntityFrameworkBench.RunQuery(benchmarker);
         DapperExecutor.RunQuery(benchmarker);
         ParameterizedSqlExecutor.RunQuery(benchmarker);
         HandrolledAdoNetExecutor.RunQuery(benchmarker);
 
+        benchmarker.Output("Running 26-column queries (shape of AdventureWorks SalesOrderHeader)");
+
         EntityFrameworkBench.RunWideQuery(benchmarker);
         DapperExecutor.RunWideQuery(benchmarker);
         ParameterizedSqlExecutor.RunWideQuery(benchmarker);
         HandrolledAdoNetExecutor.RunWideQuery(benchmarker);
+
+        benchmarker.Output("Running special-case benchmarks");
 
         ParameterizedSqlExecutor.RunTvpQuery(benchmarker);
         ParameterizedSqlExecutor.ConstructWithoutExecuting(benchmarker);

--- a/tools/ProgressOnderwijsUtilsBenchmarks/ProgressOnderwijsUtilsBenchmarks.csproj
+++ b/tools/ProgressOnderwijsUtilsBenchmarks/ProgressOnderwijsUtilsBenchmarks.csproj
@@ -1,8 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../src/Common.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />


### PR DESCRIPTION
The custom implementation still appears to be much faster, even on .net 9 and latest versions of the various libs

On my machine now:


```
Testing 100 groups of 2000 queries with 0-2957 rows
Row-count median: 7; mean: 200.2; 0 rows: 10.95%; 1 row: 19.55%; <50 rows: 69.95% <50
Reporting time per query execution; parallel executions use 16 threads
Warming up...
Benchmarking...
Running 6-column queries
39.8µs ~ 0.24µs parallel;628µs ~ 852.5µs latency; 10.76/3.02/0.01 milliGC;  EF FromSqlInterpolated (fresh contexts)  checksum:40030700
23.9µs ~ 0.28µs parallel;370µs ~ 935.8µs latency; 5.18/2.30/0.24 milliGC;  EF FromSqlInterpolated (reused context)  checksum:40030700
16.4µs ~ 0.09µs parallel;255µs ~ 647.9µs latency; 3.04/2.23/0.00 milliGC;  Dapper  checksum:40030700
18.2µs ~ 0.11µs parallel;247µs ~ 709.3µs latency; 3.43/2.33/0.01 milliGC;  Dapper (sqlite)  checksum:40030700
12.1µs ~ 0.12µs parallel;186µs ~ 377.1µs latency; 1.84/1.04/0.01 milliGC;  ParameterizedSql  checksum:40030700
11.2µs ~ 0.05µs parallel;173µs ~ 353.8µs latency; 1.91/1.32/0.00 milliGC;  Raw (via GetSql...)  checksum:40030700
11.5µs ~ 0.09µs parallel;177µs ~ 379.8µs latency; 1.91/1.38/0.00 milliGC;  Raw (via IsDBNull+Get...)  checksum:40030700
13.6µs ~ 0.06µs parallel;176µs ~ 462.5µs latency; 2.25/1.51/0.00 milliGC;  Raw (sqlite)  checksum:40030700
12.4µs ~ 0.05µs parallel;160µs ~ 441.7µs latency; 2.16/1.45/0.00 milliGC;  Raw (sqlite, cached)  checksum:40030700
Running 26-column queries (shape of AdventureWorks SalesOrderHeader)
104.8µs ~ 0.66µs parallel;1661µs ~ 3068.0µs latency; 18.58/9.71/1.67 milliGC;  EF FromSqlInterpolated (26-col, fresh contexts)  checksum:40030700
78.3µs ~ 0.51µs parallel;1234µs ~ 2949.5µs latency; 12.92/8.96/1.65 milliGC;  EF FromSqlInterpolated (26-col, reused context)  checksum:40030700
144.8µs ~ 0.77µs parallel;2278µs ~ 6018.2µs latency; 15.79/10.37/3.41 milliGC;  Dapper (26-col)  checksum:40030700
48.7µs ~ 0.15µs parallel;767µs ~ 1856.9µs latency; 6.92/6.61/0.27 milliGC;  ParameterizedSql (26-col)  checksum:40030700
53.8µs ~ 0.35µs parallel;836µs ~ 2208.6µs latency; 7.36/5.98/0.93 milliGC;  Raw (26-col)  checksum:40030700
53.4µs ~ 0.41µs parallel;829µs ~ 2199.4µs latency; 7.33/5.95/0.91 milliGC;  Raw (26-col, SqlDbTypes)  checksum:40030700
Running special-case benchmarks
97.0µs ~ 0.22µs parallel;1546µs ~ 1187.1µs latency; 0.98/0.15/0.00 milliGC;  ParameterizedSql table valued parameter  checksum:40030700
0.5µs ~ 0.01µs parallel;2µs ~ 7.0µs latency; 0.10/0.01/0.00 milliGC;  ParameterizedSql noexec  checksum:0
```