### PR TITLE
The fix adds <NoWarn>RS1038</NoWarn> to the analyzer project

### DIFF
--- a/src/ProgressOnderwijsUtils.Analyzers/ProgressOnderwijsUtils.Analyzers.csproj
+++ b/src/ProgressOnderwijsUtils.Analyzers/ProgressOnderwijsUtils.Analyzers.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\NugetPackagesCommon.props" />
   <PropertyGroup>
     <Description>Bump dependencies</Description>
@@ -7,6 +7,7 @@
     <Version>2.9.0</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <NoWarn>RS1038</NoWarn>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/src/ProgressOnderwijsUtils.Analyzers/ProgressOnderwijsUtils.Analyzers.csproj
+++ b/src/ProgressOnderwijsUtils.Analyzers/ProgressOnderwijsUtils.Analyzers.csproj
@@ -7,7 +7,7 @@
     <Version>2.9.0</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
-    <NoWarn>RS1038</NoWarn>
+    <NoWarn>$(NoWarn), RS1038</NoWarn>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
   </PropertyGroup>
 


### PR DESCRIPTION
This warning fires because the project contains both analyzers and code fix providers (which require Microsoft.CodeAnalysis.Workspaces.Common). Since splitting them into separate assemblies would be a significant restructuring, suppressing RS1038 is the pragmatic fix — the project intentionally ships both together.